### PR TITLE
Harden supply chain: audit, deny, pin deps, scope permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,4 +234,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11
+      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           save-if: false
       - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --locked --version 0.32.7
       - name: Run coverage
         run: |
           cargo tarpaulin --workspace --lib --features integration \
@@ -161,7 +161,7 @@ jobs:
       - name: Install Playwright
         working-directory: tests/frontend
         run: |
-          npm install
+          npm ci
           npx playwright install chromium --with-deps
       - name: Run frontend tests
         working-directory: tests/frontend
@@ -219,3 +219,19 @@ jobs:
         run: k6 run tests/load/smoke.js
         env:
           GATEWAY_URL: http://localhost:8080
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  supply-chain:
+    name: Supply Chain Policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,9 +225,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Run cargo-audit
+        run: cargo audit --ignore RUSTSEC-2023-0071
 
   supply-chain:
     name: Supply Chain Policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,7 @@ on:
   push:
     tags: ["v*"]
 
-permissions:
-  contents: write
-  packages: write
+permissions: read-all
 
 env:
   CARGO_TERM_COLOR: always
@@ -158,7 +156,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
+          provenance: mode=max
 
   release:
     name: GitHub Release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       security-events: write
       id-token: write
+      actions: read
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Build stage — BuildKit cache mounts persist cargo registry + target across builds
-FROM rust:1-alpine AS builder
+FROM rust:1-alpine@sha256:7f752ee8ea5deb9f4863d8c3f228a216a6466619882f09a44b9eda9617dc7770 AS builder
 RUN apk add --no-cache musl-dev
 WORKDIR /app
 
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     mkdir -p src cli/src && \
     echo 'fn main() {}' > src/main.rs && \
     echo 'fn main() {}' > cli/src/main.rs && \
-    cargo build --release --bin ccag-server 2>&1 | tail -1 && \
+    cargo build --release --bin ccag-server --locked 2>&1 | tail -1 && \
     rm -rf src cli/src
 
 # Copy source and build (incremental — only recompiles project code)
@@ -28,11 +28,11 @@ ENV SQLX_OFFLINE=true
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \
-    cargo build --release --bin ccag-server && \
+    cargo build --release --bin ccag-server --locked && \
     cp /app/target/release/ccag-server /usr/local/bin/ccag-server
 
 # Runtime stage — minimal Alpine
-FROM alpine:3.23
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --no-cache ca-certificates curl postgresql16-client && \
     addgroup -S proxy && adduser -S proxy -G proxy
 COPY --from=builder /usr/local/bin/ccag-server /usr/local/bin/

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,6 @@
 # Multi-arch release Dockerfile — uses pre-built binaries from CI
 # Used by the release workflow; for local builds use the standard Dockerfile
-FROM alpine:3.23
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 RUN apk add --no-cache ca-certificates curl postgresql16-client && \
     addgroup -S proxy && adduser -S proxy -G proxy

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,38 @@
+# Supply chain policy — enforced by `cargo deny check` in CI
+# See: https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+ignore = [
+    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin Attack — no fix available, used via sqlx-mysql (dev path only)" },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — migrate to rustls-pki-types PemObject when updating rustls" },
+]
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "LGPL-2.1-or-later",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,6 @@ allow = [
     "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
-    "LGPL-2.1-or-later",
     "MIT",
     "MIT-0",
     "MPL-2.0",
@@ -26,6 +25,9 @@ allow = [
     "Zlib",
 ]
 confidence-threshold = 0.8
+exceptions = [
+    { allow = ["LGPL-2.1-or-later"], crate = "r-efi" },
+]
 
 [bans]
 multiple-versions = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -25,9 +25,6 @@ allow = [
     "Zlib",
 ]
 confidence-threshold = 0.8
-exceptions = [
-    { allow = ["LGPL-2.1-or-later"], crate = "r-efi" },
-]
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
## Summary

Addresses OpenSSF Scorecard findings and hardens CI/CD supply chain controls.

- Add `cargo-audit` and `cargo-deny` CI jobs for dependency vulnerability and policy scanning
- Add `deny.toml` enforcing license allowlist and crates.io-only source restriction
- Pin Docker base images to SHA digests in both Dockerfiles
- Add `--locked` to Dockerfile cargo builds (was missing despite all CI using it)
- Scope `release.yml` top-level permissions to `read-all` (jobs already had their own)
- Fix `scorecard.yml` permissions (`actions:read` + `contents:read`) to unblock the failing workflow
- Enable SLSA provenance attestation (`provenance: mode=max`) on release Docker images
- Pin `cargo-tarpaulin` version in CI
- Use `npm ci` instead of `npm install` in frontend tests

No source code changes — all CI/CD config and build files only.

## Manual follow-ups (GitHub UI)

- [ ] Enable branch protection on `main` (require PR + review + status checks)
- [ ] Enable Dependabot alerts + security updates (config exists, alerts are disabled)
- [ ] Enable secret scanning + push protection

## Test plan

- [x] `make check` passes (lint, 257+169 unit tests, build)
- [x] `cargo deny check` passes locally (advisories, bans, licenses, sources all ok)
- [ ] Verify new `audit` and `supply-chain` CI jobs run on this PR
- [ ] Verify scorecard workflow succeeds on next scheduled run
- [ ] Verify `provenance: mode=max` works on next tag push (may need fallback to `true` if multi-arch push fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)