### PR TITLE
Release v1.4.0: version bump + Pricing API IAM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/infra/stack.ts
+++ b/infra/stack.ts
@@ -122,6 +122,15 @@ export class GatewayStack extends cdk.Stack {
       }),
     );
 
+    // AWS Price List API: used by the daily pricing-refresh job to pull Bedrock
+    // foundation-model rates. Pricing API does not support resource-level permissions.
+    taskDef.taskRole.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        actions: ['pricing:ListPriceLists', 'pricing:GetPriceListFileUrl'],
+        resources: ['*'],
+      }),
+    );
+
     // SNS Publish — app-level notifications (budget alerts, etc.) to BYO SNS topics
     taskDef.taskRole.addToPrincipalPolicy(
       new iam.PolicyStatement({


### PR DESCRIPTION
## Summary

- Bumps workspace version from 1.3.3 to 1.4.0 (gateway + CLI + Cargo.lock)
- Adds `pricing:ListPriceLists` and `pricing:GetPriceListFileUrl` to the ECS task role so the daily refresh job introduced in #39 can actually reach the AWS Price List API

## Context

The pricing auto-discovery feature from #39 polls the AWS Bedrock Foundation Models price list daily. Without these IAM grants the refresh job fails silently (errors captured in `RefreshReport.errors`, seed rows continue to serve requests) — staging would work but never auto-update pricing. Pricing API has no resource-level permissions, hence `*`.

## Test plan

- [x] CI green
- [ ] Merge this PR
- [ ] Tag v1.4.0 → triggers release.yml (multi-arch Docker build to GHCR + Docker Hub)
- [ ] `cd infra && npx cdk deploy -c environment=staging -c imageTag=1.4.0`
- [ ] Confirm in staging: task role shows pricing perms; `POST /admin/pricing/refresh` flips source badges to `price_list_api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)