### PR TITLE
docs: add Podman troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Claude Code connects to CCAG as it would to the Anthropic API. The gateway trans
 
 - AWS account with [Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) enabled for Claude models
 - AWS CLI configured with credentials
-- Docker
+- Docker (or [Podman](docs/faq.md#podman))
 
 ### Option A: Docker Compose
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -284,6 +284,89 @@ In ECS, update the `RUST_LOG` environment variable in the task definition and re
 
 ---
 
+## Podman
+
+CCAG works with Podman and `podman-compose` as a drop-in replacement for Docker Compose. However, rootless Podman has several common issues.
+
+### Image pull fails with "insufficient UIDs or GIDs available in user namespace"
+
+This means Podman cannot map container UIDs into your user namespace. You need subordinate UID/GID ranges allocated for your user in `/etc/subuid` and `/etc/subgid`.
+
+**If you are a domain user** (e.g., Active Directory, LDAP, AWS WorkSpaces), Podman may look up your fully-qualified username (e.g., `user@domain.com`) rather than the short login name. Check with:
+
+```bash
+podman unshare cat /proc/self/uid_map
+```
+
+If you see `size: 1`, the mappings are not working. The most reliable fix is to add entries using your **numeric UID** (which avoids username resolution issues):
+
+```bash
+# Find your UID
+id -u
+
+# Add subordinate ranges by UID (replace 1000 with your UID)
+sudo sh -c 'echo "1000:200000:65536" >> /etc/subuid'
+sudo sh -c 'echo "1000:200000:65536" >> /etc/subgid'
+
+# Reset Podman storage to pick up the new mappings
+podman system reset --force
+```
+
+Verify the fix:
+
+```bash
+podman unshare cat /proc/self/uid_map
+# Should show: 0 <your-uid> 1
+#              1 200000     65536
+```
+
+### Container fails with "OCI runtime error: unknown version specified"
+
+This occurs when Podman uses an outdated `crun` OCI runtime. Check:
+
+```bash
+podman info | grep -A3 ociRuntime
+```
+
+If the `crun` package version is old (e.g., 0.17) but you have a newer `crun` installed elsewhere (e.g., via Homebrew), point Podman to it:
+
+```bash
+mkdir -p ~/.config/containers
+cat > ~/.config/containers/containers.conf << 'EOF'
+[engine]
+runtime = "/path/to/newer/crun"
+EOF
+```
+
+Find the newer binary with `which -a crun` and verify its version with `crun --version`.
+
+### AWS SSO credentials fail with "Permission denied" or "no valid credentials"
+
+Rootless Podman remaps UIDs inside the container. When `~/.aws` is mounted into the container, the files appear owned by `nobody` and are unreadable by the container process.
+
+**Workaround:** Export temporary credentials from your SSO session and pass them as environment variables instead of relying on the volume mount:
+
+```bash
+# Ensure your SSO session is active
+aws sso login --profile your-profile
+
+# Export credentials and start the gateway
+eval $(aws configure export-credentials --profile your-profile --format env)
+podman-compose up -d
+```
+
+The `docker-compose.yml` already accepts `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` as environment variables, which take precedence over the `~/.aws` mount.
+
+Note: SSO credentials are temporary (typically 1-12 hours). You will need to re-export them after they expire.
+
+**Shell alias for convenience:**
+
+```bash
+alias ccag-up='eval $(aws configure export-credentials --profile your-profile --format env) && podman-compose up -d'
+```
+
+---
+
 ## See Also
 
 - [Getting Started](getting-started.md): initial setup

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,9 @@ This guide walks you through deploying Claude Code AWS Gateway (CCAG) and connec
 
 - **AWS account** with Bedrock model access enabled (Claude models must be enabled in the Bedrock console)
 - **AWS CLI v2** configured with credentials
-- **Docker** installed and running
+- **Docker** (or Podman) installed and running
+
+> **Podman users:** `podman-compose` works as a drop-in replacement for `docker compose`. If you encounter issues with rootless Podman (UID mapping errors, OCI runtime errors, or AWS credential failures), see the [Podman troubleshooting section](faq.md#podman) in the FAQ.
 
 ## Deployment Options
 


### PR DESCRIPTION
## Summary

- Adds a **Podman** troubleshooting section to `docs/faq.md` covering three common rootless Podman issues:
  - UID/GID namespace mapping failures (especially for domain users where the qualified username doesn't match `/etc/subuid`)
  - Outdated `crun` OCI runtime causing "unknown version" errors
  - AWS SSO credential permission errors due to UID remapping in volume mounts
- Updates `docs/getting-started.md` and `README.md` to mention Podman as a supported alternative with a link to the troubleshooting guide

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify FAQ anchor link `faq.md#podman` resolves correctly
- [ ] Confirm steps work on a fresh rootless Podman setup with an SSO profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)