### PR TITLE
feat: key management, SearXNG provider, budget enforcement for virtual keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,16 +139,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         id: meta
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/ccag
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.4.10"
+version = "1.4.11"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.4.0"
+version = "1.4.10"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.4.0"
+version = "1.4.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.4.11"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.4.11"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.4.0"
+version = "1.4.10"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.4.10"
+version = "1.4.11"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.4.11"
+version = "1.5.0"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.4.0"
+version = "1.4.10"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.4.11"
+version = "1.5.0"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.4.10"
+version = "1.4.11"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/src/commands/keys.rs
+++ b/cli/src/commands/keys.rs
@@ -40,6 +40,10 @@ pub enum KeysCommands {
     SetupToken {
         /// Key ID to generate setup token for
         key_id: String,
+
+        /// Raw API key value returned at creation time (required by server)
+        #[arg(long)]
+        raw_key: String,
     },
 }
 
@@ -122,11 +126,11 @@ pub async fn run(cmd: KeysCommands, url: Option<String>, token: Option<String>) 
             util::success(&format!("Key {key_id} deleted"));
         }
 
-        KeysCommands::SetupToken { key_id } => {
+        KeysCommands::SetupToken { key_id, raw_key } => {
             let resp = client
                 .post(
                     &format!("/admin/keys/{key_id}/setup-token"),
-                    &serde_json::json!({}),
+                    &serde_json::json!({ "raw_key": raw_key }),
                 )
                 .await?;
             if let Some(token) = resp["token"].as_str() {

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -244,19 +244,36 @@ pub async fn update_key(
     let pool = &pool;
 
     // Accept UUID string, null (clear), or absent (keep existing via re-read)
-    let parse_uuid = |v: &Option<serde_json::Value>| -> Option<Option<Uuid>> {
+    #[allow(clippy::result_large_err)]
+    fn parse_uuid(
+        field: &str,
+        v: &Option<serde_json::Value>,
+    ) -> Result<Option<Option<Uuid>>, Response> {
         match v {
-            None => None, // field absent -- caller didn't send it
-            Some(serde_json::Value::Null) => Some(None), // explicit null -- clear
-            Some(serde_json::Value::String(s)) => {
-                s.parse::<Uuid>().ok().map(|id| Some(id))
-            }
-            _ => None,
+            None => Ok(None), // field absent -- caller didn't send it
+            Some(serde_json::Value::Null) => Ok(Some(None)), // explicit null -- clear
+            Some(serde_json::Value::String(s)) => match s.parse::<Uuid>() {
+                Ok(id) => Ok(Some(Some(id))),
+                Err(_) => Err(error_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("Invalid UUID for {field}"),
+                )),
+            },
+            _ => Err(error_response(
+                StatusCode::BAD_REQUEST,
+                &format!("{field} must be a UUID string or null"),
+            )),
         }
-    };
+    }
 
-    let new_user_id = parse_uuid(&body.user_id);
-    let new_team_id = parse_uuid(&body.team_id);
+    let new_user_id = match parse_uuid("user_id", &body.user_id) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let new_team_id = match parse_uuid("team_id", &body.team_id) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
 
     // Read current values to fill in any absent fields
     let current = sqlx::query_as::<_, (Option<Uuid>, Option<Uuid>)>(
@@ -285,6 +302,14 @@ pub async fn update_key(
         }
         Ok(false) => error_response(StatusCode::NOT_FOUND, "Key not found"),
         Err(e) => {
+            if let Some(sqlx::Error::Database(dbe)) = e.downcast_ref::<sqlx::Error>()
+                && dbe.code().as_deref() == Some("23503")
+            {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "Referenced user or team does not exist",
+                );
+            }
             tracing::error!(%e, "Failed to update key");
             error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string())
         }

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -219,6 +219,78 @@ pub async fn revoke_key(
     }
 }
 
+#[derive(serde::Deserialize)]
+pub struct UpdateKeyRequest {
+    pub user_id: Option<serde_json::Value>,
+    pub team_id: Option<serde_json::Value>,
+}
+
+pub async fn update_key(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Path(key_id): Path<Uuid>,
+    Json(body): Json<UpdateKeyRequest>,
+) -> Response {
+    let (_, role, _) = match check_auth_identity(&headers, &state).await {
+        Ok(auth) => auth,
+        Err(resp) => return resp,
+    };
+
+    if role != "admin" {
+        return error_response(StatusCode::FORBIDDEN, "Admin only");
+    }
+
+    let pool = state.db().await;
+    let pool = &pool;
+
+    // Accept UUID string, null (clear), or absent (keep existing via re-read)
+    let parse_uuid = |v: &Option<serde_json::Value>| -> Option<Option<Uuid>> {
+        match v {
+            None => None, // field absent -- caller didn't send it
+            Some(serde_json::Value::Null) => Some(None), // explicit null -- clear
+            Some(serde_json::Value::String(s)) => {
+                s.parse::<Uuid>().ok().map(|id| Some(id))
+            }
+            _ => None,
+        }
+    };
+
+    let new_user_id = parse_uuid(&body.user_id);
+    let new_team_id = parse_uuid(&body.team_id);
+
+    // Read current values to fill in any absent fields
+    let current = sqlx::query_as::<_, (Option<Uuid>, Option<Uuid>)>(
+        "SELECT user_id, team_id FROM virtual_keys WHERE id = $1",
+    )
+    .bind(key_id)
+    .fetch_optional(pool)
+    .await;
+
+    let (cur_user, cur_team) = match current {
+        Ok(Some(row)) => row,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "Key not found"),
+        Err(e) => return error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    let final_user_id = new_user_id.unwrap_or(cur_user);
+    let final_team_id = new_team_id.unwrap_or(cur_team);
+
+    match db::keys::update_key(pool, key_id, final_user_id, final_team_id).await {
+        Ok(true) => {
+            if let Err(e) = state.key_cache.load_from_db(pool).await {
+                tracing::warn!(%e, "Failed to reload key cache after update");
+            }
+            tracing::info!(%key_id, "Updated virtual key");
+            Json(json!({ "updated": true })).into_response()
+        }
+        Ok(false) => error_response(StatusCode::NOT_FOUND, "Key not found"),
+        Err(e) => {
+            tracing::error!(%e, "Failed to update key");
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string())
+        }
+    }
+}
+
 pub async fn delete_key(
     State(state): State<Arc<GatewayState>>,
     headers: HeaderMap,

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -153,6 +153,7 @@ pub async fn list_keys(State(state): State<Arc<GatewayState>>, headers: HeaderMa
                         "prefix": k.key_prefix,
                         "name": k.name,
                         "user_id": k.user_id,
+                        "team_id": k.team_id,
                         "is_active": k.is_active,
                         "rate_limit_rpm": k.rate_limit_rpm,
                         "created_at": k.created_at,

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -92,6 +92,18 @@ pub async fn create_key(
     .await
     {
         Ok((raw_key, vk)) => {
+            // Fetch user email for spend attribution (needed for analytics team filter)
+            let user_email = if let Some(uid) = vk.user_id {
+                sqlx::query_scalar::<_, String>("SELECT email FROM users WHERE id = $1")
+                    .bind(uid)
+                    .fetch_optional(pool)
+                    .await
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
+
             // Update in-memory cache
             state
                 .key_cache
@@ -101,6 +113,7 @@ pub async fn create_key(
                         id: vk.id,
                         name: vk.name.clone(),
                         user_id: vk.user_id,
+                        user_email,
                         team_id: vk.team_id,
                         rate_limit_rpm: vk.rate_limit_rpm,
                     },

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -2697,7 +2697,7 @@ pub async fn set_search_provider(
         None => return error_response(StatusCode::NOT_FOUND, "User not found in database"),
     };
 
-    let valid_types = ["duckduckgo", "tavily", "serper", "custom"];
+    let valid_types = ["duckduckgo", "tavily", "serper", "searxng", "custom"];
     if !valid_types.contains(&body.provider_type.as_str()) {
         return error_response(
             StatusCode::BAD_REQUEST,
@@ -2898,6 +2898,22 @@ pub async fn test_search_provider(
                 api_url,
                 api_key: body.api_key.clone(),
                 max_results: body.max_results.clamp(1, 5) as usize,
+            }
+        }
+        "searxng" => {
+            let api_url = match &body.api_url {
+                Some(u) if !u.is_empty() => u.clone(),
+                _ => {
+                    return Json(json!({
+                        "success": false,
+                        "error": "SearXNG provider requires an API URL",
+                    }))
+                    .into_response();
+                }
+            };
+            crate::websearch::SearchProvider::SearXNG {
+                api_url,
+                max_results: body.max_results.clamp(1, 10) as usize,
             }
         }
         _ => {
@@ -3492,22 +3508,26 @@ pub async fn set_websearch_mode(
                 );
             }
             Some(provider) => {
-                let valid_types = ["duckduckgo", "tavily", "serper", "custom"];
+                let valid_types = ["duckduckgo", "tavily", "serper", "searxng", "custom"];
                 match provider.get("provider_type").and_then(|v| v.as_str()) {
                     Some(pt) if valid_types.contains(&pt) => {}
                     Some(pt) => {
                         return error_response(
                             StatusCode::BAD_REQUEST,
                             &format!(
-                                "Invalid provider_type '{}'. Must be one of: duckduckgo, tavily, serper, custom",
-                                pt
+                                "Invalid provider_type '{}'. Must be one of: {}",
+                                pt,
+                                valid_types.join(", ")
                             ),
                         );
                     }
                     None => {
                         return error_response(
                             StatusCode::BAD_REQUEST,
-                            "provider_type is required in the provider configuration. Must be one of: duckduckgo, tavily, serper, custom",
+                            &format!(
+                                "provider_type is required in the provider configuration. Must be one of: {}",
+                                valid_types.join(", ")
+                            ),
                         );
                     }
                 }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -317,9 +317,22 @@ pub async fn messages(
         }
     };
 
-    // Budget check for OIDC users (replaces old spend limit check)
-    let budget_status = if let AuthResult::Oidc(ref oidc) = auth_result {
-        match check_budget(&state, oidc.user_id()).await {
+    // Resolve budget identity: OIDC email, or virtual key's assigned user email
+    let budget_identity = match &auth_result {
+        AuthResult::Oidc(oidc) => Some(oidc.user_id().to_string()),
+        AuthResult::VirtualKey(key) => key.user_email.clone(),
+    };
+
+    let budget_status = if let Some(ref identity) = budget_identity {
+        match check_budget(&state, identity).await {
+            Ok(status) => status,
+            Err(resp) => return resp,
+        }
+    } else if let AuthResult::VirtualKey(ref key) = auth_result
+        && let Some(team_id) = key.team_id
+    {
+        // Key assigned to a team but no user -- check team budget only
+        match check_team_budget_only(&state, team_id).await {
             Ok(status) => status,
             Err(resp) => return resp,
         }
@@ -1910,6 +1923,122 @@ async fn check_budget(
             remaining_usd: remaining,
             status: "ok",
             resets: status_period.period_start().to_rfc3339(),
+            shaped_rpm: None,
+        })),
+    }
+}
+
+/// Check team budget for a virtual key that has only team_id (no user assignment).
+async fn check_team_budget_only(
+    state: &GatewayState,
+    team_id: Uuid,
+) -> Result<Option<BudgetStatus>, Response> {
+    use crate::budget::{self, BudgetDecision, BudgetPeriod, PolicyRule};
+
+    let pool = state.db().await;
+    let pool = &pool;
+
+    let team = match crate::db::teams::get_team(pool, team_id).await {
+        Ok(Some(t)) => t,
+        _ => return Ok(None),
+    };
+    let Some(team_limit) = team.budget_amount_usd else {
+        return Ok(None);
+    };
+
+    let team_period = BudgetPeriod::parse(&team.budget_period);
+    let team_spend = match state.budget_cache.get_team_spend(team_id).await {
+        Some(s) => s,
+        None => {
+            let s = crate::db::budget::get_team_spend(pool, team_id, team_period)
+                .await
+                .unwrap_or(0.0);
+            state.budget_cache.set_team_spend(team_id, s).await;
+            s
+        }
+    };
+
+    let team_policy: Vec<PolicyRule> = team
+        .budget_policy
+        .as_ref()
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_else(budget::preset_standard);
+
+    let decision = budget::evaluate(&team_policy, team_spend, team_limit);
+
+    match &decision {
+        BudgetDecision::Notify { threshold_percent }
+        | BudgetDecision::Shape {
+            threshold_percent, ..
+        }
+        | BudgetDecision::Block { threshold_percent } => {
+            let event_type = match &decision {
+                BudgetDecision::Notify { .. } => "team_notify",
+                BudgetDecision::Shape { .. } => "team_shape",
+                BudgetDecision::Block { .. } => "team_block",
+                _ => unreachable!(),
+            };
+            let _ = crate::db::budget::insert_event(
+                pool,
+                None,
+                Some(team_id),
+                event_type,
+                *threshold_percent as i32,
+                team_spend,
+                team_limit,
+                (team_spend / team_limit) * 100.0,
+                team_period.as_str(),
+                team_period.period_start(),
+            )
+            .await;
+        }
+        _ => {}
+    }
+
+    let percent = (team_spend / team_limit) * 100.0;
+    let remaining = (team_limit - team_spend).max(0.0);
+
+    match decision {
+        BudgetDecision::Block { threshold_percent } => {
+            tracing::warn!(
+                %team_id,
+                spend = team_spend,
+                limit = team_limit,
+                threshold = threshold_percent,
+                "Team budget blocked (virtual key)"
+            );
+            Err(budget_block_response(team_spend, team_limit, team_period))
+        }
+        BudgetDecision::Shape {
+            threshold_percent,
+            rpm,
+        } => {
+            tracing::info!(
+                %team_id,
+                rpm,
+                threshold = threshold_percent,
+                "Team budget shaping active (virtual key)"
+            );
+            Ok(Some(BudgetStatus {
+                percent,
+                remaining_usd: remaining,
+                status: "shaped",
+                resets: team_period.period_start().to_rfc3339(),
+                shaped_rpm: Some(rpm),
+            }))
+        }
+        BudgetDecision::Notify { .. } => Ok(Some(BudgetStatus {
+            percent,
+            remaining_usd: remaining,
+            status: "warning",
+            resets: team_period.period_start().to_rfc3339(),
+            shaped_rpm: None,
+        })),
+        BudgetDecision::Allow => Ok(Some(BudgetStatus {
+            percent,
+            remaining_usd: remaining,
+            status: "ok",
+            resets: team_period.period_start().to_rfc3339(),
             shaped_rpm: None,
         })),
     }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -300,7 +300,7 @@ pub async fn messages(
     let identity = match &auth_result {
         AuthResult::VirtualKey(k) => AuthIdentity {
             key_id: Some(k.id),
-            user_identity: k.name.clone(),
+            user_identity: k.user_email.clone().or_else(|| k.name.clone()),
             user_id: k.user_id,
         },
         AuthResult::Oidc(id) => {

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1794,6 +1794,8 @@ async fn check_budget(
     };
 
     // Evaluate team budget (if set)
+    // Hoist team values so we can use them in the block response if team is the binding constraint.
+    let mut team_binding: Option<(f64, f64, BudgetPeriod)> = None;
     if let Some(ref team) = team
         && let Some(team_limit) = team.budget_amount_usd
     {
@@ -1847,11 +1849,20 @@ async fn check_budget(
             _ => {}
         }
 
-        decision = budget::most_restrictive(decision, team_decision);
+        // If team blocks but user doesn't, record team as the binding constraint
+        let prev_decision = decision.clone();
+        decision = budget::most_restrictive(decision, team_decision.clone());
+        if matches!(team_decision, BudgetDecision::Block { .. })
+            && !matches!(prev_decision, BudgetDecision::Block { .. })
+        {
+            team_binding = Some((team_spend, team_limit, team_period));
+        }
     }
 
-    // Build budget status for headers
-    let (status_limit, status_spend, status_period) = if let Some(limit) = user_limit {
+    // Build budget status for headers -- use team values when team is the binding constraint
+    let (status_limit, status_spend, status_period) = if let Some((ts, tl, tp)) = team_binding {
+        (tl, ts, tp)
+    } else if let Some(limit) = user_limit {
         (limit, user_spend, effective_period)
     } else if let Some(ref team) = team {
         if let Some(team_limit) = team.budget_amount_usd {
@@ -1907,7 +1918,7 @@ async fn check_budget(
                 percent,
                 remaining_usd: remaining,
                 status: "shaped",
-                resets: status_period.period_start().to_rfc3339(),
+                resets: status_period.period_next_start().to_rfc3339(),
                 shaped_rpm: Some(rpm),
             }))
         }
@@ -1915,14 +1926,14 @@ async fn check_budget(
             percent,
             remaining_usd: remaining,
             status: "warning",
-            resets: status_period.period_start().to_rfc3339(),
+            resets: status_period.period_next_start().to_rfc3339(),
             shaped_rpm: None,
         })),
         BudgetDecision::Allow => Ok(Some(BudgetStatus {
             percent,
             remaining_usd: remaining,
             status: "ok",
-            resets: status_period.period_start().to_rfc3339(),
+            resets: status_period.period_next_start().to_rfc3339(),
             shaped_rpm: None,
         })),
     }
@@ -2023,7 +2034,7 @@ async fn check_team_budget_only(
                 percent,
                 remaining_usd: remaining,
                 status: "shaped",
-                resets: team_period.period_start().to_rfc3339(),
+                resets: team_period.period_next_start().to_rfc3339(),
                 shaped_rpm: Some(rpm),
             }))
         }
@@ -2031,21 +2042,21 @@ async fn check_team_budget_only(
             percent,
             remaining_usd: remaining,
             status: "warning",
-            resets: team_period.period_start().to_rfc3339(),
+            resets: team_period.period_next_start().to_rfc3339(),
             shaped_rpm: None,
         })),
         BudgetDecision::Allow => Ok(Some(BudgetStatus {
             percent,
             remaining_usd: remaining,
             status: "ok",
-            resets: team_period.period_start().to_rfc3339(),
+            resets: team_period.period_next_start().to_rfc3339(),
             shaped_rpm: None,
         })),
     }
 }
 
 fn budget_block_response(spend: f64, limit: f64, period: crate::budget::BudgetPeriod) -> Response {
-    let resets = period.period_start().to_rfc3339();
+    let resets = period.period_next_start().to_rfc3339();
     Response::builder()
         .status(StatusCode::TOO_MANY_REQUESTS)
         .header("content-type", "application/json")

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,7 +12,7 @@ use axum::{
     extract::State,
     http::Method,
     response::{Html, IntoResponse, Redirect},
-    routing::{delete, get, post, put},
+    routing::{delete, get, patch, post, put},
 };
 use subtle::ConstantTimeEq;
 use tower_http::cors::{AllowHeaders, AllowOrigin, CorsLayer};
@@ -41,6 +41,7 @@ pub fn router(state: Arc<GatewayState>) -> Router {
         .route("/admin/keys", get(admin::list_keys))
         .route("/admin/keys/{key_id}/revoke", post(admin::revoke_key))
         .route("/admin/keys/{key_id}", delete(admin::delete_key))
+        .route("/admin/keys/{key_id}", patch(admin::update_key))
         .route(
             "/admin/keys/{key_id}/setup-token",
             post(admin::create_setup_token),

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -14,6 +14,7 @@ pub struct CachedKey {
     pub id: Uuid,
     pub name: Option<String>,
     pub user_id: Option<Uuid>,
+    pub user_email: Option<String>,
     pub team_id: Option<Uuid>,
     pub rate_limit_rpm: Option<i32>,
 }
@@ -42,6 +43,8 @@ impl KeyCache {
     pub async fn load_from_db(&self, pool: &sqlx::PgPool) -> anyhow::Result<usize> {
         let keys = db::keys::get_active_keys(pool).await?;
         let count = keys.len();
+        let user_ids: Vec<Uuid> = keys.iter().filter_map(|k| k.user_id).collect();
+        let email_map = db::users::get_emails_by_ids(pool, &user_ids).await?;
         let mut map = self.inner.write().await;
         map.clear();
         for key in keys {
@@ -51,6 +54,7 @@ impl KeyCache {
                     id: key.id,
                     name: key.name,
                     user_id: key.user_id,
+                    user_email: key.user_id.and_then(|id| email_map.get(&id).cloned()),
                     team_id: key.team_id,
                     rate_limit_rpm: key.rate_limit_rpm,
                 },
@@ -108,6 +112,7 @@ mod tests {
                     id,
                     name: None,
                     user_id: None,
+                    user_email: None,
                     team_id: None,
                     rate_limit_rpm: None,
                 },
@@ -140,6 +145,7 @@ mod tests {
                     id,
                     name: Some("test-key".to_string()),
                     user_id: Some(user_id),
+                    user_email: None,
                     team_id: Some(team_id),
                     rate_limit_rpm: Some(100),
                 },
@@ -168,6 +174,7 @@ mod tests {
                         id: ids[i],
                         name: Some(format!("key-{}", i)),
                         user_id: None,
+                        user_email: None,
                         team_id: None,
                         rate_limit_rpm: None,
                     },
@@ -200,6 +207,7 @@ mod tests {
                         id: Uuid::new_v4(),
                         name: None,
                         user_id: None,
+                        user_email: None,
                         team_id: None,
                         rate_limit_rpm: None,
                     },

--- a/src/budget/mod.rs
+++ b/src/budget/mod.rs
@@ -77,6 +77,40 @@ impl BudgetPeriod {
         }
     }
 
+    /// Get the start of the next period (UTC) -- when the budget resets.
+    pub fn period_next_start(&self) -> DateTime<Utc> {
+        let now = Utc::now();
+        match self {
+            Self::Daily => {
+                let tomorrow = now + Duration::days(1);
+                Utc.with_ymd_and_hms(tomorrow.year(), tomorrow.month(), tomorrow.day(), 0, 0, 0)
+                    .unwrap()
+            }
+            Self::Weekly => {
+                let days_until_next_monday =
+                    7 - now.weekday().num_days_from_monday() as i64;
+                let next_monday = now + Duration::days(days_until_next_monday);
+                Utc.with_ymd_and_hms(
+                    next_monday.year(),
+                    next_monday.month(),
+                    next_monday.day(),
+                    0,
+                    0,
+                    0,
+                )
+                .unwrap()
+            }
+            Self::Monthly => {
+                let (year, month) = if now.month() == 12 {
+                    (now.year() + 1, 1)
+                } else {
+                    (now.year(), now.month() + 1)
+                };
+                Utc.with_ymd_and_hms(year, month, 1, 0, 0, 0).unwrap()
+            }
+        }
+    }
+
     /// SQL date_trunc arg.
     pub fn trunc_arg(&self) -> &'static str {
         match self {

--- a/src/budget/mod.rs
+++ b/src/budget/mod.rs
@@ -87,8 +87,7 @@ impl BudgetPeriod {
                     .unwrap()
             }
             Self::Weekly => {
-                let days_until_next_monday =
-                    7 - now.weekday().num_days_from_monday() as i64;
+                let days_until_next_monday = 7 - now.weekday().num_days_from_monday() as i64;
                 let next_monday = now + Duration::days(days_until_next_monday);
                 Utc.with_ymd_and_hms(
                     next_monday.year(),
@@ -507,5 +506,45 @@ mod tests {
 
         cache.set_user_spend("alice", 42.0).await;
         assert_eq!(cache.get_user_spend("alice").await, Some(42.0));
+    }
+
+    #[test]
+    fn test_period_next_start_daily() {
+        let now = Utc::now();
+        let next = BudgetPeriod::Daily.period_next_start();
+        let tomorrow = now + Duration::days(1);
+        assert_eq!(next.day(), tomorrow.day());
+        assert_eq!(next.month(), tomorrow.month());
+        assert_eq!(next.year(), tomorrow.year());
+        assert_eq!(next.hour(), 0);
+        assert_eq!(next.minute(), 0);
+        assert_eq!(next.second(), 0);
+    }
+
+    #[test]
+    fn test_period_next_start_weekly() {
+        let now = Utc::now();
+        let next = BudgetPeriod::Weekly.period_next_start();
+        assert_eq!(next.weekday(), Weekday::Mon);
+        assert!(next > now, "next Monday start must be strictly after now");
+        assert_eq!(next.hour(), 0);
+        assert_eq!(next.minute(), 0);
+        assert_eq!(next.second(), 0);
+    }
+
+    #[test]
+    fn test_period_next_start_monthly() {
+        let now = Utc::now();
+        let next = BudgetPeriod::Monthly.period_next_start();
+        assert_eq!(next.day(), 1);
+        let expected_month = if now.month() == 12 {
+            1
+        } else {
+            now.month() + 1
+        };
+        assert_eq!(next.month(), expected_month);
+        assert_eq!(next.hour(), 0);
+        assert_eq!(next.minute(), 0);
+        assert_eq!(next.second(), 0);
     }
 }

--- a/src/db/budget.rs
+++ b/src/db/budget.rs
@@ -162,6 +162,7 @@ pub struct TeamSpendSummary {
     pub team_name: String,
     pub budget_amount_usd: Option<f64>,
     pub budget_period: String,
+    pub default_user_budget_usd: Option<f64>,
     pub current_spend_usd: Option<f64>,
     pub user_count: Option<i64>,
 }
@@ -173,6 +174,7 @@ pub async fn get_analytics_overview(pool: &PgPool) -> anyhow::Result<Vec<TeamSpe
             t.name as team_name,
             t.budget_amount_usd,
             t.budget_period,
+            t.default_user_budget_usd,
             COALESCE(
                 SUM(estimate_cost_usd(sl.model, sl.input_tokens, sl.output_tokens, sl.cache_read_tokens, sl.cache_write_tokens)),
                 0
@@ -189,7 +191,7 @@ pub async fn get_analytics_overview(pool: &PgPool) -> anyhow::Result<Vec<TeamSpe
                 END,
                 now() AT TIME ZONE 'UTC'
             )
-        GROUP BY t.id, t.name, t.budget_amount_usd, t.budget_period
+        GROUP BY t.id, t.name, t.budget_amount_usd, t.budget_period, t.default_user_budget_usd
         ORDER BY current_spend_usd DESC NULLS LAST"#,
     )
     .fetch_all(pool)

--- a/src/db/budget.rs
+++ b/src/db/budget.rs
@@ -202,6 +202,7 @@ pub async fn get_analytics_overview(pool: &PgPool) -> anyhow::Result<Vec<TeamSpe
 /// Get team analytics detail: per-user spend breakdown.
 #[derive(Debug, sqlx::FromRow, Serialize)]
 pub struct UserSpendInTeam {
+    pub user_id: Uuid,
     pub email: String,
     pub spend_limit_monthly_usd: Option<f64>,
     pub budget_period: String,
@@ -215,6 +216,7 @@ pub async fn get_team_analytics(
 ) -> anyhow::Result<Vec<UserSpendInTeam>> {
     let rows = sqlx::query_as::<_, UserSpendInTeam>(
         r#"SELECT
+            u.id as user_id,
             u.email,
             u.spend_limit_monthly_usd,
             u.budget_period,

--- a/src/db/keys.rs
+++ b/src/db/keys.rs
@@ -92,14 +92,12 @@ pub async fn update_key(
     user_id: Option<Uuid>,
     team_id: Option<Uuid>,
 ) -> anyhow::Result<bool> {
-    let result = sqlx::query(
-        "UPDATE virtual_keys SET user_id = $2, team_id = $3 WHERE id = $1",
-    )
-    .bind(key_id)
-    .bind(user_id)
-    .bind(team_id)
-    .execute(pool)
-    .await?;
+    let result = sqlx::query("UPDATE virtual_keys SET user_id = $2, team_id = $3 WHERE id = $1")
+        .bind(key_id)
+        .bind(user_id)
+        .bind(team_id)
+        .execute(pool)
+        .await?;
     if result.rows_affected() > 0 {
         bump_cache_version(pool).await?;
     }

--- a/src/db/keys.rs
+++ b/src/db/keys.rs
@@ -86,6 +86,26 @@ pub async fn revoke_key(pool: &PgPool, key_id: Uuid) -> anyhow::Result<bool> {
     Ok(result.rows_affected() > 0)
 }
 
+pub async fn update_key(
+    pool: &PgPool,
+    key_id: Uuid,
+    user_id: Option<Uuid>,
+    team_id: Option<Uuid>,
+) -> anyhow::Result<bool> {
+    let result = sqlx::query(
+        "UPDATE virtual_keys SET user_id = $2, team_id = $3 WHERE id = $1",
+    )
+    .bind(key_id)
+    .bind(user_id)
+    .bind(team_id)
+    .execute(pool)
+    .await?;
+    if result.rows_affected() > 0 {
+        bump_cache_version(pool).await?;
+    }
+    Ok(result.rows_affected() > 0)
+}
+
 pub async fn delete_key(pool: &PgPool, key_id: Uuid) -> anyhow::Result<bool> {
     let result = sqlx::query("DELETE FROM virtual_keys WHERE id = $1")
         .bind(key_id)

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -38,12 +38,11 @@ pub async fn get_emails_by_ids(
     if ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let rows = sqlx::query_as::<_, (Uuid, String)>(
-        "SELECT id, email FROM users WHERE id = ANY($1)",
-    )
-    .bind(ids)
-    .fetch_all(pool)
-    .await?;
+    let rows =
+        sqlx::query_as::<_, (Uuid, String)>("SELECT id, email FROM users WHERE id = ANY($1)")
+            .bind(ids)
+            .fetch_all(pool)
+            .await?;
     Ok(rows.into_iter().collect())
 }
 

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -26,6 +28,23 @@ pub async fn list_users(pool: &PgPool) -> anyhow::Result<Vec<User>> {
         .fetch_all(pool)
         .await?;
     Ok(users)
+}
+
+/// Fetch a map of user id -> email for the given set of ids.
+pub async fn get_emails_by_ids(
+    pool: &PgPool,
+    ids: &[Uuid],
+) -> anyhow::Result<HashMap<Uuid, String>> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let rows = sqlx::query_as::<_, (Uuid, String)>(
+        "SELECT id, email FROM users WHERE id = ANY($1)",
+    )
+    .bind(ids)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().collect())
 }
 
 pub async fn get_user_by_email(pool: &PgPool, email: &str) -> anyhow::Result<Option<User>> {

--- a/src/websearch/providers.rs
+++ b/src/websearch/providers.rs
@@ -310,6 +310,8 @@ async fn search_searxng(
     let url = format!("{}/search", api_url.trim_end_matches('/'));
     let resp = client
         .get(&url)
+        .header("User-Agent", "Mozilla/5.0 (compatible; CCAG/1.0)")
+        .header("Accept", "application/json")
         .query(&[
             ("q", query),
             ("format", "json"),

--- a/src/websearch/providers.rs
+++ b/src/websearch/providers.rs
@@ -71,7 +71,10 @@ impl SearchProvider {
                     .filter(|u| !u.is_empty())
                     .ok_or_else(|| anyhow::anyhow!("SearXNG provider requires an API URL"))?
                     .clone();
-                Ok(Self::SearXNG { api_url, max_results })
+                Ok(Self::SearXNG {
+                    api_url,
+                    max_results,
+                })
             }
             other => anyhow::bail!("Unknown search provider: {}", other),
         }
@@ -133,7 +136,10 @@ impl SearchProvider {
                 let api_url = api_url
                     .filter(|u| !u.is_empty())
                     .ok_or_else(|| anyhow::anyhow!("SearXNG provider requires an API URL"))?;
-                Ok(Self::SearXNG { api_url, max_results })
+                Ok(Self::SearXNG {
+                    api_url,
+                    max_results,
+                })
             }
             other => anyhow::bail!("Unknown search provider: {}", other),
         }
@@ -167,9 +173,10 @@ impl SearchProvider {
                 api_key,
                 max_results,
             } => search_serper(client, api_key, query, *max_results).await,
-            Self::SearXNG { api_url, max_results } => {
-                search_searxng(client, api_url, query, *max_results).await
-            }
+            Self::SearXNG {
+                api_url,
+                max_results,
+            } => search_searxng(client, api_url, query, *max_results).await,
             Self::Custom {
                 api_url,
                 api_key,
@@ -318,6 +325,7 @@ async fn search_searxng(
             ("categories", "general"),
             ("language", "en"),
         ])
+        .timeout(std::time::Duration::from_secs(10))
         .send()
         .await?;
 
@@ -670,5 +678,54 @@ mod tests {
             }
             _ => panic!("Expected DuckDuckGo variant"),
         }
+    }
+
+    #[test]
+    fn test_provider_from_config_searxng() {
+        let config = UserSearchProvider {
+            id: uuid::Uuid::new_v4(),
+            user_id: uuid::Uuid::new_v4(),
+            provider_type: "searxng".to_string(),
+            api_key: None,
+            api_url: Some("http://searxng.local".to_string()),
+            max_results: 5,
+            enabled: true,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let provider = SearchProvider::from_config(&config).unwrap();
+        assert_eq!(provider.provider_name(), "searxng");
+    }
+
+    #[test]
+    fn test_provider_from_config_searxng_requires_url() {
+        let config = UserSearchProvider {
+            id: uuid::Uuid::new_v4(),
+            user_id: uuid::Uuid::new_v4(),
+            provider_type: "searxng".to_string(),
+            api_key: None,
+            api_url: None,
+            max_results: 5,
+            enabled: true,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        assert!(SearchProvider::from_config(&config).is_err());
+    }
+
+    #[test]
+    fn test_provider_from_config_searxng_empty_url() {
+        let config = UserSearchProvider {
+            id: uuid::Uuid::new_v4(),
+            user_id: uuid::Uuid::new_v4(),
+            provider_type: "searxng".to_string(),
+            api_key: None,
+            api_url: Some("".to_string()),
+            max_results: 5,
+            enabled: true,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        assert!(SearchProvider::from_config(&config).is_err());
     }
 }

--- a/src/websearch/providers.rs
+++ b/src/websearch/providers.rs
@@ -12,6 +12,8 @@ pub enum SearchProvider {
     Tavily { api_key: String, max_results: usize },
     /// Serper.dev Google Search API
     Serper { api_key: String, max_results: usize },
+    /// SearXNG self-hosted instance (GET JSON API)
+    SearXNG { api_url: String, max_results: usize },
     /// Custom provider with a simple POST JSON contract
     Custom {
         api_url: String,
@@ -61,6 +63,15 @@ impl SearchProvider {
                     api_key: config.api_key.clone(),
                     max_results,
                 })
+            }
+            "searxng" => {
+                let api_url = config
+                    .api_url
+                    .as_ref()
+                    .filter(|u| !u.is_empty())
+                    .ok_or_else(|| anyhow::anyhow!("SearXNG provider requires an API URL"))?
+                    .clone();
+                Ok(Self::SearXNG { api_url, max_results })
             }
             other => anyhow::bail!("Unknown search provider: {}", other),
         }
@@ -118,6 +129,12 @@ impl SearchProvider {
                     max_results,
                 })
             }
+            "searxng" => {
+                let api_url = api_url
+                    .filter(|u| !u.is_empty())
+                    .ok_or_else(|| anyhow::anyhow!("SearXNG provider requires an API URL"))?;
+                Ok(Self::SearXNG { api_url, max_results })
+            }
             other => anyhow::bail!("Unknown search provider: {}", other),
         }
     }
@@ -127,6 +144,7 @@ impl SearchProvider {
             Self::DuckDuckGo { .. } => "duckduckgo",
             Self::Tavily { .. } => "tavily",
             Self::Serper { .. } => "serper",
+            Self::SearXNG { .. } => "searxng",
             Self::Custom { .. } => "custom",
         }
     }
@@ -149,6 +167,9 @@ impl SearchProvider {
                 api_key,
                 max_results,
             } => search_serper(client, api_key, query, *max_results).await,
+            Self::SearXNG { api_url, max_results } => {
+                search_searxng(client, api_url, query, *max_results).await
+            }
             Self::Custom {
                 api_url,
                 api_key,
@@ -270,6 +291,55 @@ async fn search_serper(
                 snippet: r
                     .get("snippet")
                     .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            })
+        })
+        .collect())
+}
+
+/// Search via a SearXNG self-hosted instance.
+/// GET {api_url}/search?q=...&format=json&categories=general
+/// Expects: {"results": [{"title": "...", "url": "...", "content": "..."}]}
+async fn search_searxng(
+    client: &reqwest::Client,
+    api_url: &str,
+    query: &str,
+    max_results: usize,
+) -> anyhow::Result<Vec<WebSearchResult>> {
+    let url = format!("{}/search", api_url.trim_end_matches('/'));
+    let resp = client
+        .get(&url)
+        .query(&[
+            ("q", query),
+            ("format", "json"),
+            ("categories", "general"),
+            ("language", "en"),
+        ])
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        anyhow::bail!("SearXNG returned HTTP {}", status);
+    }
+
+    let json: Value = resp.json().await?;
+    let results = json
+        .get("results")
+        .and_then(|r| r.as_array())
+        .ok_or_else(|| anyhow::anyhow!("SearXNG response missing results array"))?;
+
+    Ok(results
+        .iter()
+        .take(max_results)
+        .filter_map(|r| {
+            Some(WebSearchResult {
+                title: r.get("title")?.as_str()?.to_string(),
+                url: r.get("url")?.as_str()?.to_string(),
+                snippet: r
+                    .get("content")
+                    .and_then(|c| c.as_str())
                     .unwrap_or("")
                     .to_string(),
             })

--- a/static/index.html
+++ b/static/index.html
@@ -5571,8 +5571,8 @@ function cancelGlobalProvider() {
 
 function wsGlobalTypeChanged() {
   const type = document.getElementById('ws-global-type').value;
-  document.getElementById('ws-global-key-group').style.display = (type === 'duckduckgo') ? 'none' : '';
-  document.getElementById('ws-global-url-group').style.display = (type === 'custom') ? '' : 'none';
+  document.getElementById('ws-global-key-group').style.display = (type === 'duckduckgo' || type === 'searxng') ? 'none' : '';
+  document.getElementById('ws-global-url-group').style.display = (type === 'custom' || type === 'searxng') ? '' : 'none';
 }
 
 async function setWebsearchMode(mode) {

--- a/static/index.html
+++ b/static/index.html
@@ -2524,21 +2524,12 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
                       <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
                         <div>
                           <div class="form-label">Provider</div>
-                          <select id="ws-global-type" class="form-select" style="width:140px" onchange="wsGlobalTypeChanged()">
-                            <option value="duckduckgo">DuckDuckGo</option>
-                            <option value="tavily">Tavily</option>
-                            <option value="serper">Serper</option>
-                            <option value="searxng">SearXNG</option>
-                            <option value="custom">Custom</option>
-                          </select>
+                          <select id="ws-global-type" class="form-select" style="width:160px" onchange="wsGlobalTypeChanged()"></select>
                         </div>
-                        <div id="ws-global-key-group">
+                        <div id="ws-global-key-group" style="display:none">
                           <div class="form-label">API Key</div>
-                          <input class="form-input" id="ws-global-key" type="password" placeholder="API key" style="width:200px">
-                        </div>
-                        <div id="ws-global-url-group" style="display:none">
-                          <div class="form-label">API URL</div>
-                          <input class="form-input" id="ws-global-url" type="text" placeholder="https://..." style="width:200px">
+                          <input class="form-input" id="ws-global-key" type="password" placeholder="Re-enter key" style="width:200px">
+                          <div class="form-hint">Key is not stored in plain text — re-enter to set globally.</div>
                         </div>
                         <div>
                           <div class="form-label">Max Results</div>
@@ -5561,18 +5552,33 @@ async function loadGlobalProviderInfo() {
 }
 
 function showGlobalProviderForm() {
+  const sel = document.getElementById('ws-global-type');
+  sel.innerHTML = '';
+  // Populate from already-configured providers
+  const configured = Object.entries(wsProviderConfigs);
+  if (configured.length === 0) {
+    sel.innerHTML = '<option value="">No providers configured</option>';
+  } else {
+    for (const [type, cfg] of configured) {
+      const meta = wsProviderMeta[type];
+      const opt = document.createElement('option');
+      opt.value = type;
+      opt.textContent = meta?.name || type;
+      sel.appendChild(opt);
+    }
+  }
   document.getElementById('websearch-global-provider-form').style.display = '';
   wsGlobalTypeChanged();
 }
 
-function cancelGlobalProvider() {
-  document.getElementById('websearch-global-provider-form').style.display = 'none';
-}
-
 function wsGlobalTypeChanged() {
   const type = document.getElementById('ws-global-type').value;
-  document.getElementById('ws-global-key-group').style.display = (type === 'duckduckgo' || type === 'searxng') ? 'none' : '';
-  document.getElementById('ws-global-url-group').style.display = (type === 'custom' || type === 'searxng') ? '' : 'none';
+  const saved = wsProviderConfigs[type];
+  const meta = wsProviderMeta[type];
+  // Only show key field for providers that need a key (and don't have it stored accessibly)
+  document.getElementById('ws-global-key-group').style.display = meta?.needsKey ? '' : 'none';
+  // Pre-fill max results from saved config
+  if (saved?.max_results) document.getElementById('ws-global-max').value = saved.max_results;
 }
 
 async function setWebsearchMode(mode) {
@@ -5597,15 +5603,21 @@ async function setWebsearchMode(mode) {
   }
 }
 
-async function saveGlobalProvider() {
-  const providerType = document.getElementById('ws-global-type').value;
-  const apiKey = document.getElementById('ws-global-key').value;
-  const apiUrl = document.getElementById('ws-global-url').value;
-  const maxResults = parseInt(document.getElementById('ws-global-max').value) || 5;
+function cancelGlobalProvider() {
+  document.getElementById('websearch-global-provider-form').style.display = 'none';
+}
 
-  const provider = { provider_type: providerType, max_results: maxResults };
-  if (apiKey) provider.api_key = apiKey;
-  if (apiUrl) provider.api_url = apiUrl;
+async function saveGlobalProvider() {
+  const type = document.getElementById('ws-global-type').value;
+  if (!type) { toast('Select a provider first', 'error'); return; }
+  const saved = wsProviderConfigs[type];
+  const maxResults = parseInt(document.getElementById('ws-global-max').value) || 5;
+  const provider = { provider_type: type, max_results: maxResults };
+  // Pull url from saved config
+  if (saved?.api_url) provider.api_url = saved.api_url;
+  // Key must be re-entered (not returned by API)
+  const keyEl = document.getElementById('ws-global-key');
+  if (keyEl?.value) provider.api_key = keyEl.value;
 
   const res = await api('PUT', '/admin/websearch-mode', { mode: 'global', provider });
   if (res.updated) {

--- a/static/index.html
+++ b/static/index.html
@@ -1788,7 +1788,7 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
         </div>
         <div class="card">
           <table>
-            <thead><tr><th>Key Prefix</th><th>Name</th><th>Team</th><th>Status</th><th>Created</th><th></th></tr></thead>
+            <thead><tr><th>Key Prefix</th><th>Name</th><th>Team</th><th>User</th><th>Status</th><th>Created</th><th></th></tr></thead>
             <tbody id="keys-table"></tbody>
           </table>
           <div id="keys-empty" class="empty-state" style="display:none">
@@ -2625,6 +2625,13 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
           <option value="">None</option>
         </select>
         <div class="form-hint">Assign to a team for budget enforcement</div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">User</label>
+        <select class="form-select" id="mk-user">
+          <option value="">None</option>
+        </select>
+        <div class="form-hint">Assign to a specific member</div>
       </div>
     </div>
     <div class="modal-footer">
@@ -3704,11 +3711,16 @@ function renderKeys() {
     const teamCell = teamObj
       ? `<span style="font-size:12px">${escHtml(teamObj.team_name)}</span>`
       : `<span style="color:var(--text-muted)">--</span>`;
+    const userObj = (data.users || []).find(u => u.id === k.user_id);
+    const userCell = userObj
+      ? `<span style="font-size:12px">${escHtml(userObj.email)}</span>`
+      : `<span style="color:var(--text-muted)">--</span>`;
     return `
     <tr>
       <td><code>${k.prefix}</code></td>
       <td>${k.name || '<span style="color:var(--text-muted)">--</span>'}</td>
       <td>${teamCell}</td>
+      <td>${userCell}</td>
       <td><span class="badge ${k.is_active ? 'badge-green' : 'badge-red'}"><span class="badge-dot"></span>${k.is_active ? 'Active' : 'Revoked'}</span></td>
       <td>${fmtDate(k.created_at)}</td>
       <td>${k.is_active ? `<button class="btn btn-danger btn-sm" onclick="revokeKey('${k.id}')">Revoke</button>` : ''}</td>
@@ -3736,6 +3748,10 @@ function renderMembers() {
   const mkTeamSelect = document.getElementById('mk-team');
   if (mkTeamSelect) {
     mkTeamSelect.innerHTML = '<option value="">None</option>' + teams.map(t => `<option value="${t.team_id}">${escHtml(t.team_name)}</option>`).join('');
+  }
+  const mkUserSelect = document.getElementById('mk-user');
+  if (mkUserSelect) {
+    mkUserSelect.innerHTML = '<option value="">None</option>' + (data.users || []).map(u => `<option value="${u.id}">${escHtml(u.email)}</option>`).join('');
   }
   document.getElementById('members-table').innerHTML = data.users.map(u => {
     const userTeam = u.team_id || '';
@@ -6190,13 +6206,15 @@ async function revokeScimToken(tokenId) {
 async function createKey() {
   const name = document.getElementById('mk-name').value || undefined;
   const team_id = document.getElementById('mk-team').value || undefined;
-  const res = await api('POST', '/admin/keys', { name, team_id, user_id: currentUserId || undefined });
+  const user_id = document.getElementById('mk-user').value || undefined;
+  const res = await api('POST', '/admin/keys', { name, team_id, user_id });
   if (res.key) {
     closeModal();
     document.getElementById('new-key-banner').style.display = 'block';
     document.getElementById('new-key-value').textContent = res.key;
     document.getElementById('mk-name').value = '';
     document.getElementById('mk-team').value = '';
+    document.getElementById('mk-user').value = '';
     toast('Virtual key created', 'success');
     loadAll();
   } else {

--- a/static/index.html
+++ b/static/index.html
@@ -2619,6 +2619,13 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
         <input class="form-input" id="mk-name" placeholder="e.g. dev-team-key, john-personal">
         <div class="form-hint">A descriptive name to identify this key</div>
       </div>
+      <div class="form-group">
+        <label class="form-label">Team</label>
+        <select class="form-select" id="mk-team">
+          <option value="">None</option>
+        </select>
+        <div class="form-hint">Assign to a team for budget enforcement</div>
+      </div>
     </div>
     <div class="modal-footer">
       <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
@@ -3718,6 +3725,10 @@ function renderMembers() {
   const mmTeamSelect = document.getElementById('mm-team');
   if (mmTeamSelect) {
     mmTeamSelect.innerHTML = '<option value="">None</option>' + teams.map(t => `<option value="${t.team_id}">${escHtml(t.team_name)}</option>`).join('');
+  }
+  const mkTeamSelect = document.getElementById('mk-team');
+  if (mkTeamSelect) {
+    mkTeamSelect.innerHTML = '<option value="">None</option>' + teams.map(t => `<option value="${t.team_id}">${escHtml(t.team_name)}</option>`).join('');
   }
   document.getElementById('members-table').innerHTML = data.users.map(u => {
     const userTeam = u.team_id || '';
@@ -6153,12 +6164,14 @@ async function revokeScimToken(tokenId) {
 // ---- Actions ----
 async function createKey() {
   const name = document.getElementById('mk-name').value || undefined;
-  const res = await api('POST', '/admin/keys', { name, user_id: currentUserId || undefined });
+  const team_id = document.getElementById('mk-team').value || undefined;
+  const res = await api('POST', '/admin/keys', { name, team_id, user_id: currentUserId || undefined });
   if (res.key) {
     closeModal();
     document.getElementById('new-key-banner').style.display = 'block';
     document.getElementById('new-key-value').textContent = res.key;
     document.getElementById('mk-name').value = '';
+    document.getElementById('mk-team').value = '';
     toast('Virtual key created', 'success');
     loadAll();
   } else {

--- a/static/index.html
+++ b/static/index.html
@@ -2528,6 +2528,7 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
                             <option value="duckduckgo">DuckDuckGo</option>
                             <option value="tavily">Tavily</option>
                             <option value="serper">Serper</option>
+                            <option value="searxng">SearXNG</option>
                             <option value="custom">Custom</option>
                           </select>
                         </div>
@@ -5188,9 +5189,16 @@ const wsProviderMeta = {
     hint: 'Google Search results via <a href="https://serper.dev" target="_blank" style="color:var(--accent)">serper.dev</a>.',
     keyHint: 'Get your key at <a href="https://serper.dev/dashboard" target="_blank" style="color:var(--accent)">serper.dev/dashboard</a>.',
   },
+  searxng: {
+    name: 'SearXNG',
+    desc: 'Self-hosted search engine. No API key required; just point to your instance URL.',
+    needsKey: false, needsUrl: true,
+    hint: 'Enter your SearXNG instance URL (e.g. your internal ALB or private hostname).',
+    keyHint: '',
+  },
   custom: {
     name: 'Custom',
-    desc: 'Any POST endpoint. Works with SearXNG, custom proxies, or internal search APIs.',
+    desc: 'Any POST endpoint. Works with custom proxies or internal search APIs.',
     needsKey: false, needsUrl: true,
     hint: 'Any POST endpoint returning search results.',
     keyHint: 'Optional Bearer token for your endpoint.',

--- a/static/index.html
+++ b/static/index.html
@@ -3967,7 +3967,7 @@ function renderBudgets() {
   document.getElementById('budgets-empty').style.display = 'none';
 
   document.getElementById('budgets-table').innerHTML = teams.map(t => {
-    const keyCount = (data.keys || []).filter(k => k.team_id === t.team_id && k.is_active).length;
+    const keyCount = (data.keys || []).filter(k => k.team_id === t.team_id && !k.user_id && k.is_active).length;
     const pct = t.budget_amount_usd ? (t.current_spend_usd / t.budget_amount_usd * 100) : 0;
     const barColor = pct >= 100 ? 'var(--red)' : pct >= 80 ? 'var(--yellow)' : 'var(--green)';
     const statusBadge = !t.budget_amount_usd

--- a/static/index.html
+++ b/static/index.html
@@ -3304,7 +3304,15 @@ async function api(method, path, body) {
   const opts = { method, headers: { 'content-type': 'application/json', 'x-api-key': apiKey } };
   if (body) opts.body = JSON.stringify(body);
   const res = await fetch(BASE + path, opts);
-  return res.json();
+  const text = await res.text();
+  try { return JSON.parse(text); } catch { return { error: text || `HTTP ${res.status}` }; }
+}
+
+function normalizeUrl(url) {
+  if (!url) return url;
+  url = url.trim();
+  if (!url.startsWith('http://') && !url.startsWith('https://')) return 'http://' + url;
+  return url;
 }
 
 // ---- Navigation ----
@@ -5311,7 +5319,7 @@ function renderWsCards(activeType) {
       if (meta.needsUrl || type === 'custom') {
         html += `<div class="form-group" style="margin-bottom:10px">`;
         html += `<label class="form-label" style="font-size:11px">API URL</label>`;
-        html += `<input class="form-input" id="ws-url-${type}" type="url" placeholder="https://your-search-api.example.com/search" style="max-width:360px" value="${escHtml(config?.api_url || '')}">`;
+        html += `<input class="form-input" id="ws-url-${type}" type="text" placeholder="http://your-search-instance/search" style="max-width:360px" value="${escHtml(config?.api_url || '')}">`;
         html += `<div class="form-hint">POST endpoint accepting:<pre style="margin:6px 0 0;padding:8px 10px;background:var(--bg-base);border:1px solid var(--border);border-radius:4px;font-size:11px;line-height:1.5;overflow-x:auto">{ "query": "...", "count": N }</pre>and returning:<pre style="margin:6px 0 0;padding:8px 10px;background:var(--bg-base);border:1px solid var(--border);border-radius:4px;font-size:11px;line-height:1.5;overflow-x:auto">[ { "title": "...", "link": "...", "snippet": "..." } ]</pre></div>`;
         html += `</div>`;
       }
@@ -5375,7 +5383,7 @@ async function wsCardSave(type) {
       // If required and empty and no existing key, that's an error
     }
   }
-  if (urlEl) body.api_url = urlEl.value.trim();
+  if (urlEl) body.api_url = normalizeUrl(urlEl.value.trim());
   if (maxEl) body.max_results = parseInt(maxEl.value, 10) || 5;
 
   // Validation
@@ -5441,7 +5449,7 @@ async function wsCardTest(type) {
   const urlEl = document.getElementById(`ws-url-${type}`);
   if (keyEl && keyEl.value.trim()) body.api_key = keyEl.value.trim();
   else if (config?.has_api_key) body.api_key = '__saved__'; // placeholder — server uses saved
-  if (urlEl) body.api_url = urlEl.value.trim();
+  if (urlEl) body.api_url = normalizeUrl(urlEl.value.trim());
   else if (config?.api_url) body.api_url = config.api_url;
 
   // For test endpoint we need actual keys — if using saved, we can't test without them

--- a/static/index.html
+++ b/static/index.html
@@ -1788,7 +1788,7 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
         </div>
         <div class="card">
           <table>
-            <thead><tr><th>Key Prefix</th><th>Name</th><th>Status</th><th>Created</th><th></th></tr></thead>
+            <thead><tr><th>Key Prefix</th><th>Name</th><th>Team</th><th>Status</th><th>Created</th><th></th></tr></thead>
             <tbody id="keys-table"></tbody>
           </table>
           <div id="keys-empty" class="empty-state" style="display:none">
@@ -2050,7 +2050,7 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
         <!-- Teams table -->
         <div class="card">
           <table>
-            <thead><tr><th>Team</th><th>Members</th><th>Team Budget</th><th>Resets</th><th>Spend</th><th>Usage</th><th></th></tr></thead>
+            <thead><tr><th>Team</th><th>Members</th><th>Keys</th><th>Team Budget</th><th>Resets</th><th>Spend</th><th>Usage</th><th></th></tr></thead>
             <tbody id="budgets-table"></tbody>
           </table>
           <div id="budgets-empty" class="empty-state" style="display:none">
@@ -3699,14 +3699,21 @@ function renderKeys() {
     return;
   }
   document.getElementById('keys-empty').style.display = 'none';
-  document.getElementById('keys-table').innerHTML = all.map(k => `
+  document.getElementById('keys-table').innerHTML = all.map(k => {
+    const teamObj = (data.budgetTeams || []).find(t => t.team_id === k.team_id);
+    const teamCell = teamObj
+      ? `<span style="font-size:12px">${escHtml(teamObj.team_name)}</span>`
+      : `<span style="color:var(--text-muted)">--</span>`;
+    return `
     <tr>
       <td><code>${k.prefix}</code></td>
       <td>${k.name || '<span style="color:var(--text-muted)">--</span>'}</td>
+      <td>${teamCell}</td>
       <td><span class="badge ${k.is_active ? 'badge-green' : 'badge-red'}"><span class="badge-dot"></span>${k.is_active ? 'Active' : 'Revoked'}</span></td>
       <td>${fmtDate(k.created_at)}</td>
       <td>${k.is_active ? `<button class="btn btn-danger btn-sm" onclick="revokeKey('${k.id}')">Revoke</button>` : ''}</td>
-    </tr>`).join('');
+    </tr>`;
+  }).join('');
 }
 
 // ---- Members ----
@@ -3908,6 +3915,7 @@ function renderBudgets() {
   document.getElementById('budgets-empty').style.display = 'none';
 
   document.getElementById('budgets-table').innerHTML = teams.map(t => {
+    const keyCount = (data.keys || []).filter(k => k.team_id === t.team_id && k.is_active).length;
     const pct = t.budget_amount_usd ? (t.current_spend_usd / t.budget_amount_usd * 100) : 0;
     const barColor = pct >= 100 ? 'var(--red)' : pct >= 80 ? 'var(--yellow)' : 'var(--green)';
     const statusBadge = !t.budget_amount_usd
@@ -3918,6 +3926,7 @@ function renderBudgets() {
     return `<tr>
       <td><strong>${escHtml(t.team_name)}</strong></td>
       <td>${t.user_count || 0}</td>
+      <td>${keyCount}</td>
       <td>${t.budget_amount_usd ? fmtUsd(t.budget_amount_usd) : '<span style="color:var(--text-muted)">-</span>'}</td>
       <td>${t.budget_amount_usd ? `<span style="font-size:11px;color:var(--text-secondary)">${fmtResetDate(t.budget_period)}</span>` : ''}</td>
       <td>${fmtUsd(t.current_spend_usd)}</td>
@@ -5713,6 +5722,21 @@ async function renderSetup() {
     const keysNote = activeKeys.length > 0
       ? `<p style="color:var(--text-secondary);font-size:11px;margin-top:8px">You have ${activeKeys.length} active key${activeKeys.length !== 1 ? 's' : ''}. Manage them in <a href="#" onclick="navigate('keys');return false" style="color:var(--accent)">Virtual Keys</a>.</p>`
       : '';
+    const existingKeyOptions = activeKeys.map(k =>
+      `<option value="${k.id}">${escHtml(k.name || k.prefix)}</option>`
+    ).join('');
+    const existingKeySection = activeKeys.length > 0 ? `
+      <div style="margin-top:16px;padding-top:16px;border-top:1px solid var(--border)">
+        <p style="font-size:12px;color:var(--text-secondary);margin-bottom:8px">Or set up an existing key:</p>
+        <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+          <select class="form-select" id="vk-existing-select" style="width:200px;font-size:12px;padding:6px 10px">
+            ${existingKeyOptions}
+          </select>
+          <input class="form-input" id="vk-existing-rawkey" placeholder="Paste raw key value" type="password" style="width:220px;font-size:12px;padding:6px 10px">
+          <button class="btn btn-secondary btn-sm" onclick="setupExistingKey()">Generate Setup Command</button>
+        </div>
+        <p style="font-size:11px;color:var(--text-muted);margin-top:6px">The raw key is only needed here to generate the one-time setup command and is never stored.</p>
+      </div>` : '';
     return `
       <div id="vk-setup-actions" style="margin:0 0 12px">
         <div style="display:flex;align-items:center;gap:10px">
@@ -5720,6 +5744,7 @@ async function renderSetup() {
           <button class="btn btn-primary btn-sm" onclick="createKeyFromSetup()">Create Key &amp; Setup</button>
         </div>
         ${keysNote}
+        ${existingKeySection}
       </div>
       <div id="vk-setup-scope-area" style="${vkSetupToken ? '' : 'display:none'}">
         <p style="margin-bottom:12px">This command downloads a setup script that configures Claude Code to route through this gateway. It will:</p>
@@ -6202,6 +6227,24 @@ async function createKeyFromSetup() {
   // renderSetup() restores vkSetupToken terminal state automatically
 }
 
+
+async function setupExistingKey() {
+  const keyId = document.getElementById('vk-existing-select')?.value;
+  const rawKey = document.getElementById('vk-existing-rawkey')?.value;
+  if (!keyId || !rawKey) {
+    toast('Select a key and paste its value', 'error');
+    return;
+  }
+  const tokenRes = await api('POST', `/admin/keys/${keyId}/setup-token`, { raw_key: rawKey });
+  if (tokenRes.token) {
+    vkSetupToken = tokenRes.token;
+    toast('Setup command ready', 'success');
+    activeSetupTab = 'vk';
+    await loadAll();
+  } else {
+    toast(tokenRes.error?.message || 'Failed to generate setup token', 'error');
+  }
+}
 
 async function revokeKey(id) {
   if (!confirm('Revoke this virtual key? This action cannot be undone.')) return;

--- a/static/index.html
+++ b/static/index.html
@@ -2641,6 +2641,32 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
   </div>
 </div>
 
+<!-- Modal: Edit Key -->
+<div id="modal-edit-key" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeModal()">
+  <div class="modal">
+    <div class="modal-header"><h3>Edit Key Assignment</h3><button class="btn btn-ghost btn-sm" onclick="closeModal()">&times;</button></div>
+    <div class="modal-body">
+      <input type="hidden" id="ek-id">
+      <div class="form-group">
+        <label class="form-label">Team</label>
+        <select class="form-select" id="ek-team">
+          <option value="">None</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label class="form-label">User</label>
+        <select class="form-select" id="ek-user">
+          <option value="">None</option>
+        </select>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+      <button class="btn btn-primary" onclick="saveEditKey()">Save</button>
+    </div>
+  </div>
+</div>
+
 <!-- Modal: Add Member -->
 <div id="modal-create-member" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeModal()">
   <div class="modal">
@@ -3723,7 +3749,9 @@ function renderKeys() {
       <td>${userCell}</td>
       <td><span class="badge ${k.is_active ? 'badge-green' : 'badge-red'}"><span class="badge-dot"></span>${k.is_active ? 'Active' : 'Revoked'}</span></td>
       <td>${fmtDate(k.created_at)}</td>
-      <td>${k.is_active ? `<button class="btn btn-danger btn-sm" onclick="revokeKey('${k.id}')">Revoke</button>` : ''}</td>
+      <td>${k.is_active ? `
+        <button class="btn btn-secondary btn-sm" onclick="showEditKey('${k.id}', '${k.team_id || ''}', '${k.user_id || ''}')" style="margin-right:4px">Edit</button>
+        <button class="btn btn-danger btn-sm" onclick="revokeKey('${k.id}')">Revoke</button>` : ''}</td>
     </tr>`;
   }).join('');
 }
@@ -3752,6 +3780,14 @@ function renderMembers() {
   const mkUserSelect = document.getElementById('mk-user');
   if (mkUserSelect) {
     mkUserSelect.innerHTML = '<option value="">None</option>' + (data.users || []).map(u => `<option value="${u.id}">${escHtml(u.email)}</option>`).join('');
+  }
+  const ekTeamSelect = document.getElementById('ek-team');
+  if (ekTeamSelect) {
+    ekTeamSelect.innerHTML = '<option value="">None</option>' + teams.map(t => `<option value="${t.team_id}">${escHtml(t.team_name)}</option>`).join('');
+  }
+  const ekUserSelect = document.getElementById('ek-user');
+  if (ekUserSelect) {
+    ekUserSelect.innerHTML = '<option value="">None</option>' + (data.users || []).map(u => `<option value="${u.id}">${escHtml(u.email)}</option>`).join('');
   }
   document.getElementById('members-table').innerHTML = data.users.map(u => {
     const userTeam = u.team_id || '';
@@ -6245,6 +6281,27 @@ async function createKeyFromSetup() {
   // renderSetup() restores vkSetupToken terminal state automatically
 }
 
+
+function showEditKey(keyId, teamId, userId) {
+  document.getElementById('ek-id').value = keyId;
+  document.getElementById('ek-team').value = teamId || '';
+  document.getElementById('ek-user').value = userId || '';
+  showModal('edit-key');
+}
+
+async function saveEditKey() {
+  const keyId = document.getElementById('ek-id').value;
+  const team_id = document.getElementById('ek-team').value || null;
+  const user_id = document.getElementById('ek-user').value || null;
+  const res = await api('PATCH', `/admin/keys/${keyId}`, { team_id, user_id });
+  if (res.updated) {
+    closeModal();
+    toast('Key updated', 'success');
+    loadAll();
+  } else {
+    toast(res.error?.message || 'Failed to update key', 'error');
+  }
+}
 
 async function setupExistingKey() {
   const keyId = document.getElementById('vk-existing-select')?.value;


### PR DESCRIPTION
## Summary

Community contribution from @jonathan-nicoletti (originally #43) with maintainer fixups.

### Bug Fixes
- CLI `setup-token` missing `--raw-key` arg
- Analytics team filter: `user_identity` now uses user email for proper team attribution
- SearXNG provider: added to allowlists, URL field fix, User-Agent/Accept headers, 10s timeout
- Budget enforcement extended to virtual keys (user + team budgets)
- Budget block response: correct reset date (`period_next_start`), shows binding constraint
- Teams dialog: `default_user_budget_usd` now returned in analytics overview
- Team detail modal: user removal now works (added `user_id` to `UserSpendInTeam`)

### New Features
- Portal: team + user assignment on key creation and editing
- PATCH `/admin/keys/{id}` endpoint with proper UUID validation and FK error handling
- Portal: edit key team/user assignment modal
- SearXNG as native web search provider
- Connect page: setup existing key flow
- Teams table: key count column (team-only keys)

### Maintainer Fixups
- Version: 1.5.0 (not 1.4.11)
- PATCH validation: 400 on bad UUID, FK violation detection
- SearXNG: 10s request timeout
- Team key count: only counts team-only keys (no user_id)
- Tests: `period_next_start` (daily/weekly/monthly), SearXNG provider config

## Test plan
- [x] `make check` passes (fmt, clippy, 279 tests)
- [ ] Create key with team + user; verify analytics team filter
- [ ] Edit key team/user assignment
- [ ] SearXNG global provider configuration
- [ ] `ccag keys setup-token` with `--raw-key`
- [ ] Budget enforcement on virtual keys (429 after limit)
- [ ] Team detail modal: remove member works

🤖 Generated with [Claude Code](https://claude.com/claude-code)