### PR TITLE
Add Google Search Console verification

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
       - "docs/**"
       - "README.md"
       - "_config.yml"
+      - "google*.html"
 
 permissions:
   contents: read

--- a/googleee8ebf6139e0c79f.html
+++ b/googleee8ebf6139e0c79f.html
@@ -1,0 +1,5 @@
+---
+layout: null
+permalink: /googleee8ebf6139e0c79f.html
+---
+google-site-verification: googleee8ebf6139e0c79f.html


### PR DESCRIPTION
## Summary
- Add `googleee8ebf6139e0c79f.html` verification file for Google Search Console
- Update Pages workflow to trigger on Google verification file changes

## Context
The GitHub Pages docs site (`antkawam.github.io`) is not indexed by Google at all. This enables Search Console verification so we can submit the sitemap and get the comparison/guide pages discoverable via search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)