### PR TITLE
fix(infra): bump Fargate task memory 1024 → 2048 MiB (1.7.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/infra/stack.ts
+++ b/infra/stack.ts
@@ -90,7 +90,7 @@ export class GatewayStack extends cdk.Stack {
 
     // Task Definition
     const taskDef = new ecs.FargateTaskDefinition(this, 'TaskDef', {
-      memoryLimitMiB: 1024,
+      memoryLimitMiB: 2048,
       cpu: 512,
       runtimePlatform: {
         cpuArchitecture: ecs.CpuArchitecture.ARM64,


### PR DESCRIPTION
## Summary

- `infra/stack.ts`: `memoryLimitMiB: 1024` → `2048` on the Fargate task definition
- Version bump 1.7.1 → 1.7.2 (patch) in `Cargo.toml` + `cli/Cargo.toml` + `Cargo.lock`

Closes #56.

## Why

Under production load — Rust runtime + Postgres pool + background loops (health, spend, pricing, cache poller) + one or more concurrent large streaming responses — the task hits the 1 GiB ceiling and is OOM-killed (exit code 137). From the client's perspective the TCP socket drops mid-stream, surfacing in Claude Code as `API Error: The socket connection was closed unexpectedly` on large tool-call outputs (e.g. writing big files). 2 GiB gives enough headroom without being excessive.

This is a focused, single-line salvage of the infra fix from the now-closed #57; the version-display backend half of that PR already shipped to main, and the unrelated DB/migration changes from #57 weren't covered by its title and aren't included here.

## Test plan

- [ ] CI: Lint, Unit, Integration, Build, Coverage, Frontend, Load (smoke), Security Audit, Supply Chain — all green
- [ ] After merge: `/deploy --staging` and confirm the Fargate task definition shows 2048 MiB
- [ ] Repro check: ask Claude Code to write a >500-line file in one tool call against staging — confirm no mid-stream socket drop