### PR TITLE
fix(auth): respect idp.scopes in portal SSO login URL (1.7.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.7.2"
+version = "1.7.3"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.7.2"
+version = "1.7.3"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/src/api/cli_auth.rs
+++ b/src/api/cli_auth.rs
@@ -239,39 +239,7 @@ async fn build_auth_url(
     // Cryptographically random nonce
     let nonce = format!("{:032x}", rand::random::<u128>());
 
-    // Determine OIDC scopes: explicit per-IDP config takes priority.
-    // If not set, infer from user_claim: claims like email/preferred_username/upn
-    // need the email+profile scopes on some IDPs (e.g. Entra).
-    // Default to just "openid" (safe for IDPs like Midway that reject extra scopes).
-    let scopes = idp
-        .scopes
-        .as_deref()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| {
-            match idp.user_claim.as_deref() {
-                Some("email")
-                | Some("preferred_username")
-                | Some("upn")
-                | Some("name")
-                | Some("auto") => "openid email profile",
-                None => {
-                    // Auto-detect: if user_claim is unset (auto fallback chain starts with email),
-                    // only request broader scopes if the IDP looks like it needs them.
-                    // Heuristic: Entra/Okta/Google issuers benefit from email+profile scopes;
-                    // others (Midway, custom) may reject them.
-                    let issuer = idp.issuer.to_lowercase();
-                    if issuer.contains("microsoftonline")
-                        || issuer.contains("okta")
-                        || issuer.contains("accounts.google")
-                    {
-                        "openid email profile"
-                    } else {
-                        "openid"
-                    }
-                }
-                _ => "openid",
-            }
-        });
+    let scopes = crate::auth::oidc::resolve_oidc_scopes(idp);
     let encoded_scopes = scopes.replace(' ', "%20");
 
     Some(format!(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -414,8 +414,10 @@ async fn build_provider_info(
         '?'
     };
 
+    let scopes = crate::auth::oidc::resolve_oidc_scopes(idp);
+    let encoded_scopes = scopes.replace(' ', "%20");
     let login_url = format!(
-        "{authorize_endpoint}{separator}response_type=id_token&client_id={audience}&redirect_uri={redirect_uri}&nonce={nonce}&scope=openid"
+        "{authorize_endpoint}{separator}response_type=id_token&client_id={audience}&redirect_uri={redirect_uri}&nonce={nonce}&scope={encoded_scopes}"
     );
 
     Some(serde_json::json!({

--- a/src/auth/oidc.rs
+++ b/src/auth/oidc.rs
@@ -409,6 +409,44 @@ impl MultiIdpValidator {
     }
 }
 
+/// Resolve the OIDC scopes string to request during authorization.
+///
+/// Priority:
+/// 1. `idp.scopes` when `Some(s)` and `s` is non-empty — returned verbatim.
+/// 2. Otherwise infer from `idp.user_claim`:
+///    - "email", "preferred_username", "upn", "name", or "auto" → "openid email profile"
+///    - `None` → heuristic on issuer URL (Entra/Okta/Google → "openid email profile",
+///      anything else → "openid")
+///    - any other `Some(_)` → "openid"
+pub(crate) fn resolve_oidc_scopes(idp: &IdpConfig) -> String {
+    // Explicit scopes take priority if non-empty.
+    if let Some(s) = &idp.scopes
+        && !s.is_empty()
+    {
+        return s.clone();
+    }
+
+    // Infer from user_claim.
+    match idp.user_claim.as_deref() {
+        Some("email") | Some("preferred_username") | Some("upn") | Some("name") | Some("auto") => {
+            "openid email profile".to_string()
+        }
+        None => {
+            // Heuristic on issuer: well-known multi-claim IDPs benefit from email+profile.
+            let issuer = idp.issuer.to_lowercase();
+            if issuer.contains("microsoftonline")
+                || issuer.contains("okta")
+                || issuer.contains("accounts.google")
+            {
+                "openid email profile".to_string()
+            } else {
+                "openid".to_string()
+            }
+        }
+        Some(_) => "openid".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -974,5 +1012,153 @@ mod tests {
         let found = validator.find_key(&keys, None);
         assert!(found.is_some());
         assert_eq!(found.unwrap().n.unwrap(), "n-sig");
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for resolve_oidc_scopes (issue #76)
+    //
+    // The function does not exist yet — these tests are intentionally failing
+    // at compile time until @Builder Agent implements it in src/auth/oidc.rs.
+    // -----------------------------------------------------------------------
+
+    fn make_idp(issuer: &str, user_claim: Option<&str>, scopes: Option<&str>) -> IdpConfig {
+        IdpConfig {
+            name: "test-idp".to_string(),
+            issuer: issuer.to_string(),
+            audience: None,
+            jwks_url: None,
+            auto_provision: true,
+            default_role: "member".to_string(),
+            allowed_domains: None,
+            user_claim: user_claim.map(String::from),
+            scopes: scopes.map(String::from),
+        }
+    }
+
+    // 1. Explicit scopes are returned verbatim, regardless of user_claim or issuer.
+    #[test]
+    fn resolve_scopes_explicit_wins_over_all() {
+        let idp = make_idp(
+            "https://midway-auth.amazon.com",
+            Some("email"),
+            Some("openid email profile groups"),
+        );
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile groups",
+            "Explicit scopes must be returned unchanged"
+        );
+    }
+
+    // 2. Explicit but empty string is treated as unset, falls through to inference.
+    #[test]
+    fn resolve_scopes_empty_explicit_falls_through_to_inference() {
+        // Issuer is Entra → inference should give "openid email profile"
+        let idp = make_idp(
+            "https://login.microsoftonline.com/tenant-id/v2.0",
+            None,
+            Some(""),
+        );
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile",
+            "Empty scopes string must be treated as None and fall through to inference"
+        );
+    }
+
+    // 3. user_claim = "email" with no explicit scopes → "openid email profile"
+    #[test]
+    fn resolve_scopes_user_claim_email_implies_profile() {
+        let idp = make_idp("https://neutral.example.com", Some("email"), None);
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile",
+            "user_claim=email should infer email+profile scopes"
+        );
+    }
+
+    // 4. user_claim = "preferred_username" with no explicit scopes → "openid email profile"
+    #[test]
+    fn resolve_scopes_user_claim_preferred_username_implies_profile() {
+        let idp = make_idp(
+            "https://neutral.example.com",
+            Some("preferred_username"),
+            None,
+        );
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile",
+            "user_claim=preferred_username should infer email+profile scopes"
+        );
+    }
+
+    // 5. user_claim = "upn" with no explicit scopes → "openid email profile"
+    #[test]
+    fn resolve_scopes_user_claim_upn_implies_profile() {
+        let idp = make_idp("https://neutral.example.com", Some("upn"), None);
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile",
+            "user_claim=upn should infer email+profile scopes"
+        );
+    }
+
+    // 6. scopes=None, user_claim=None, Entra issuer → "openid email profile"
+    #[test]
+    fn resolve_scopes_no_claim_entra_issuer_infers_profile() {
+        let idp = make_idp(
+            "https://login.microsoftonline.com/tenant-id/v2.0",
+            None,
+            None,
+        );
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile",
+            "Entra issuer without user_claim should infer email+profile scopes"
+        );
+    }
+
+    // 7. scopes=None, user_claim=None, Okta issuer → "openid email profile"
+    #[test]
+    fn resolve_scopes_no_claim_okta_issuer_infers_profile() {
+        let idp = make_idp("https://mycompany.okta.com/oauth2/default", None, None);
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile",
+            "Okta issuer without user_claim should infer email+profile scopes"
+        );
+    }
+
+    // 8. scopes=None, user_claim=None, Google issuer → "openid email profile"
+    #[test]
+    fn resolve_scopes_no_claim_google_issuer_infers_profile() {
+        let idp = make_idp("https://accounts.google.com", None, None);
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile",
+            "Google issuer without user_claim should infer email+profile scopes"
+        );
+    }
+
+    // 9. scopes=None, user_claim=None, neutral/Midway-style issuer → "openid" only
+    #[test]
+    fn resolve_scopes_no_claim_neutral_issuer_returns_openid_only() {
+        let idp = make_idp("https://midway-auth.amazon.com", None, None);
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid",
+            "Neutral issuer (Midway-style) without user_claim should only request 'openid'"
+        );
+    }
+
+    // 10. Issuer matching is case-insensitive.
+    #[test]
+    fn resolve_scopes_issuer_match_is_case_insensitive() {
+        let idp = make_idp("https://LOGIN.MICROSOFTONLINE.COM/TENANT/v2.0", None, None);
+        assert_eq!(
+            resolve_oidc_scopes(&idp),
+            "openid email profile",
+            "Issuer substring matching must be case-insensitive"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Extract scope-resolution from `cli_auth::build_auth_url` into pure helper `auth::oidc::resolve_oidc_scopes(&IdpConfig) -> String`.
- Call it from both `build_auth_url` (CLI auth) and `build_provider_info` (portal SSO) — the latter previously hardcoded `&scope=openid`.
- 10 new unit tests covering all branches (explicit scopes win, empty falls through, user_claim inference, issuer-host inference, case-insensitive issuer match).
- Patch bump 1.7.1 → 1.7.3 (sequenced after #56's 1.7.2).

Closes #76.

## Why

`src/api/mod.rs::build_provider_info` is the portal-side SSO URL builder. It hardcoded `scope=openid` and never read `idp.scopes` or applied the same `user_claim`/issuer-based inference that `cli_auth::build_auth_url` has been doing for a while. Reporters wiring Microsoft Entra into the portal couldn't request the `profile` scope, which Entra needs to surface user-claim identifiers — so SCIM-provisioned users couldn't sign in cleanly. Behavior on the CLI auth path is unchanged (exact port of existing logic into a shared helper).

## Test plan

- [x] `SQLX_OFFLINE=true cargo test --lib auth::oidc::tests::resolve` — 10/10 pass
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Post-merge: smoke check the portal SSO flow against an Entra IDP — confirm the launched URL includes `scope=openid%20email%20profile`