### PR TITLE
feat: consolidated team Configure modal with Keys tab

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -3761,6 +3761,39 @@ pub async fn list_team_members(
     }
 }
 
+pub async fn list_team_keys(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Path(team_id): Path<Uuid>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+    match db::keys::list_keys_for_team(&pool, team_id).await {
+        Ok(keys) => {
+            let keys_json: Vec<_> = keys
+                .iter()
+                .map(|k| {
+                    json!({
+                        "id": k.id,
+                        "prefix": k.key_prefix,
+                        "name": k.name,
+                        "user_id": k.user_id,
+                        "team_id": k.team_id,
+                        "is_active": k.is_active,
+                        "rate_limit_rpm": k.rate_limit_rpm,
+                        "created_at": k.created_at,
+                        "expires_at": k.expires_at,
+                    })
+                })
+                .collect();
+            Json(json!({ "keys": keys_json })).into_response()
+        }
+        Err(e) => admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
 /// POST /admin/teams/{team_id}/members — Add a member to a team
 pub async fn add_team_member(
     State(state): State<Arc<GatewayState>>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -117,6 +117,7 @@ pub fn router(state: Arc<GatewayState>) -> Router {
             "/admin/teams/{team_id}/members/{user_id}",
             delete(admin::remove_team_member),
         )
+        .route("/admin/teams/{team_id}/keys", get(admin::list_team_keys))
         // Admin API — Endpoints
         .route("/admin/endpoints", get(admin::list_endpoints))
         .route("/admin/endpoints", post(admin::create_endpoint))

--- a/src/db/keys.rs
+++ b/src/db/keys.rs
@@ -62,6 +62,16 @@ pub async fn list_keys(pool: &PgPool) -> anyhow::Result<Vec<VirtualKey>> {
     Ok(keys)
 }
 
+pub async fn list_keys_for_team(pool: &PgPool, team_id: Uuid) -> anyhow::Result<Vec<VirtualKey>> {
+    let keys = sqlx::query_as::<_, VirtualKey>(
+        "SELECT * FROM virtual_keys WHERE team_id = $1 ORDER BY created_at DESC",
+    )
+    .bind(team_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(keys)
+}
+
 pub async fn get_active_keys(pool: &PgPool) -> anyhow::Result<Vec<VirtualKey>> {
     let keys = sqlx::query_as::<_, VirtualKey>(
         "SELECT v.* FROM virtual_keys v \
@@ -113,4 +123,73 @@ pub async fn delete_key(pool: &PgPool, key_id: Uuid) -> anyhow::Result<bool> {
         bump_cache_version(pool).await?;
     }
     Ok(result.rows_affected() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_key_deterministic() {
+        let h1 = hash_key("sk-proxy-abc123");
+        let h2 = hash_key("sk-proxy-abc123");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_hash_key_different_inputs() {
+        let h1 = hash_key("sk-proxy-abc123");
+        let h2 = hash_key("sk-proxy-xyz789");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_hash_key_hex_output() {
+        let h = hash_key("test");
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(h.len(), 64); // SHA-256 = 32 bytes = 64 hex chars
+    }
+
+    #[test]
+    fn test_generate_key_format() {
+        let key = generate_key();
+        assert!(key.starts_with("sk-proxy-"));
+        assert!(key.len() > 16);
+    }
+
+    #[test]
+    fn test_generate_key_unique() {
+        let k1 = generate_key();
+        let k2 = generate_key();
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn test_key_prefix_long_key() {
+        let key = "sk-proxy-abcdefghijklmnopqrstuvwxyz";
+        let prefix = key_prefix(key);
+        assert_eq!(prefix, "sk-proxy-abcdefg...");
+        assert_eq!(prefix.len(), 19); // 16 chars + "..."
+    }
+
+    #[test]
+    fn test_key_prefix_short_key() {
+        let key = "short";
+        let prefix = key_prefix(key);
+        assert_eq!(prefix, "short");
+    }
+
+    #[test]
+    fn test_key_prefix_exactly_16_chars() {
+        let key = "1234567890123456";
+        let prefix = key_prefix(key);
+        assert_eq!(prefix, "1234567890123456");
+    }
+
+    #[test]
+    fn test_key_prefix_17_chars_gets_truncated() {
+        let key = "12345678901234567";
+        let prefix = key_prefix(key);
+        assert_eq!(prefix, "1234567890123456...");
+    }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -2885,13 +2885,15 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
   </div>
 </div>
 
-<!-- Modal: Team Detail (Members / Endpoints tabs) -->
+<!-- Modal: Team Detail (Members / Routing / Budget / Keys tabs) -->
 <div id="modal-team-members" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeModal()">
-  <div class="modal" style="width:640px">
+  <div class="modal" style="width:720px">
     <div class="modal-header"><h3 id="team-members-modal-title">Team</h3><button class="btn btn-ghost btn-sm" onclick="closeModal()">&times;</button></div>
     <div class="modal-tabs">
       <button class="modal-tab active" id="team-tab-members" onclick="switchTeamTab('members')">Members</button>
-      <button class="modal-tab" id="team-tab-endpoints" onclick="switchTeamTab('endpoints')">Endpoints</button>
+      <button class="modal-tab" id="team-tab-routing" onclick="switchTeamTab('routing')">Routing</button>
+      <button class="modal-tab" id="team-tab-budget" onclick="switchTeamTab('budget')">Budget</button>
+      <button class="modal-tab" id="team-tab-keys" onclick="switchTeamTab('keys')">Keys</button>
     </div>
     <!-- Members tab panel -->
     <div id="team-panel-members" class="modal-body" style="padding:12px 24px">
@@ -2904,8 +2906,8 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
         <tbody id="team-members-table"></tbody>
       </table>
     </div>
-    <!-- Endpoints tab panel -->
-    <div id="team-panel-endpoints" style="display:none">
+    <!-- Routing tab panel -->
+    <div id="team-panel-routing" style="display:none">
       <div class="modal-body" style="padding:16px 24px 8px">
         <div style="margin-bottom:16px">
           <div class="form-label" style="margin-bottom:8px">Routing Strategy</div>
@@ -2927,6 +2929,80 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
       <div class="modal-footer">
         <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
         <button class="btn btn-primary" onclick="saveTeamEndpoints()">Save</button>
+      </div>
+    </div>
+    <!-- Budget tab panel -->
+    <div id="team-panel-budget" style="display:none">
+      <div class="modal-body" style="padding:16px 24px 8px">
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label">Spend Limit (USD)</label>
+            <input class="form-input" id="tb-amount" type="number" step="0.01" min="0" placeholder="e.g. 500">
+            <div class="form-hint">Leave empty to remove the limit</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Period</label>
+            <select class="form-select" id="tb-period">
+              <option value="monthly">Monthly</option>
+              <option value="weekly">Weekly</option>
+              <option value="daily">Daily</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="form-label">Enforcement Policy</label>
+          <select class="form-select" id="tb-policy" onchange="toggleCustomPolicy('tb')">
+            <option value="standard">Standard (80% notify, 100% block)</option>
+            <option value="soft">Soft (80% notify, 100% notify, 150% block)</option>
+            <option value="shaped">Shaped (80% notify, 100% throttle@5rpm, 150% block)</option>
+            <option value="custom">Custom rules...</option>
+          </select>
+        </div>
+        <div class="form-group" id="tb-custom-group" style="display:none">
+          <label class="form-label">Custom Rules <span style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-muted)">(up to 5)</span></label>
+          <div id="tb-custom-rules-list"></div>
+          <button class="btn btn-secondary btn-sm" id="tb-add-rule-btn" onclick="addCustomRule(undefined, undefined, undefined, 'tb')" style="margin-top:8px">
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Add Rule
+          </button>
+        </div>
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label">Per-Member Limit (USD)</label>
+            <input class="form-input" id="tb-user-budget" type="number" step="0.01" min="0" placeholder="e.g. 100">
+            <div class="form-hint">Max spend per member in this team. Members with explicit budgets are exempt.</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Notify Recipients</label>
+            <select class="form-select" id="tb-notify">
+              <option value="both">Both (user + admin)</option>
+              <option value="user">User only</option>
+              <option value="admin">Admin only</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+        <button class="btn btn-primary" onclick="saveTeamBudgetInline()">Save Budget</button>
+      </div>
+    </div>
+    <!-- Keys tab panel -->
+    <div id="team-panel-keys" style="display:none">
+      <div class="modal-body" style="padding:12px 24px">
+        <div style="display:flex;gap:8px;margin-bottom:12px;align-items:center">
+          <input class="form-input" id="tk-name" placeholder="Key name (optional)" style="flex:1">
+          <button class="btn btn-primary btn-sm" onclick="createTeamKey()">Create Key</button>
+        </div>
+        <div id="tk-new-key-banner" style="display:none;margin-bottom:12px;padding:10px 12px;background:var(--bg-inset);border:1px solid var(--border);border-radius:var(--radius)">
+          <div style="font-size:11px;color:var(--text-muted);margin-bottom:4px">New key created — copy it now, it won't be shown again:</div>
+          <code id="tk-new-key-value" style="font-size:13px;word-break:break-all"></code>
+          <button class="btn btn-secondary btn-sm" onclick="navigator.clipboard.writeText(document.getElementById('tk-new-key-value').textContent);toast('Copied','success')" style="margin-left:8px">Copy</button>
+        </div>
+        <table>
+          <thead><tr><th>Prefix</th><th>Name</th><th>Owner</th><th>Status</th><th>Created</th><th></th></tr></thead>
+          <tbody id="team-keys-table"></tbody>
+        </table>
       </div>
     </div>
   </div>
@@ -3971,7 +4047,7 @@ function renderBudgets() {
     const pct = t.budget_amount_usd ? (t.current_spend_usd / t.budget_amount_usd * 100) : 0;
     const barColor = pct >= 100 ? 'var(--red)' : pct >= 80 ? 'var(--yellow)' : 'var(--green)';
     const statusBadge = !t.budget_amount_usd
-      ? `<a href="#" onclick="event.preventDefault();editBudget('${t.team_id}', '${escHtml(t.team_name)}')" style="color:var(--text-muted);font-size:11px;text-decoration:underline;text-decoration-style:dotted">No budget set</a>`
+      ? `<a href="#" onclick="event.preventDefault();showTeamDetail('${t.team_id}', 'budget')" style="color:var(--text-muted);font-size:11px;text-decoration:underline;text-decoration-style:dotted">No budget set</a>`
       : pct >= 100 ? '<span class="badge badge-red">Over budget</span>'
       : pct >= 80 ? '<span class="badge badge-yellow">Warning</span>'
       : '<span class="badge badge-green">OK</span>';
@@ -3992,17 +4068,9 @@ function renderBudgets() {
           </div>` : statusBadge}
       </td>
       <td style="white-space:nowrap">
-        <button class="btn btn-secondary btn-sm" onclick="showTeamDetail('${t.team_id}', 'members')" style="margin-right:4px">
-          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
-          Members
-        </button>
-        <button class="btn btn-secondary btn-sm" onclick="showTeamDetail('${t.team_id}', 'endpoints')" style="margin-right:4px">
-          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          Routing
-        </button>
-        <button class="btn btn-primary btn-sm" onclick="editBudget('${t.team_id}', '${escHtml(t.team_name)}')" style="margin-right:4px">
-          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-          Budget
+        <button class="btn btn-primary btn-sm" onclick="showTeamDetail('${t.team_id}')" style="margin-right:4px">
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+          Configure
         </button>
         <button class="btn btn-ghost btn-sm" onclick="showDeleteTeam('${t.team_id}', '${escHtml(t.team_name)}', ${t.user_count || 0})" title="Delete team" style="color:var(--red)">
           <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
@@ -4025,6 +4093,7 @@ const STRATEGY_DESCS = {
 
 async function showTeamDetail(teamId, tab) {
   teamDetailId = teamId;
+  document.getElementById('tk-new-key-banner').style.display = 'none';
   const team = (data.budgetTeams || []).find(t => t.team_id === teamId);
   const teamName = team ? team.team_name : 'Team';
   document.getElementById('team-members-modal-title').textContent = teamName;
@@ -4058,6 +4127,8 @@ async function showTeamDetail(teamId, tab) {
   }
 
   await loadTeamEndpoints(teamId);
+  await loadTeamKeys(teamId);
+  populateTeamBudgetTab(teamId);
 }
 
 async function loadTeamEndpoints(teamId) {
@@ -4105,7 +4176,7 @@ function renderTeamEndpointsPanel() {
 }
 
 function switchTeamTab(tab) {
-  ['members', 'endpoints'].forEach(t => {
+  ['members', 'routing', 'budget', 'keys'].forEach(t => {
     const btn = document.getElementById('team-tab-' + t);
     const panel = document.getElementById('team-panel-' + t);
     if (btn) btn.classList.toggle('active', t === tab);
@@ -4210,6 +4281,105 @@ async function removeTeamMember(userId) {
   }
 }
 
+function populateTeamBudgetTab(teamId) {
+  const team = (data.budgetTeams || []).find(t => t.team_id === teamId);
+  document.getElementById('tb-amount').value = team?.budget_amount_usd || '';
+  document.getElementById('tb-period').value = team?.budget_period || 'monthly';
+  document.getElementById('tb-user-budget').value = team?.default_user_budget_usd || '';
+  document.getElementById('tb-notify').value = team?.notify_recipients || 'both';
+  document.getElementById('tb-custom-rules-list').innerHTML = '';
+  document.getElementById('tb-custom-group').style.display = 'none';
+  setPolicyFromRules(team?.budget_policy || [], 'tb');
+}
+
+async function saveTeamBudgetInline() {
+  if (!teamDetailId) return;
+  const amount = parseFloat(document.getElementById('tb-amount').value);
+  const period = document.getElementById('tb-period').value;
+  const policySelect = document.getElementById('tb-policy').value;
+  const userBudget = parseFloat(document.getElementById('tb-user-budget').value);
+  const notify = document.getElementById('tb-notify').value;
+
+  let policy;
+  if (policySelect === 'custom') {
+    policy = getCustomRules('tb');
+    if (!policy.length) { toast('Add at least one custom rule', 'error'); return; }
+  } else {
+    policy = policySelect;
+  }
+
+  const body = { budget_period: period, budget_policy: policy, notify_recipients: notify };
+  if (!isNaN(amount) && amount > 0) body.budget_amount_usd = amount;
+  else body.budget_amount_usd = null;
+  if (!isNaN(userBudget) && userBudget > 0) body.default_user_budget_usd = userBudget;
+  else body.default_user_budget_usd = null;
+
+  try {
+    await api('PUT', `/admin/teams/${teamDetailId}/budget`, body);
+    toast('Budget updated', 'success');
+    await loadAll();
+    populateTeamBudgetTab(teamDetailId);
+  } catch (e) {
+    toast(e.message || 'Failed to save budget', 'error');
+  }
+}
+
+async function loadTeamKeys(teamId) {
+  document.getElementById('team-keys-table').innerHTML = '<tr><td colspan="6" style="text-align:center;color:var(--text-muted)">Loading...</td></tr>';
+  try {
+    const res = await api('GET', `/admin/teams/${teamId}/keys`);
+    const keys = res.keys || [];
+    if (keys.length === 0) {
+      document.getElementById('team-keys-table').innerHTML = '<tr><td colspan="6" style="text-align:center;color:var(--text-muted)">No keys for this team</td></tr>';
+    } else {
+      document.getElementById('team-keys-table').innerHTML = keys.map(k => {
+        const userObj = (data.users || []).find(u => u.id === k.user_id);
+        const ownerCell = k.user_id ? escHtml(userObj?.email || 'Unknown') : '<span style="color:var(--text-muted)">team-level</span>';
+        return `<tr>
+          <td><code>${escHtml(k.prefix)}</code></td>
+          <td>${k.name ? escHtml(k.name) : '<span style="color:var(--text-muted)">—</span>'}</td>
+          <td>${ownerCell}</td>
+          <td><span class="badge ${k.is_active ? 'badge-green' : 'badge-red'}"><span class="badge-dot"></span>${k.is_active ? 'Active' : 'Revoked'}</span></td>
+          <td>${fmtDate(k.created_at)}</td>
+          <td>${k.is_active ? '<button class="btn btn-danger btn-sm" onclick="revokeTeamKey(\'' + k.id + '\')">Revoke</button>' : ''}</td>
+        </tr>`;
+      }).join('');
+    }
+  } catch (e) {
+    document.getElementById('team-keys-table').innerHTML = '<tr><td colspan="6" style="color:var(--red)">' + escHtml(e.message) + '</td></tr>';
+  }
+}
+
+async function createTeamKey() {
+  if (!teamDetailId) return;
+  const name = document.getElementById('tk-name').value.trim() || undefined;
+  try {
+    const res = await api('POST', '/admin/keys', { name, team_id: teamDetailId });
+    if (res.key) {
+      document.getElementById('tk-new-key-banner').style.display = '';
+      document.getElementById('tk-new-key-value').textContent = res.key;
+      document.getElementById('tk-name').value = '';
+      toast('Team key created', 'success');
+      await loadAll();
+      await loadTeamKeys(teamDetailId);
+    }
+  } catch (e) {
+    toast(e.message || 'Failed to create key', 'error');
+  }
+}
+
+async function revokeTeamKey(keyId) {
+  if (!confirm('Revoke this key? This cannot be undone.')) return;
+  try {
+    await api('POST', '/admin/keys/' + keyId + '/revoke');
+    toast('Key revoked', 'success');
+    await loadAll();
+    await loadTeamKeys(teamDetailId);
+  } catch (e) {
+    toast(e.message || 'Failed to revoke', 'error');
+  }
+}
+
 // ---- Delete Team ----
 function showDeleteTeam(teamId, teamName, memberCount) {
   document.getElementById('delete-team-id').value = teamId;
@@ -4259,7 +4429,7 @@ function editBudget(teamId, teamName) {
   // Show per-member limit field for teams
   document.getElementById('mb-user-budget-group').style.display = '';
   // Detect and set policy preset or custom
-  setPolicyFromRules(team?.budget_policy);
+  setPolicyFromRules(team?.budget_policy, 'mb');
   showModal('edit-budget');
 }
 
@@ -4275,24 +4445,26 @@ function editDefaultBudget() {
   // Hide per-member limit field for default policy (it IS the user budget)
   document.getElementById('mb-user-budget-group').style.display = 'none';
   // Detect and set policy preset or custom
-  setPolicyFromRules(db.budget_policy);
+  setPolicyFromRules(db.budget_policy, 'mb');
   showModal('edit-budget');
 }
 
 // ---- Custom Rules Form Builder ----
-function toggleCustomPolicy() {
-  const isCustom = document.getElementById('mb-policy').value === 'custom';
-  const group = document.getElementById('mb-custom-group');
+function toggleCustomPolicy(prefix) {
+  prefix = prefix || 'mb';
+  const isCustom = document.getElementById(prefix + '-policy').value === 'custom';
+  const group = document.getElementById(prefix + '-custom-group');
   group.style.display = isCustom ? 'block' : 'none';
-  if (isCustom && document.getElementById('mb-custom-rules-list').children.length === 0) {
+  if (isCustom && document.getElementById(prefix + '-custom-rules-list').children.length === 0) {
     // Pre-populate with standard rules
-    addCustomRule(80, 'notify');
-    addCustomRule(100, 'block');
+    addCustomRule(80, 'notify', undefined, prefix);
+    addCustomRule(100, 'block', undefined, prefix);
   }
 }
 
-function addCustomRule(atPercent, action, rpm) {
-  const list = document.getElementById('mb-custom-rules-list');
+function addCustomRule(atPercent, action, rpm, prefix) {
+  prefix = prefix || 'mb';
+  const list = document.getElementById(prefix + '-custom-rules-list');
   if (list.children.length >= 5) return;
   const row = document.createElement('div');
   row.style.cssText = 'display:flex;gap:6px;align-items:center;margin-bottom:6px';
@@ -4309,19 +4481,21 @@ function addCustomRule(atPercent, action, rpm) {
       <input class="form-input cr-rpm" type="number" min="1" max="999" value="${rpm || 5}" style="width:60px;padding:6px 8px;font-size:12px">
       <span style="font-size:11px;color:var(--text-muted)">rpm</span>
     </span>
-    <button class="btn btn-ghost btn-sm" onclick="this.parentElement.remove();updateAddRuleBtn()" style="color:var(--red);padding:2px 6px" title="Remove rule">&times;</button>
+    <button class="btn btn-ghost btn-sm" onclick="this.parentElement.remove();updateAddRuleBtn('${prefix}')" style="color:var(--red);padding:2px 6px" title="Remove rule">&times;</button>
   `;
   list.appendChild(row);
-  updateAddRuleBtn();
+  updateAddRuleBtn(prefix);
 }
 
-function updateAddRuleBtn() {
-  const count = document.getElementById('mb-custom-rules-list').children.length;
-  document.getElementById('mb-add-rule-btn').disabled = count >= 5;
+function updateAddRuleBtn(prefix) {
+  prefix = prefix || 'mb';
+  const count = document.getElementById(prefix + '-custom-rules-list').children.length;
+  document.getElementById(prefix + '-add-rule-btn').disabled = count >= 5;
 }
 
-function getCustomRules() {
-  const rows = document.getElementById('mb-custom-rules-list').children;
+function getCustomRules(prefix) {
+  prefix = prefix || 'mb';
+  const rows = document.getElementById(prefix + '-custom-rules-list').children;
   const rules = [];
   for (const row of rows) {
     const pct = parseInt(row.querySelector('.cr-percent').value);
@@ -4336,12 +4510,13 @@ function getCustomRules() {
   return rules.sort((a, b) => a.at_percent - b.at_percent);
 }
 
-function setPolicyFromRules(policy) {
-  const list = document.getElementById('mb-custom-rules-list');
+function setPolicyFromRules(policy, prefix) {
+  prefix = prefix || 'mb';
+  const list = document.getElementById(prefix + '-custom-rules-list');
   list.innerHTML = '';
   if (!policy || !Array.isArray(policy)) {
-    document.getElementById('mb-policy').value = 'standard';
-    document.getElementById('mb-custom-group').style.display = 'none';
+    document.getElementById(prefix + '-policy').value = 'standard';
+    document.getElementById(prefix + '-custom-group').style.display = 'none';
     return;
   }
   const compact = JSON.stringify(policy.map(r => {
@@ -4353,18 +4528,18 @@ function setPolicyFromRules(policy) {
   const soft = JSON.stringify([{at_percent:80,action:'notify'},{at_percent:100,action:'notify'},{at_percent:150,action:'block'}]);
   const shaped = JSON.stringify([{at_percent:80,action:'notify'},{at_percent:100,action:'shape',shaped_rpm:5},{at_percent:150,action:'block'}]);
   if (compact === std) {
-    document.getElementById('mb-policy').value = 'standard';
-    document.getElementById('mb-custom-group').style.display = 'none';
+    document.getElementById(prefix + '-policy').value = 'standard';
+    document.getElementById(prefix + '-custom-group').style.display = 'none';
   } else if (compact === soft) {
-    document.getElementById('mb-policy').value = 'soft';
-    document.getElementById('mb-custom-group').style.display = 'none';
+    document.getElementById(prefix + '-policy').value = 'soft';
+    document.getElementById(prefix + '-custom-group').style.display = 'none';
   } else if (compact === shaped) {
-    document.getElementById('mb-policy').value = 'shaped';
-    document.getElementById('mb-custom-group').style.display = 'none';
+    document.getElementById(prefix + '-policy').value = 'shaped';
+    document.getElementById(prefix + '-custom-group').style.display = 'none';
   } else {
-    document.getElementById('mb-policy').value = 'custom';
-    document.getElementById('mb-custom-group').style.display = 'block';
-    policy.forEach(r => addCustomRule(r.at_percent, r.action, r.shaped_rpm));
+    document.getElementById(prefix + '-policy').value = 'custom';
+    document.getElementById(prefix + '-custom-group').style.display = 'block';
+    policy.forEach(r => addCustomRule(r.at_percent, r.action, r.shaped_rpm, prefix));
   }
 }
 
@@ -4378,7 +4553,7 @@ async function saveBudget() {
 
   let budgetPolicy;
   if (policySelect === 'custom') {
-    budgetPolicy = getCustomRules();
+    budgetPolicy = getCustomRules('mb');
     if (budgetPolicy.length === 0) {
       toast('Add at least one enforcement rule', 'error');
       return;

--- a/static/index.html
+++ b/static/index.html
@@ -4514,7 +4514,7 @@ function setPolicyFromRules(policy, prefix) {
   prefix = prefix || 'mb';
   const list = document.getElementById(prefix + '-custom-rules-list');
   list.innerHTML = '';
-  if (!policy || !Array.isArray(policy)) {
+  if (!policy || !Array.isArray(policy) || policy.length === 0) {
     document.getElementById(prefix + '-policy').value = 'standard';
     document.getElementById(prefix + '-custom-group').style.display = 'none';
     return;

--- a/tests/frontend/tests/teams.spec.ts
+++ b/tests/frontend/tests/teams.spec.ts
@@ -21,7 +21,7 @@ test.describe('Team Management', () => {
     await expect(page.locator('#page-budgets')).toContainText(teamName, { timeout: 5_000 });
   });
 
-  test('sets a team budget', async ({ page }) => {
+  test('sets a team budget via Configure modal Budget tab', async ({ page }) => {
     // Create team first
     await page.click('button:has-text("Create Team")');
     const teamName = `budget-team-${Date.now()}`;
@@ -29,22 +29,25 @@ test.describe('Team Management', () => {
     await page.click('#modal-create-team button:has-text("Create Team")');
     await expect(page.locator('#page-budgets')).toContainText(teamName, { timeout: 5_000 });
 
-    // Click budget edit for this team
+    // Open Configure modal for this team
     const teamRow = page.locator(`text=${teamName}`).locator('..');
-    const editBudgetBtn = teamRow.locator('button:has-text("Budget"), button:has-text("Edit"), button:has-text("Set")').first();
-    if (await editBudgetBtn.isVisible()) {
-      await editBudgetBtn.click();
-      await expect(page.locator('#modal-edit-budget')).toBeVisible();
+    const configureBtn = teamRow.locator('button:has-text("Configure")').first();
+    await configureBtn.click();
+    await expect(page.locator('#modal-team-members')).toBeVisible();
 
-      // Set budget amount
-      await page.fill('#mb-amount', '500');
-      await page.click('#modal-edit-budget button:has-text("Save")');
-      // Modal should close
-      await expect(page.locator('#modal-edit-budget')).toBeHidden({ timeout: 5_000 });
-    }
+    // Switch to Budget tab
+    await page.click('#team-tab-budget');
+    await expect(page.locator('#team-panel-budget')).toBeVisible();
+
+    // Set budget amount and save
+    await page.fill('#tb-amount', '500');
+    await page.click('#team-panel-budget button:has-text("Save Budget")');
+
+    // Modal should close after save
+    await expect(page.locator('#modal-team-members')).toBeHidden({ timeout: 5_000 });
   });
 
-  test('opens team members panel', async ({ page }) => {
+  test('opens team members panel via Configure modal', async ({ page }) => {
     // Create team first
     await page.click('button:has-text("Create Team")');
     const teamName = `members-team-${Date.now()}`;
@@ -52,14 +55,55 @@ test.describe('Team Management', () => {
     await page.click('#modal-create-team button:has-text("Create Team")');
     await expect(page.locator('#page-budgets')).toContainText(teamName, { timeout: 5_000 });
 
-    // Click on team name or members button to open members panel
-    const teamLink = page.locator(`text=${teamName}`).first();
-    await teamLink.click();
-    // Members modal or panel should appear
-    const membersPanel = page.locator('#modal-team-members, [class*="team-detail"]').first();
-    if (await membersPanel.isVisible({ timeout: 3_000 }).catch(() => false)) {
-      await expect(membersPanel).toBeVisible();
-    }
+    // Open Configure modal — Members tab is default
+    const teamRow = page.locator(`text=${teamName}`).locator('..');
+    const configureBtn = teamRow.locator('button:has-text("Configure")').first();
+    await configureBtn.click();
+
+    // The consolidated modal uses the same #modal-team-members ID
+    await expect(page.locator('#modal-team-members')).toBeVisible({ timeout: 5_000 });
+
+    // Members tab panel should be visible by default
+    await expect(page.locator('#team-panel-members')).toBeVisible();
+  });
+
+  test('manages team keys via Configure modal', async ({ page }) => {
+    // Create team first
+    await page.click('button:has-text("Create Team")');
+    const teamName = `keys-team-${Date.now()}`;
+    await page.fill('#mt-name', teamName);
+    await page.click('#modal-create-team button:has-text("Create Team")');
+    await expect(page.locator('#page-budgets')).toContainText(teamName, { timeout: 5_000 });
+
+    // Open Configure modal
+    const teamRow = page.locator(`text=${teamName}`).locator('..');
+    const configureBtn = teamRow.locator('button:has-text("Configure")').first();
+    await configureBtn.click();
+    await expect(page.locator('#modal-team-members')).toBeVisible();
+
+    // Switch to Keys tab
+    await page.click('#team-tab-keys');
+    await expect(page.locator('#team-panel-keys')).toBeVisible();
+
+    // Create a team key
+    const keyName = `e2e-key-${Date.now()}`;
+    await page.fill('#tk-name', keyName);
+    await page.click('#team-panel-keys button:has-text("Create Key")');
+
+    // New key banner should appear with the raw key value
+    await expect(page.locator('#tk-new-key-banner')).toBeVisible({ timeout: 5_000 });
+
+    // Key should appear in the table
+    await expect(page.locator('#team-keys-table')).toContainText(keyName, { timeout: 5_000 });
+
+    // Revoke the key
+    const keyRow = page.locator(`#team-keys-table tr`).filter({ hasText: keyName });
+    await keyRow.locator('button:has-text("Revoke")').click();
+
+    // After revoke the row status should reflect inactive or the revoke button disappears
+    await expect(
+      keyRow.locator('button:has-text("Revoke")'),
+    ).toBeHidden({ timeout: 5_000 });
   });
 
   test('deletes a team', async ({ page }) => {

--- a/tests/frontend/tests/teams.spec.ts
+++ b/tests/frontend/tests/teams.spec.ts
@@ -30,9 +30,8 @@ test.describe('Team Management', () => {
     await expect(page.locator('#page-budgets')).toContainText(teamName, { timeout: 5_000 });
 
     // Open Configure modal for this team
-    const teamRow = page.locator(`text=${teamName}`).locator('..');
-    const configureBtn = teamRow.locator('button:has-text("Configure")').first();
-    await configureBtn.click();
+    const teamRow = page.locator('#budgets-table tr').filter({ hasText: teamName });
+    await teamRow.locator('button:has-text("Configure")').click();
     await expect(page.locator('#modal-team-members')).toBeVisible();
 
     // Switch to Budget tab
@@ -56,9 +55,8 @@ test.describe('Team Management', () => {
     await expect(page.locator('#page-budgets')).toContainText(teamName, { timeout: 5_000 });
 
     // Open Configure modal — Members tab is default
-    const teamRow = page.locator(`text=${teamName}`).locator('..');
-    const configureBtn = teamRow.locator('button:has-text("Configure")').first();
-    await configureBtn.click();
+    const teamRow = page.locator('#budgets-table tr').filter({ hasText: teamName });
+    await teamRow.locator('button:has-text("Configure")').click();
 
     // The consolidated modal uses the same #modal-team-members ID
     await expect(page.locator('#modal-team-members')).toBeVisible({ timeout: 5_000 });
@@ -76,9 +74,8 @@ test.describe('Team Management', () => {
     await expect(page.locator('#page-budgets')).toContainText(teamName, { timeout: 5_000 });
 
     // Open Configure modal
-    const teamRow = page.locator(`text=${teamName}`).locator('..');
-    const configureBtn = teamRow.locator('button:has-text("Configure")').first();
-    await configureBtn.click();
+    const teamRow = page.locator('#budgets-table tr').filter({ hasText: teamName });
+    await teamRow.locator('button:has-text("Configure")').click();
     await expect(page.locator('#modal-team-members')).toBeVisible();
 
     // Switch to Keys tab
@@ -96,7 +93,8 @@ test.describe('Team Management', () => {
     // Key should appear in the table
     await expect(page.locator('#team-keys-table')).toContainText(keyName, { timeout: 5_000 });
 
-    // Revoke the key
+    // Revoke the key (accept the confirm dialog)
+    page.once('dialog', dialog => dialog.accept());
     const keyRow = page.locator(`#team-keys-table tr`).filter({ hasText: keyName });
     await keyRow.locator('button:has-text("Revoke")').click();
 
@@ -115,7 +113,7 @@ test.describe('Team Management', () => {
     await expect(page.locator('#page-budgets')).toContainText(teamName, { timeout: 5_000 });
 
     // Find and click delete button for this team
-    const teamRow = page.locator(`text=${teamName}`).locator('..');
+    const teamRow = page.locator('#budgets-table tr').filter({ hasText: teamName });
     const deleteBtn = teamRow.locator('button:has-text("Delete"), button[title*="delete"], button[title*="Delete"]').first();
     if (await deleteBtn.isVisible()) {
       await deleteBtn.click();

--- a/tests/frontend/tests/teams.spec.ts
+++ b/tests/frontend/tests/teams.spec.ts
@@ -43,7 +43,7 @@ test.describe('Team Management', () => {
     await page.click('#team-panel-budget button:has-text("Save Budget")');
 
     // Success toast should appear
-    await expect(page.locator('.toast, [class*="toast"]')).toContainText('Budget updated', { timeout: 5_000 });
+    await expect(page.locator('#toast-container')).toContainText('Budget updated', { timeout: 5_000 });
   });
 
   test('opens team members panel via Configure modal', async ({ page }) => {

--- a/tests/frontend/tests/teams.spec.ts
+++ b/tests/frontend/tests/teams.spec.ts
@@ -42,8 +42,8 @@ test.describe('Team Management', () => {
     await page.fill('#tb-amount', '500');
     await page.click('#team-panel-budget button:has-text("Save Budget")');
 
-    // Modal should close after save
-    await expect(page.locator('#modal-team-members')).toBeHidden({ timeout: 5_000 });
+    // Success toast should appear
+    await expect(page.locator('.toast, [class*="toast"]')).toContainText('Budget updated', { timeout: 5_000 });
   });
 
   test('opens team members panel via Configure modal', async ({ page }) => {

--- a/tests/integration/db_tests.rs
+++ b/tests/integration/db_tests.rs
@@ -90,6 +90,95 @@ async fn keys_with_rate_limit() {
 }
 
 // ============================================================
+// Keys: list_keys_for_team
+// ============================================================
+
+#[tokio::test]
+async fn list_keys_for_team_only_returns_matching_team() {
+    let pool = helpers::setup_test_db().await;
+    let team_a = helpers::create_test_team(&pool, "team-a").await;
+    let team_b = helpers::create_test_team(&pool, "team-b").await;
+
+    let (_, k_a1) = helpers::create_test_key(&pool, Some("a-key-1"), None, Some(team_a.id)).await;
+    let (_, k_a2) = helpers::create_test_key(&pool, Some("a-key-2"), None, Some(team_a.id)).await;
+    let (_, _k_b) = helpers::create_test_key(&pool, Some("b-key"), None, Some(team_b.id)).await;
+    // global key with no team
+    helpers::create_test_key(&pool, Some("global-key"), None, None).await;
+
+    let team_a_keys = db::keys::list_keys_for_team(&pool, team_a.id)
+        .await
+        .unwrap();
+    assert_eq!(team_a_keys.len(), 2);
+    let ids: Vec<_> = team_a_keys.iter().map(|k| k.id).collect();
+    assert!(ids.contains(&k_a1.id));
+    assert!(ids.contains(&k_a2.id));
+
+    let team_b_keys = db::keys::list_keys_for_team(&pool, team_b.id)
+        .await
+        .unwrap();
+    assert_eq!(team_b_keys.len(), 1);
+    assert_eq!(team_b_keys[0].name.as_deref(), Some("b-key"));
+}
+
+#[tokio::test]
+async fn list_keys_for_team_includes_team_only_and_user_scoped_keys() {
+    let pool = helpers::setup_test_db().await;
+    let team = helpers::create_test_team(&pool, "mixed-team").await;
+    let user = helpers::create_test_user(&pool, "member@test.com", Some(team.id), "member").await;
+
+    // team-only key (user_id = NULL)
+    let (_, team_key) =
+        helpers::create_test_key(&pool, Some("team-only"), None, Some(team.id)).await;
+    // user-scoped key (user_id = user.id)
+    let (_, user_key) =
+        helpers::create_test_key(&pool, Some("user-scoped"), Some(user.id), Some(team.id)).await;
+
+    let keys = db::keys::list_keys_for_team(&pool, team.id).await.unwrap();
+    assert_eq!(keys.len(), 2);
+
+    let ids: Vec<_> = keys.iter().map(|k| k.id).collect();
+    assert!(ids.contains(&team_key.id));
+    assert!(ids.contains(&user_key.id));
+
+    let found_team_only = keys.iter().find(|k| k.id == team_key.id).unwrap();
+    assert!(found_team_only.user_id.is_none());
+
+    let found_user_scoped = keys.iter().find(|k| k.id == user_key.id).unwrap();
+    assert_eq!(found_user_scoped.user_id, Some(user.id));
+}
+
+#[tokio::test]
+async fn list_keys_for_team_empty_for_team_with_no_keys() {
+    let pool = helpers::setup_test_db().await;
+    let team = helpers::create_test_team(&pool, "empty-team").await;
+    // Create a key for a different team to make sure isolation works
+    let other_team = helpers::create_test_team(&pool, "other-team").await;
+    helpers::create_test_key(&pool, Some("other-key"), None, Some(other_team.id)).await;
+
+    let keys = db::keys::list_keys_for_team(&pool, team.id).await.unwrap();
+    assert!(keys.is_empty());
+}
+
+#[tokio::test]
+async fn list_keys_for_team_ordered_by_created_at_desc() {
+    let pool = helpers::setup_test_db().await;
+    let team = helpers::create_test_team(&pool, "ordered-team").await;
+
+    // Insert three keys sequentially; DB timestamps will be in insertion order
+    let (_, k1) = helpers::create_test_key(&pool, Some("first"), None, Some(team.id)).await;
+    let (_, k2) = helpers::create_test_key(&pool, Some("second"), None, Some(team.id)).await;
+    let (_, k3) = helpers::create_test_key(&pool, Some("third"), None, Some(team.id)).await;
+
+    let keys = db::keys::list_keys_for_team(&pool, team.id).await.unwrap();
+    assert_eq!(keys.len(), 3);
+
+    // DESC order: most recently created first
+    assert_eq!(keys[0].id, k3.id);
+    assert_eq!(keys[1].id, k2.id);
+    assert_eq!(keys[2].id, k1.id);
+}
+
+// ============================================================
 // Users
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Replaces 3 separate team action buttons (Members, Routing, Budget) with a single **Configure** modal containing 4 tabs: Members, Routing, Budget, Keys
- Adds `GET /admin/teams/{team_id}/keys` endpoint for team-scoped key listing
- Keys tab lets admins create/revoke team-only keys directly from the team context
- Budget editing moved inline into the Configure modal (standalone modal preserved for Default User Budget)
- Budget helper functions parameterized to support both modal contexts

## Test plan
- [x] `make check` passes (214 tests)
- [x] Manual: Teams screen → single Configure button per row
- [ ] Manual: Members tab — add/remove users
- [ ] Manual: Routing tab — strategy + endpoints (renamed from "Endpoints")
- [ ] Manual: Budget tab — set/save budget inline
- [ ] Manual: Keys tab — create team key, copy from banner, revoke
- [ ] Manual: "No budget set" link opens Configure → Budget tab
- [ ] Manual: Default User Budget standalone modal still works
- [ ] CI status checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)