### PR TITLE
Bump version to 1.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"


### PR DESCRIPTION
## Summary
- Version bump for release v1.3.3
- Includes: beta flag stripping, prefix correction removal, security dep updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)