### PR TITLE
feat(1m-context): self-learning beta translation + 1M context support [v1.8.0]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ docs/
 - **Presents as Anthropic Direct API**: Set `ANTHROPIC_BASE_URL` (NOT `CLAUDE_CODE_USE_BEDROCK`)
 - **Model ID mapping**: Auto-detected from AWS SDK region. See `config/mod.rs`
 - **Model availability**: `/v1/models` returns dynamically discovered models from Bedrock `ListInferenceProfiles` (filtered by routing prefix). Health loop caches per-endpoint availability every 60s. Requests are blocked with a clear error if the model isn't available on the user's team endpoints. See `endpoint/mod.rs`, `api/handlers.rs`
-- **Beta flag allowlist**: Only forward betas Bedrock accepts. See `translate/models.rs`
+- **Beta flags**: forwarded if cache shows (profile, beta) supported. Cache is populated by health-loop probes (24h TTL), opportunistic learning on successful requests, and rejection-parsing on Bedrock ValidationException (with a single-retry-without-rejected-beta). No hardcoded allowlist. Admin override via `ccag betas override`. See spec `1m-context-support`.
 - **Auth**: Virtual keys (DB cache) + OIDC JWT (multi-IDP) + gateway session tokens + SCIM 2.0 provisioning
 - **Web search**: Intercepts `web_search` tool, executes via DuckDuckGo. See `websearch/mod.rs`
 - **Cache invalidation**: Polling `cache_version` table every 5s
@@ -103,7 +103,7 @@ Full list: see `docs/configuration.md`
 - `cache_control` is sanitized before forwarding to Bedrock (only `type` and `ttl` fields are kept; unknown fields like `scope` are stripped)
 - `amazon-bedrock-invocationMetrics` must be stripped from SSE events
 - Inference profiles are mandatory for newer Claude models (4.5+)
-- Beta flags: ALLOWLIST approach (only forward betas Bedrock accepts)
+- Beta flags: forwarded if cache shows (profile, beta) supported. Cache is populated by health-loop probes (24h TTL), opportunistic learning on successful requests, and rejection-parsing on Bedrock ValidationException (with a single-retry-without-rejected-beta). No hardcoded allowlist. Admin override via `ccag betas override`. See spec `1m-context-support`.
 - Bedrock SDK `Display` impl is terse. Use `Debug` format for error messages.
 - `ListInferenceProfiles` returns ALL region profiles (us., eu., global.) regardless of calling region — filter by routing prefix before caching
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.7.3"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.7.3"
+version = "1.8.0"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.7.3"
+version = "1.8.0"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/src/commands/betas.rs
+++ b/cli/src/commands/betas.rs
@@ -1,0 +1,129 @@
+use anyhow::Result;
+use clap::Subcommand;
+use uuid::Uuid;
+
+use crate::config::AdminClient;
+use crate::util;
+
+#[derive(Subcommand, Debug)]
+pub enum BetasCommands {
+    /// List all admin beta overrides
+    ListOverrides,
+
+    /// Set an override that wins over learned cache values (TTL-immune)
+    Override {
+        /// Endpoint UUID
+        endpoint_id: Uuid,
+
+        /// Bedrock profile ID, e.g. `us.anthropic.claude-opus-4-7`
+        profile_id: String,
+
+        /// Beta name, e.g. `context-1m-2025-08-07`
+        beta_name: String,
+
+        /// `true` to mark supported; `false` to mark unsupported
+        #[arg(action = clap::ArgAction::Set)]
+        supported: bool,
+
+        /// Optional human-readable reason; stored alongside the override
+        #[arg(long)]
+        reason: Option<String>,
+    },
+
+    /// Remove an admin override; cache reverts to learned state (or absent)
+    ClearOverride {
+        /// Endpoint UUID
+        endpoint_id: Uuid,
+
+        /// Bedrock profile ID
+        profile_id: String,
+
+        /// Beta name
+        beta_name: String,
+    },
+}
+
+pub async fn run(cmd: BetasCommands, url: Option<String>, token: Option<String>) -> Result<()> {
+    let client = AdminClient::from_options(url, token).await?;
+
+    match cmd {
+        BetasCommands::ListOverrides => {
+            let resp = client.get("/admin/beta-overrides").await?;
+            if let Some(overrides) = resp["overrides"].as_array() {
+                if overrides.is_empty() {
+                    eprintln!("No beta overrides configured.");
+                    return Ok(());
+                }
+                eprintln!(
+                    "{:<36}  {:<42}  {:<30}  {:<9}  REASON",
+                    "ENDPOINT_ID", "PROFILE_ID", "BETA_NAME", "SUPPORTED"
+                );
+                eprintln!("{}", "-".repeat(165));
+                for ovr in overrides {
+                    println!(
+                        "{:<36}  {:<42}  {:<30}  {:<9}  {}",
+                        ovr["endpoint_id"].as_str().unwrap_or("-"),
+                        ovr["profile_id"].as_str().unwrap_or("-"),
+                        ovr["beta_name"].as_str().unwrap_or("-"),
+                        if ovr["supported"].as_bool().unwrap_or(false) {
+                            "true"
+                        } else {
+                            "false"
+                        },
+                        ovr["reason"].as_str().unwrap_or("-"),
+                    );
+                }
+            } else {
+                println!("{}", serde_json::to_string_pretty(&resp)?);
+            }
+        }
+
+        BetasCommands::Override {
+            endpoint_id,
+            profile_id,
+            beta_name,
+            supported,
+            reason,
+        } => {
+            let mut body = serde_json::json!({
+                "endpoint_id": endpoint_id.to_string(),
+                "profile_id": profile_id,
+                "beta_name": beta_name,
+                "supported": supported,
+            });
+            if let Some(r) = reason {
+                body["reason"] = serde_json::Value::String(r);
+            }
+
+            let resp = client.post("/admin/beta-overrides", &body).await?;
+            util::success(&format!(
+                "Beta override set: endpoint={} profile={} beta={} supported={}",
+                resp["endpoint_id"]
+                    .as_str()
+                    .unwrap_or(&endpoint_id.to_string()),
+                resp["profile_id"].as_str().unwrap_or(&profile_id),
+                resp["beta_name"].as_str().unwrap_or(&beta_name),
+                resp["supported"].as_bool().unwrap_or(supported),
+            ));
+        }
+
+        BetasCommands::ClearOverride {
+            endpoint_id,
+            profile_id,
+            beta_name,
+        } => {
+            client
+                .delete(&format!(
+                    "/admin/beta-overrides/{}/{}/{}",
+                    endpoint_id, profile_id, beta_name,
+                ))
+                .await?;
+            util::success(&format!(
+                "Beta override cleared: endpoint={} profile={} beta={}",
+                endpoint_id, profile_id, beta_name,
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod betas;
 pub mod config;
 pub mod endpoints;
 pub mod idps;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,7 @@
+// Allow `unused_variables` in test code only — test match arms like
+// `other => panic!(...)` are intentional catch-alls that bind the
+// unmatched value for readability without using it.
+#![cfg_attr(test, allow(unused_variables))]
 use clap::{Parser, Subcommand};
 
 mod commands;
@@ -68,6 +72,10 @@ enum Commands {
     #[command(subcommand)]
     Scim(commands::scim::ScimCommands),
 
+    /// Manage beta-capability overrides
+    #[command(subcommand)]
+    Betas(commands::betas::BetasCommands),
+
     /// Check deployment status and health
     Status(commands::status::StatusArgs),
 
@@ -123,8 +131,196 @@ async fn main() -> anyhow::Result<()> {
         Commands::Endpoints(cmd) => commands::endpoints::run(cmd, cli.url, cli.token).await,
         Commands::Idps(cmd) => commands::idps::run(cmd, cli.url, cli.token).await,
         Commands::Scim(cmd) => commands::scim::run(cmd, cli.url, cli.token).await,
+        Commands::Betas(cmd) => commands::betas::run(cmd, cli.url, cli.token).await,
         Commands::Status(args) => commands::status::run(args, cli.url).await,
         Commands::Logs(args) => commands::logs::run(args).await,
         Commands::Update => commands::update::run().await,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer A — CLI clap parser contract tests (T8)
+//
+// These tests drive the clap `derive` parser directly via `Cli::try_parse_from`
+// with no I/O or network calls.  They will FAIL TO COMPILE until the Builder
+// creates `cli/src/commands/betas.rs` and registers it in `Commands` (see
+// task 8 contract in `.claude/specs/1m-context-support-tasks.md`).
+//
+// Contract the Builder must satisfy:
+//   1. Add `pub mod betas;` to `cli/src/commands/mod.rs`.
+//   2. Add a `Betas` variant to `Commands` in this file:
+//        /// Manage beta-capability overrides
+//        #[command(subcommand)]
+//        Betas(commands::betas::BetasCommands),
+//   3. Add handler arm in `main()`:
+//        Commands::Betas(cmd) => commands::betas::run(cmd, cli.url, cli.token).await,
+//   4. `BetasCommands` must expose:
+//        - `ListOverrides`                     (no args)
+//        - `Override { endpoint_id: Uuid, profile_id: String, beta_name: String, supported: bool, reason: Option<String> }`
+//        - `ClearOverride { endpoint_id: Uuid, profile_id: String, beta_name: String }`
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests_cli_betas {
+    use super::{Cli, Commands};
+    use clap::Parser;
+    // `commands` is a private module declared at crate root — accessible via `crate::`.
+    // These imports will fail to compile until the Builder adds `betas.rs` and registers it.
+    #[allow(unused_imports)]
+    use crate::commands::betas::BetasCommands;
+
+    fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
+        Cli::try_parse_from(args)
+    }
+
+    /// Test 6 — `ccag betas list-overrides` parses to `Commands::Betas(BetasCommands::ListOverrides)`.
+    ///
+    /// Fails to compile until Builder adds `Commands::Betas` + `BetasCommands`.
+    #[test]
+    fn list_overrides_parses() {
+        let cli = parse(&["ccag", "betas", "list-overrides"])
+            .expect("list-overrides should parse without error");
+        assert!(
+            matches!(cli.command, Commands::Betas(BetasCommands::ListOverrides)),
+            "expected Commands::Betas(BetasCommands::ListOverrides)"
+        );
+    }
+
+    /// Test 7 — `ccag betas override <uuid> <profile> <beta> true --reason "manual"`.
+    /// Parses; reason is `Some("manual")`.
+    ///
+    /// Fails to compile until Builder adds `Commands::Betas` + `BetasCommands`.
+    #[test]
+    fn override_parses_with_reason() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let cli = parse(&[
+            "ccag",
+            "betas",
+            "override",
+            uuid,
+            "us.anthropic.claude-opus-4-7",
+            "context-1m-2025-08-07",
+            "true",
+            "--reason",
+            "manual",
+        ])
+        .expect("override with --reason should parse successfully");
+
+        match cli.command {
+            Commands::Betas(BetasCommands::Override {
+                endpoint_id,
+                profile_id,
+                beta_name,
+                supported,
+                reason,
+            }) => {
+                assert_eq!(endpoint_id.to_string(), uuid, "endpoint_id mismatch");
+                assert_eq!(profile_id, "us.anthropic.claude-opus-4-7");
+                assert_eq!(beta_name, "context-1m-2025-08-07");
+                assert!(supported, "supported must be true");
+                assert_eq!(reason, Some("manual".to_string()));
+            }
+            other => panic!("expected Betas(Override), got a different variant"),
+        }
+    }
+
+    /// Test 8 — `ccag betas override <uuid> <profile> <beta> false` (no --reason).
+    /// Parses; reason is `None`.
+    ///
+    /// Fails to compile until Builder adds `Commands::Betas` + `BetasCommands`.
+    #[test]
+    fn override_parses_without_reason() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let cli = parse(&[
+            "ccag",
+            "betas",
+            "override",
+            uuid,
+            "us.anthropic.claude-haiku-4-5",
+            "context-1m-2025-08-07",
+            "false",
+        ])
+        .expect("override without --reason should parse successfully");
+
+        match cli.command {
+            Commands::Betas(BetasCommands::Override {
+                supported, reason, ..
+            }) => {
+                assert!(!supported, "supported must be false");
+                assert!(reason.is_none(), "reason must be None when omitted");
+            }
+            _ => panic!("expected Betas(Override) variant"),
+        }
+    }
+
+    /// Test 9 — a non-boolean `supported` value causes a clap parse error (exit 2).
+    ///
+    /// Fails to compile until Builder adds `Commands::Betas` + `BetasCommands`.
+    #[test]
+    fn override_rejects_invalid_bool() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let result = parse(&[
+            "ccag",
+            "betas",
+            "override",
+            uuid,
+            "us.anthropic.claude-opus-4-7",
+            "context-1m-2025-08-07",
+            "not-a-bool",
+        ]);
+        assert!(
+            result.is_err(),
+            "a non-bool 'supported' value must produce a clap parse error"
+        );
+    }
+
+    /// Test 10 — a non-UUID `endpoint_id` causes a clap parse error (exit 2).
+    ///
+    /// Fails to compile until Builder adds `Commands::Betas` + `BetasCommands`.
+    #[test]
+    fn override_rejects_invalid_uuid() {
+        let result = parse(&[
+            "ccag",
+            "betas",
+            "override",
+            "not-a-uuid",
+            "us.anthropic.claude-opus-4-7",
+            "context-1m-2025-08-07",
+            "true",
+        ]);
+        assert!(
+            result.is_err(),
+            "a non-UUID endpoint_id must produce a clap parse error"
+        );
+    }
+
+    /// Test 11 — `ccag betas clear-override <uuid> <profile> <beta>` parses to
+    /// `Commands::Betas(BetasCommands::ClearOverride)` with all three fields.
+    ///
+    /// Fails to compile until Builder adds `Commands::Betas` + `BetasCommands`.
+    #[test]
+    fn clear_override_parses() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let cli = parse(&[
+            "ccag",
+            "betas",
+            "clear-override",
+            uuid,
+            "us.anthropic.claude-opus-4-7",
+            "context-1m-2025-08-07",
+        ])
+        .expect("clear-override should parse successfully");
+
+        match cli.command {
+            Commands::Betas(BetasCommands::ClearOverride {
+                endpoint_id,
+                profile_id,
+                beta_name,
+            }) => {
+                assert_eq!(endpoint_id.to_string(), uuid);
+                assert_eq!(profile_id, "us.anthropic.claude-opus-4-7");
+                assert_eq!(beta_name, "context-1m-2025-08-07");
+            }
+            _ => panic!("expected Betas(ClearOverride) variant"),
+        }
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,36 @@ When `DATABASE_HOST` is set, the gateway constructs the connection string from t
 |---|---|---|
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | _(none)_ | OTLP gRPC endpoint for exporting metrics (e.g., `http://otel-collector:4317`). When set, all metric instruments are exported via gRPC every 60 seconds alongside the Prometheus scrape endpoint. See `docs/metrics.md` for the full metric list. |
 
+## Client-Side Environment Variables
+
+These variables are set in the **client's shell** (not the gateway process). The standard CCAG setup flow exports them automatically via `proxy_login.sh` (the `apiKeyHelper` script installed by the Connect page). You do not normally need to set them manually.
+
+| Variable | Value | Description |
+|---|---|---|
+| `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY` | `1` | Instructs Claude Code to query the gateway's `/v1/models` endpoint for the model picker, instead of using CC's hardcoded model list. Set automatically by `proxy_login.sh` on every invocation (before any early-return path, so it is always exported regardless of whether a cached token is reused or a fresh browser login occurs). Required for `[1m]` suffix variants to appear in `/model`. |
+
+### 1M context window
+
+CCAG supports Claude Code's 1M-context model variants via the `[1m]` suffix convention (e.g., `claude-opus-4-7[1m]`).
+
+**How it works end-to-end:**
+
+1. **Advertising.** `/v1/models` emits a paired `<model-id>[1m]` entry (display name appended with `(1M context)`) for any Bedrock inference profile where the `context-1m-2025-08-07` beta has been confirmed supported. With `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` set, CC's model picker shows these variants.
+
+2. **Auto-discovery.** The gateway health loop probes each `(profile, beta)` pair with a synthetic 1-token `InvokeModel` call every 24 hours. A 200 response marks the pair as supported; a `ValidationException` whose message names the beta marks it unsupported. Throttle/5xx responses are ignored and retried on the next tick. No operator configuration is required.
+
+3. **Opportunistic learning.** When a real user request succeeds with a beta that had no cache entry, the gateway records it as supported. When Bedrock rejects a request naming specific betas, those betas are recorded as unsupported, the rejected betas are stripped, and the request is retried once automatically. This means a single `(profile, beta)` pair absorbs at most one round-trip penalty per 24-hour window.
+
+4. **Self-healing.** If Bedrock changes which betas it accepts on a model — a beta promoted to GA starts returning a 400, or a new model starts accepting a beta — the cache corrects itself on the next health-loop tick or the next rejected request. No gateway binary release is required.
+
+5. **Admin override.** Operators can force a `(endpoint, profile, beta) → supported` value via `ccag betas override` (see Tasks 7–8). Overrides persist across restarts and ignore the 24-hour TTL. Use as an escape hatch when the learned value is wrong (transient Bedrock error misclassified as unsupported, new beta before the parser recognizes the format, etc.).
+
+**Bootstrap window.** After a gateway restart, the capability cache is empty. The first health-loop tick completes within seconds and populates entries. During that window, no `[1m]` variants are advertised by `/v1/models`, and betas are forwarded optimistically on real requests (with rejection-retry protection).
+
+**No operator maintenance.** Self-deployers do not need a new CCAG binary release when Anthropic ships a new beta header that Bedrock accepts, or when AWS launches a new 1M-capable Claude model. The health-loop probe and rejection-learning paths handle both cases automatically.
+
+
+
 ### Pricing
 
 | Variable | Default | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,8 @@ These variables are set in the **client's shell** (not the gateway process). The
 
 CCAG supports Claude Code's 1M-context model variants via the `[1m]` suffix convention (e.g., `claude-opus-4-7[1m]`).
 
+> **Multi-endpoint requirement.** `[1m]` variants only appear in `/v1/models` for endpoints configured in the admin portal (or via `ccag` CLI). The gateway's built-in default Bedrock client (used when no endpoint is configured) does not run capability probes, so single-endpoint deployments using only the default client will not see `[1m]` variants in CC's model picker. To enable 1M context discovery, add at least one named endpoint via `Admin → Endpoints` or `ccag endpoints add`.
+
 **How it works end-to-end:**
 
 1. **Advertising.** `/v1/models` emits a paired `<model-id>[1m]` entry (display name appended with `(1M context)`) for any Bedrock inference profile where the `context-1m-2025-08-07` beta has been confirmed supported. With `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` set, CC's model picker shows these variants.
@@ -123,7 +125,7 @@ CCAG supports Claude Code's 1M-context model variants via the `[1m]` suffix conv
 
 4. **Self-healing.** If Bedrock changes which betas it accepts on a model — a beta promoted to GA starts returning a 400, or a new model starts accepting a beta — the cache corrects itself on the next health-loop tick or the next rejected request. No gateway binary release is required.
 
-5. **Admin override.** Operators can force a `(endpoint, profile, beta) → supported` value via `ccag betas override` (see Tasks 7–8). Overrides persist across restarts and ignore the 24-hour TTL. Use as an escape hatch when the learned value is wrong (transient Bedrock error misclassified as unsupported, new beta before the parser recognizes the format, etc.).
+5. **Admin override.** Operators can force a `(endpoint, profile, beta) → supported` value via `ccag betas override <endpoint-id> <profile-id> <beta-name> true|false [--reason "..."]` — sets a permanent capability override that ignores TTL and survives restarts. Useful when the auto-discovery is wrong (Bedrock returns a misleading error string, transient outage misclassified as `unsupported`, or a new beta needs to be force-enabled before our parser knows about it).
 
 **Bootstrap window.** After a gateway restart, the capability cache is empty. The first health-loop tick completes within seconds and populates entries. During that window, no `[1m]` variants are advertised by `/v1/models`, and betas are forwarded optimistically on real requests (with rejection-retry protection).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -124,6 +124,12 @@ https://your-domain.com/portal          # CDK deployment
 
 For OIDC/SSO authentication (browser-based login, no static API keys), see [Authentication](authentication.md).
 
+### Recommended client environment
+
+The standard CCAG setup flow (via the Connect page or `proxy_login.sh`) automatically exports `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` into Claude Code's environment. With this flag set, CC's `/model` picker queries the gateway's `/v1/models` endpoint rather than using CC's hardcoded model list — which is what allows CCAG to surface the correct available models for your team's endpoints, including `[1m]` (1M context) variants for models where Bedrock has confirmed that capability. If you are configuring CC manually, set this variable before launching Claude Code.
+
+
+
 ## Verifying It Works
 
 ```bash

--- a/migrations/011_beta_overrides.sql
+++ b/migrations/011_beta_overrides.sql
@@ -1,0 +1,13 @@
+-- Admin-managed capability overrides: operator-set (profile, beta) supported flags.
+-- These override the learned (seed-probe, request-path) cache entries and ignore TTL.
+
+CREATE TABLE beta_overrides (
+    endpoint_id UUID NOT NULL REFERENCES endpoints(id) ON DELETE CASCADE,
+    profile_id  TEXT NOT NULL,
+    beta_name   TEXT NOT NULL,
+    supported   BOOLEAN NOT NULL,
+    set_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    set_by      TEXT NOT NULL,
+    reason      TEXT,
+    PRIMARY KEY (endpoint_id, profile_id, beta_name)
+);

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -4121,11 +4121,19 @@ pub async fn upsert_beta_override(
     if let Some(client) = state.endpoint_pool.get_client(req.endpoint_id).await {
         if ovr.supported {
             client
-                .mark_supported(&ovr.profile_id, &ovr.beta_name, crate::endpoint::ProbeSource::AdminOverride)
+                .mark_supported(
+                    &ovr.profile_id,
+                    &ovr.beta_name,
+                    crate::endpoint::ProbeSource::AdminOverride,
+                )
                 .await;
         } else {
             client
-                .mark_unsupported(&ovr.profile_id, &ovr.beta_name, crate::endpoint::ProbeSource::AdminOverride)
+                .mark_unsupported(
+                    &ovr.profile_id,
+                    &ovr.beta_name,
+                    crate::endpoint::ProbeSource::AdminOverride,
+                )
                 .await;
         }
     } else {
@@ -4134,6 +4142,9 @@ pub async fn upsert_beta_override(
             "upsert_beta_override: endpoint exists in DB but not in EndpointPool — in-memory cache not updated"
         );
     }
+
+    // Bump cache_version so other gateway replicas pick up the change within 5s.
+    let _ = db::settings::bump_cache_version(pool).await;
 
     Json(json!({
         "endpoint_id": ovr.endpoint_id,
@@ -4174,6 +4185,8 @@ pub async fn delete_beta_override(
             if let Some(client) = state.endpoint_pool.get_client(endpoint_id).await {
                 client.forget_capability(&profile_id, &beta_name).await;
             }
+            // Bump cache_version so other gateway replicas evict the override within 5s.
+            let _ = db::settings::bump_cache_version(pool).await;
             Json(json!({ "deleted": true })).into_response()
         }
         Err(e) => admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -4031,3 +4031,151 @@ pub async fn refresh_pricing(
         });
     Json(report).into_response()
 }
+
+// --- Beta overrides ---
+
+/// GET /admin/beta-overrides — list all admin-managed capability overrides.
+pub async fn list_beta_overrides(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+    let pool = &pool;
+
+    match db::beta_overrides::list_all(pool).await {
+        Ok(overrides) => {
+            let items: Vec<serde_json::Value> = overrides
+                .iter()
+                .map(|o| {
+                    json!({
+                        "endpoint_id": o.endpoint_id,
+                        "profile_id": o.profile_id,
+                        "beta_name": o.beta_name,
+                        "supported": o.supported,
+                        "set_at": o.set_at,
+                        "set_by": o.set_by,
+                        "reason": o.reason,
+                    })
+                })
+                .collect();
+            Json(json!({ "overrides": items })).into_response()
+        }
+        Err(e) => admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct UpsertBetaOverrideRequest {
+    pub endpoint_id: Uuid,
+    pub profile_id: String,
+    pub beta_name: String,
+    pub supported: bool,
+    pub reason: Option<String>,
+}
+
+/// POST /admin/beta-overrides — upsert a (endpoint, profile, beta) override.
+pub async fn upsert_beta_override(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Json(req): Json<UpsertBetaOverrideRequest>,
+) -> Response {
+    let set_by = match check_admin_auth_identity(&headers, &state).await {
+        Ok(identity) => identity,
+        Err(resp) => return resp,
+    };
+
+    let pool = state.db().await;
+    let pool = &pool;
+
+    // Pre-validate that the endpoint exists — convert the FK violation into a clean 404.
+    match db::endpoints::get_endpoint(pool, req.endpoint_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return error_response(
+                StatusCode::NOT_FOUND,
+                &format!("Endpoint '{}' not found", req.endpoint_id),
+            );
+        }
+        Err(e) => return admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+
+    let ovr = db::beta_overrides::BetaOverride {
+        endpoint_id: req.endpoint_id,
+        profile_id: req.profile_id.clone(),
+        beta_name: req.beta_name.clone(),
+        supported: req.supported,
+        set_at: chrono::Utc::now(),
+        set_by,
+        reason: req.reason.clone(),
+    };
+
+    if let Err(e) = db::beta_overrides::upsert(pool, &ovr).await {
+        return admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string());
+    }
+
+    // Synchronously update the in-memory cache so the new value is visible immediately,
+    // without waiting for the 5s cache_version poll.
+    if let Some(client) = state.endpoint_pool.get_client(req.endpoint_id).await {
+        if ovr.supported {
+            client
+                .mark_supported(&ovr.profile_id, &ovr.beta_name, crate::endpoint::ProbeSource::AdminOverride)
+                .await;
+        } else {
+            client
+                .mark_unsupported(&ovr.profile_id, &ovr.beta_name, crate::endpoint::ProbeSource::AdminOverride)
+                .await;
+        }
+    } else {
+        tracing::warn!(
+            endpoint_id = %req.endpoint_id,
+            "upsert_beta_override: endpoint exists in DB but not in EndpointPool — in-memory cache not updated"
+        );
+    }
+
+    Json(json!({
+        "endpoint_id": ovr.endpoint_id,
+        "profile_id": ovr.profile_id,
+        "beta_name": ovr.beta_name,
+        "supported": ovr.supported,
+        "set_at": ovr.set_at,
+        "set_by": ovr.set_by,
+        "reason": ovr.reason,
+    }))
+    .into_response()
+}
+
+/// DELETE /admin/beta-overrides/{endpoint_id}/{profile_id}/{beta_name}
+///
+/// Returns 200 on success, 404 if the override does not exist.
+pub async fn delete_beta_override(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Path((endpoint_id, profile_id, beta_name)): Path<(Uuid, String, String)>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+
+    let pool = state.db().await;
+    let pool = &pool;
+
+    match db::beta_overrides::delete(pool, endpoint_id, &profile_id, &beta_name).await {
+        Ok(0) => error_response(
+            StatusCode::NOT_FOUND,
+            &format!(
+                "No override found for endpoint={endpoint_id} profile={profile_id} beta={beta_name}"
+            ),
+        ),
+        Ok(_) => {
+            // Synchronously evict from in-memory cache.
+            if let Some(client) = state.endpoint_pool.get_client(endpoint_id).await {
+                client.forget_capability(&profile_id, &beta_name).await;
+            }
+            Json(json!({ "deleted": true })).into_response()
+        }
+        Err(e) => admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -15,9 +15,10 @@ use uuid::Uuid;
 use crate::auth::CachedKey;
 use crate::auth::oidc::OidcIdentity;
 use crate::db::spend::RequestLogEntry;
+use crate::endpoint::{EndpointClient, ProbeSource};
 use crate::proxy::GatewayState;
 use crate::telemetry::Metrics;
-use crate::translate::{models, request, response, streaming};
+use crate::translate::{betas as beta_filter, models, request, response, streaming};
 use crate::websearch;
 
 /// RAII guard that decrements the in-flight request counter on drop.
@@ -42,6 +43,21 @@ impl Drop for InFlightGuard {
 enum AuthResult {
     VirtualKey(CachedKey),
     Oidc(OidcIdentity),
+}
+
+/// Context passed to `handle_non_streaming` / `handle_streaming` so they can
+/// perform opportunistic beta-capability learning and retry-on-rejection.
+struct BetaRetryContext {
+    /// The endpoint client whose capability cache should be updated.
+    endpoint_client: Arc<EndpointClient>,
+    /// Bedrock profile ID used as the cache key (e.g. `us.anthropic.claude-opus-4-7`).
+    profile: String,
+    /// Forwarded betas whose cache state was `None` at filter time.
+    /// On HTTP 200 these are marked `(profile, beta) → true` via `RequestSuccess`.
+    unknown_betas: Vec<String>,
+    /// All betas that were forwarded in this request.
+    /// Used to match against Bedrock's `ValidationException` error message.
+    forwarded_betas: Vec<String>,
 }
 
 /// Identity extracted from auth for spend tracking.
@@ -547,7 +563,7 @@ pub async fn messages(
         .flatten()
         .unwrap_or_else(|| "enabled".to_string());
 
-    let (mut bedrock_model, bedrock_body, web_search_ctx) = request::translate(
+    let (mut bedrock_model, mut bedrock_body, web_search_ctx) = request::translate(
         body,
         &routing_prefix,
         Some(&state.model_cache),
@@ -597,6 +613,39 @@ pub async fn messages(
     if web_search_ctx.is_some() {
         tracing::info!(request_id = %request_id, "Web search tool detected, interception enabled");
     }
+
+    // ── Beta capability filtering ────────────────────────────────────────────
+    // Filter anthropic_beta through the per-endpoint capability cache.
+    // Betas the cache says Some(false) are dropped here to avoid a Bedrock
+    // ValidationException. Betas whose cache state is None are kept optimistically
+    // and tracked for opportunistic learning when the request succeeds.
+    //
+    // This block also builds BetaRetryContext for the handler to use when
+    // a ValidationException fires at runtime (parse, mark_unsupported, retry once).
+    let beta_retry_ctx: Option<BetaRetryContext> = if let Some(ref ep) = selected_endpoint {
+        let filter_result =
+            beta_filter::filter_betas_by_cache(ep, &bedrock_model, &bedrock_body.anthropic_beta)
+                .await;
+
+        if !filter_result.dropped.is_empty() {
+            tracing::info!(
+                request_id = %request_id,
+                dropped = ?filter_result.dropped,
+                "Dropped betas that cache records as unsupported"
+            );
+        }
+
+        let ctx = BetaRetryContext {
+            endpoint_client: Arc::clone(ep),
+            profile: bedrock_model.clone(),
+            unknown_betas: filter_result.unknown.clone(),
+            forwarded_betas: filter_result.kept.clone(),
+        };
+        bedrock_body.anthropic_beta = filter_result.kept;
+        Some(ctx)
+    } else {
+        None
+    };
 
     let body_bytes = match serde_json::to_vec(&bedrock_body) {
         Ok(b) => b,
@@ -730,6 +779,7 @@ pub async fn messages(
             req_info.clone(),
             start,
             endpoint_id,
+            beta_retry_ctx,
         )
         .await
     } else {
@@ -744,6 +794,7 @@ pub async fn messages(
             req_info.clone(),
             start,
             endpoint_id,
+            beta_retry_ctx,
         )
         .await
     };
@@ -791,6 +842,7 @@ pub async fn messages(
                         req_info.clone(),
                         start,
                         fb_endpoint_id,
+                        None, // no beta retry on failover — already retried on primary
                     )
                     .await
                 } else {
@@ -805,6 +857,7 @@ pub async fn messages(
                         req_info.clone(),
                         start,
                         fb_endpoint_id,
+                        None, // no beta retry on failover — already retried on primary
                     )
                     .await
                 };
@@ -1088,18 +1141,152 @@ async fn handle_non_streaming(
     req_info: RequestInfo,
     start: Instant,
     endpoint_id: Option<Uuid>,
+    beta_ctx: Option<BetaRetryContext>,
 ) -> Response {
     let result = runtime_client
         .invoke_model()
         .model_id(bedrock_model)
         .content_type("application/json")
         .accept("application/json")
-        .body(Blob::new(body_bytes))
+        .body(Blob::new(body_bytes.clone()))
         .send()
         .await;
 
+    // Check for ValidationException that names a known beta — retry once with those
+    // betas stripped, and mark them as unsupported in the capability cache.
+    let result = if let Err(ref e) = result {
+        use aws_sdk_bedrockruntime::error::SdkError;
+        let is_ve = matches!(e, SdkError::ServiceError(svc) if svc.err().is_validation_exception());
+        if is_ve && let Some(ref ctx) = beta_ctx {
+            let err_str = format!("{e:?}");
+            let rejected = beta_filter::parse_rejected_betas(&err_str, &ctx.forwarded_betas);
+            if !rejected.is_empty() {
+                tracing::info!(
+                    model = %bedrock_model,
+                    rejected = ?rejected,
+                    "ValidationException named betas — marking unsupported and retrying"
+                );
+                for beta in &rejected {
+                    ctx.endpoint_client
+                        .mark_unsupported(&ctx.profile, beta, ProbeSource::RequestRejection)
+                        .await;
+                }
+                // Rebuild body with rejected betas removed.
+                let retry_bytes =
+                    rebuild_body_without_betas(&body_bytes, &rejected).unwrap_or_default();
+                if retry_bytes.is_empty() {
+                    // Serialization failed — bubble original error.
+                } else {
+                    let retry_result = runtime_client
+                        .invoke_model()
+                        .model_id(bedrock_model)
+                        .content_type("application/json")
+                        .accept("application/json")
+                        .body(Blob::new(retry_bytes))
+                        .send()
+                        .await;
+                    // Return retry result regardless; if it also fails we bubble that.
+                    // Per spec: "if retry fails (any reason) → bubble the original Bedrock error".
+                    // We actually bubble the retry error here so the client gets a fresh message.
+                    // On success the unknown betas are NOT re-marked (we only had ctx.forwarded);
+                    // the remaining betas will be marked by the opportunistic path on Ok below.
+                    match retry_result {
+                        Ok(output) => {
+                            // Retry succeeded — opportunistically learn remaining unknown betas.
+                            let remaining_unknown: Vec<String> = ctx
+                                .unknown_betas
+                                .iter()
+                                .filter(|b| !rejected.contains(b))
+                                .cloned()
+                                .collect();
+                            for beta in &remaining_unknown {
+                                ctx.endpoint_client
+                                    .mark_supported(&ctx.profile, beta, ProbeSource::RequestSuccess)
+                                    .await;
+                            }
+                            // Process the successful retry response.
+                            let response_bytes = output.body().as_ref();
+                            return match serde_json::from_slice::<Value>(response_bytes) {
+                                Ok(resp) => {
+                                    let (input, output_tok, cache_read, cache_write, stop_reason) =
+                                        extract_response_metadata(&resp);
+                                    state.metrics.record_tokens(
+                                        original_model,
+                                        input as u64,
+                                        output_tok as u64,
+                                        cache_read as u64,
+                                        cache_write as u64,
+                                    );
+                                    state.metrics.record_tools(&req_info.tool_names);
+                                    state
+                                        .spend_tracker
+                                        .record(RequestLogEntry {
+                                            key_id: identity.key_id,
+                                            user_identity: identity.user_identity,
+                                            request_id,
+                                            model: original_model.to_string(),
+                                            streaming: false,
+                                            duration_ms: start.elapsed().as_millis() as i32,
+                                            input_tokens: input,
+                                            output_tokens: output_tok,
+                                            cache_read_tokens: cache_read,
+                                            cache_write_tokens: cache_write,
+                                            stop_reason,
+                                            tool_count: req_info.tool_count,
+                                            tool_names: req_info.tool_names,
+                                            turn_count: req_info.turn_count,
+                                            thinking_enabled: req_info.thinking_enabled,
+                                            has_system_prompt: req_info.has_system_prompt,
+                                            session_id: req_info.session_id,
+                                            project_key: req_info.project_key,
+                                            tool_errors: req_info.tool_errors,
+                                            has_correction: req_info.has_correction,
+                                            content_block_types: req_info.content_block_types,
+                                            system_prompt_hash: req_info.system_prompt_hash,
+                                            detection_flags: req_info.detection_flags,
+                                            endpoint_id,
+                                        })
+                                        .await;
+                                    let normalized = response::normalize_response(
+                                        resp,
+                                        original_model,
+                                        Some(&state.model_cache),
+                                    );
+                                    Json(normalized).into_response()
+                                }
+                                Err(e) => {
+                                    tracing::error!(%e, "Failed to parse Bedrock retry response");
+                                    error_response(
+                                        StatusCode::BAD_GATEWAY,
+                                        "api_error",
+                                        "Failed to parse upstream response",
+                                    )
+                                }
+                            };
+                        }
+                        Err(_) => {
+                            // Retry failed — fall through and bubble the original error.
+                        }
+                    }
+                }
+            }
+        }
+        result
+    } else {
+        result
+    };
+
     match result {
         Ok(output) => {
+            // Opportunistic learning: betas whose cache state was None are now known to work.
+            if let Some(ref ctx) = beta_ctx {
+                for beta in &ctx.unknown_betas {
+                    ctx.endpoint_client
+                        .mark_supported(&ctx.profile, beta, ProbeSource::RequestSuccess)
+                        .await;
+                }
+            }
+
             let response_bytes = output.body().as_ref();
             match serde_json::from_slice::<Value>(response_bytes) {
                 Ok(resp) => {
@@ -1199,6 +1386,24 @@ async fn handle_non_streaming(
     }
 }
 
+/// Strip the given `rejected_betas` from the `anthropic_beta` array in `body_bytes`.
+///
+/// Returns the re-serialized bytes, or `None` if the body can't be parsed.
+fn rebuild_body_without_betas(body_bytes: &[u8], rejected: &[String]) -> Option<Vec<u8>> {
+    let mut body: Value = serde_json::from_slice(body_bytes).ok()?;
+    if let Some(arr) = body
+        .get_mut("anthropic_beta")
+        .and_then(|v| v.as_array_mut())
+    {
+        arr.retain(|v| {
+            v.as_str()
+                .map(|s| !rejected.iter().any(|r| r == s))
+                .unwrap_or(true)
+        });
+    }
+    serde_json::to_vec(&body).ok()
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_streaming(
     state: &GatewayState,
@@ -1211,17 +1416,89 @@ async fn handle_streaming(
     req_info: RequestInfo,
     start: Instant,
     endpoint_id: Option<Uuid>,
+    beta_ctx: Option<BetaRetryContext>,
 ) -> Response {
     let result = runtime_client
         .invoke_model_with_response_stream()
         .model_id(bedrock_model)
         .content_type("application/json")
-        .body(Blob::new(body_bytes))
+        .body(Blob::new(body_bytes.clone()))
         .send()
         .await;
 
+    // Check for ValidationException naming a known beta — retry once with those betas stripped.
+    let (result, beta_ctx) = if let Err(ref e) = result {
+        use aws_sdk_bedrockruntime::error::SdkError;
+        let is_ve = matches!(
+            e,
+            SdkError::ServiceError(svc) if svc.err().is_validation_exception()
+        );
+        if is_ve {
+            if let Some(ref ctx) = beta_ctx {
+                let err_str = format!("{e:?}");
+                let rejected = beta_filter::parse_rejected_betas(&err_str, &ctx.forwarded_betas);
+                if !rejected.is_empty() {
+                    tracing::info!(
+                        model = %bedrock_model,
+                        rejected = ?rejected,
+                        "ValidationException named betas (stream) — marking unsupported and retrying"
+                    );
+                    for beta in &rejected {
+                        ctx.endpoint_client
+                            .mark_unsupported(&ctx.profile, beta, ProbeSource::RequestRejection)
+                            .await;
+                    }
+                    let retry_bytes =
+                        rebuild_body_without_betas(&body_bytes, &rejected).unwrap_or_default();
+                    if !retry_bytes.is_empty() {
+                        let retry_result = runtime_client
+                            .invoke_model_with_response_stream()
+                            .model_id(bedrock_model)
+                            .content_type("application/json")
+                            .body(Blob::new(retry_bytes))
+                            .send()
+                            .await;
+                        // Build an updated ctx with the rejected betas removed from unknown_betas
+                        let remaining_ctx = BetaRetryContext {
+                            endpoint_client: Arc::clone(&ctx.endpoint_client),
+                            profile: ctx.profile.clone(),
+                            unknown_betas: ctx
+                                .unknown_betas
+                                .iter()
+                                .filter(|b| !rejected.contains(b))
+                                .cloned()
+                                .collect(),
+                            forwarded_betas: ctx.forwarded_betas.clone(),
+                        };
+                        (retry_result, Some(remaining_ctx))
+                    } else {
+                        (result, beta_ctx)
+                    }
+                } else {
+                    (result, beta_ctx)
+                }
+            } else {
+                (result, beta_ctx)
+            }
+        } else {
+            (result, beta_ctx)
+        }
+    } else {
+        (result, beta_ctx)
+    };
+
     match result {
         Ok(output) => {
+            // Opportunistic learning: Bedrock accepted the request, so unknown betas are now known
+            // to work. Fire mark_supported before spawning the stream task.
+            if let Some(ref ctx) = beta_ctx {
+                for beta in &ctx.unknown_betas {
+                    ctx.endpoint_client
+                        .mark_supported(&ctx.profile, beta, ProbeSource::RequestSuccess)
+                        .await;
+                }
+            }
+
             let original_model = original_model.to_string();
             let mut event_stream = output.body;
 
@@ -2914,6 +3191,7 @@ mod tests {
             top_p: None,
             top_k: None,
             mcp_servers: None,
+            anthropic_beta: vec![],
         }
     }
 

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use crate::auth::CachedKey;
 use crate::auth::oidc::OidcIdentity;
 use crate::db::spend::RequestLogEntry;
-use crate::endpoint::{EndpointClient, ProbeSource};
+use crate::endpoint::{EndpointClient, ProbeSource, SUFFIX_BETA_MAP};
 use crate::proxy::GatewayState;
 use crate::telemetry::Metrics;
 use crate::translate::{betas as beta_filter, models, request, response, streaming};
@@ -126,26 +126,91 @@ fn model_display_name(anthropic_id: &str) -> String {
     }
 }
 
-/// Build the JSON model list response from a slice of Anthropic model IDs.
-fn build_models_response(anthropic_ids: &[String]) -> serde_json::Value {
-    let data: Vec<serde_json::Value> = anthropic_ids
-        .iter()
-        .map(|id| {
-            let display = model_display_name(id);
-            json!({
-                "id": id,
-                "display_name": display,
-                "type": "model",
-                "created_at": "2025-01-01T00:00:00Z",
-            })
-        })
-        .collect();
+/// Build the `/v1/models` JSON response, including suffix variants for models
+/// whose Bedrock profiles have a supported beta capability in the cache.
+///
+/// Parameters:
+/// - `pairs`: (anthropic_id, bedrock_profile_id) pairs, one per available profile.
+///   May contain duplicate anthropic_ids (e.g. same model on multiple profile prefixes);
+///   deduplication is applied to bare entries and to variant entries independently.
+/// - `capability_lookup`: pre-snapshotted closure. Callers `.await` the cache snapshot
+///   in async land, then pass an owned closure to this sync helper.
+///   - Some(true)  → beta supported on that profile → emit variant
+///   - Some(false) → not supported → no variant
+///   - None        → cache absent or TTL expired → no variant (bootstrap safety)
+/// - `suffix_map`: (suffix, beta_name, display_suffix) tuples. Production caller passes
+///   `crate::endpoint::SUFFIX_BETA_MAP`. Tests pass synthetic slices.
+///
+/// Output sort order: all bare entries first (alphabetic by id), then all suffix
+/// variants (alphabetic by id). first_id and last_id reflect the resulting data.
+pub(crate) fn build_models_response_with_variants(
+    pairs: &[(String, String)],
+    capability_lookup: impl Fn(&str, &str) -> Option<bool>,
+    suffix_map: &[(&str, &str, &str)],
+) -> serde_json::Value {
+    let mut bare_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut variant_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Map from variant id → display_name, populated during collection
+    let mut variant_display: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+
+    for (anthropic_id, bedrock_profile_id) in pairs {
+        // Always include the bare entry
+        bare_set.insert(anthropic_id.clone());
+
+        // Check each suffix mapping
+        for &(suffix, beta_name, display_suffix) in suffix_map {
+            if capability_lookup(bedrock_profile_id, beta_name) == Some(true) {
+                let variant_id = format!("{anthropic_id}{suffix}");
+                if !variant_set.contains(&variant_id) {
+                    let bare_display = model_display_name(anthropic_id);
+                    let variant_display_name = format!("{bare_display} ({display_suffix})");
+                    variant_display.insert(variant_id.clone(), variant_display_name);
+                    variant_set.insert(variant_id);
+                }
+            }
+        }
+    }
+
+    // Sort bare entries alphabetically
+    let mut bare_ids: Vec<String> = bare_set.into_iter().collect();
+    bare_ids.sort();
+
+    // Sort variant entries alphabetically
+    let mut variant_ids: Vec<String> = variant_set.into_iter().collect();
+    variant_ids.sort();
+
+    // Build data: bare entries first, then variant entries
+    let mut data: Vec<serde_json::Value> = Vec::new();
+
+    for id in &bare_ids {
+        let display = model_display_name(id);
+        data.push(json!({
+            "id": id,
+            "display_name": display,
+            "type": "model",
+            "created_at": "2025-01-01T00:00:00Z",
+        }));
+    }
+
+    for id in &variant_ids {
+        let display = variant_display
+            .get(id)
+            .cloned()
+            .unwrap_or_else(|| model_display_name(id));
+        data.push(json!({
+            "id": id,
+            "display_name": display,
+            "type": "model",
+            "created_at": "2025-01-01T00:00:00Z",
+        }));
+    }
 
     json!({
         "data": data,
         "has_more": false,
-        "first_id": data.first().map(|m| m["id"].as_str().unwrap_or("")),
-        "last_id": data.last().map(|m| m["id"].as_str().unwrap_or("")),
+        "first_id": data.first().and_then(|m| m["id"].as_str()),
+        "last_id": data.last().and_then(|m| m["id"].as_str()),
     })
 }
 
@@ -184,20 +249,62 @@ pub async fn list_models(State(state): State<Arc<GatewayState>>) -> Response {
             .into_response();
     }
 
-    // Map each Bedrock profile ID to Anthropic format, then deduplicate
-    let mut seen = std::collections::HashSet::new();
-    let mut anthropic_ids: Vec<String> = bedrock_ids
+    // Build (anthropic_id, bedrock_profile_id) pairs, deduplicating by bedrock_id
+    // to avoid feeding the same bedrock profile twice (from default_available_models
+    // and per-client available_models which can overlap).
+    let mut seen_bedrock: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let pairs: Vec<(String, String)> = bedrock_ids
         .iter()
+        .filter(|bedrock_id| seen_bedrock.insert((*bedrock_id).clone()))
         .map(|bedrock_id| {
-            crate::translate::models::bedrock_to_anthropic(bedrock_id, Some(&state.model_cache))
+            let anthropic_id = crate::translate::models::bedrock_to_anthropic(
+                bedrock_id,
+                Some(&state.model_cache),
+            );
+            (anthropic_id, bedrock_id.clone())
         })
-        .filter(|id| seen.insert(id.clone()))
         .collect();
 
-    // Stable sort for deterministic output
-    anthropic_ids.sort();
+    // Snapshot beta capability data from all endpoint clients.
+    // Merge across endpoints: a (profile, beta) is "supported" if ANY endpoint says so.
+    let mut supported: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::new();
+    let mut seen_cap: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::new();
 
-    let response = build_models_response(&anthropic_ids);
+    for client in &clients {
+        // For each beta in the suffix map, check all profiles this endpoint advertises.
+        let profile_ids = client.available_models.read().await.clone();
+        for profile in &profile_ids {
+            for &(_suffix, beta, _display) in SUFFIX_BETA_MAP {
+                let key = (profile.clone(), beta.to_string());
+                match client.is_beta_supported(profile, beta).await {
+                    Some(true) => {
+                        supported.insert(key.clone());
+                        seen_cap.insert(key);
+                    }
+                    Some(false) => {
+                        seen_cap.insert(key);
+                    }
+                    None => {}
+                }
+            }
+        }
+    }
+
+    // Build sync capability closure capturing the snapshots.
+    let capability_lookup = move |profile: &str, beta: &str| -> Option<bool> {
+        let key = (profile.to_string(), beta.to_string());
+        if supported.contains(&key) {
+            Some(true)
+        } else if seen_cap.contains(&key) {
+            Some(false)
+        } else {
+            None
+        }
+    };
+
+    let response = build_models_response_with_variants(&pairs, capability_lookup, SUFFIX_BETA_MAP);
 
     (StatusCode::OK, Json(response)).into_response()
 }
@@ -3720,6 +3827,580 @@ mod tests_slice4_no_hardcoded {
         assert!(
             json["last_id"].is_string(),
             "last_id must be a non-null string when data is non-empty"
+        );
+    }
+}
+
+// ── Slice 5: `/v1/models` advertises suffix variants from cache ─────────────────────────────
+//
+// These tests exercise a pure helper function that the Builder must extract:
+//
+//   `pub(crate) fn build_models_response_with_variants(
+//       pairs: &[(String, String)],           // (anthropic_id, bedrock_profile_id)
+//       capability_lookup: impl Fn(&str, &str) -> Option<bool>,  // (profile, beta) -> Option<bool>
+//       suffix_map: &[(&str, &str, &str)],    // (suffix, beta_name, display_suffix)
+//   ) -> serde_json::Value`
+//
+// Design rationale:
+//   - `capability_lookup` is SYNC (not async). The production caller pre-snapshots
+//     the async RwLock in `list_models` and hands a closure over the snapshot to
+//     this pure function. Tests can then pass a simple closure over a HashMap
+//     without any async machinery.
+//   - `suffix_map` is an explicit parameter (not a direct read of the `SUFFIX_BETA_MAP`
+//     const) so Test 8 can inject a synthetic 2-entry slice without modifying
+//     production constants.
+//   - `pairs` uses the `(anthropic_id, bedrock_profile_id)` shape because the
+//     production caller already iterates bedrock_ids → anthropic mapping and needs
+//     to keep both sides for the capability lookup.
+//
+// All tests are `#[test]` (not `#[tokio::test]`) because the helper is sync.
+// Tests are tagged `offline` in their doc comments to signal they require no DB/AWS.
+#[cfg(test)]
+mod tests_t5_suffix_variants {
+    use super::*;
+    use serde_json::Value;
+    use std::collections::HashMap;
+
+    // ── helper to call the function under test ────────────────────────────────────
+
+    /// Thin wrapper so tests don't need to repeat the turbofish / type annotation
+    /// for the closure.
+    fn run(
+        pairs: &[(&str, &str)],
+        capability_lookup: impl Fn(&str, &str) -> Option<bool>,
+        suffix_map: &[(&str, &str, &str)],
+    ) -> Value {
+        let owned: Vec<(String, String)> = pairs
+            .iter()
+            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .collect();
+        build_models_response_with_variants(&owned, capability_lookup, suffix_map)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 1 [offline]: variant emitted when capability cache says Some(true)
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // Input:  one model pair; cache returns `Some(true)` for its beta.
+    // Expect: response contains BOTH the bare entry and the `[1m]` suffixed variant.
+    //         The variant's display name is "<existing> (1M context)".
+    #[test]
+    fn variants_emitted_for_supported_betas() {
+        let pairs = &[("claude-opus-4-7", "us.anthropic.claude-opus-4-7")];
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        let json = run(
+            pairs,
+            |profile, beta| {
+                if profile == "us.anthropic.claude-opus-4-7" && beta == "context-1m-2025-08-07" {
+                    Some(true)
+                } else {
+                    None
+                }
+            },
+            suffix_map,
+        );
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        let ids: Vec<&str> = data.iter().map(|m| m["id"].as_str().unwrap()).collect();
+
+        assert!(
+            ids.contains(&"claude-opus-4-7"),
+            "bare entry must be present; got ids: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"claude-opus-4-7[1m]"),
+            "[1m] variant must be emitted when cache returns Some(true); got ids: {ids:?}"
+        );
+
+        // Verify the display name of the variant.
+        let variant = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("claude-opus-4-7[1m]"))
+            .expect("[1m] variant entry must exist in data");
+
+        let display = variant["display_name"]
+            .as_str()
+            .expect("display_name must be a string");
+        assert!(
+            display.contains("1M context"),
+            "variant display_name must contain '1M context'; got: '{display}'"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 2 [offline]: no variant when cache says Some(false)
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // Input:  one model pair; cache returns `Some(false)` for its beta.
+    // Expect: only the bare entry — no `[1m]` variant.
+    #[test]
+    fn no_variants_when_unsupported() {
+        let pairs = &[("claude-opus-4-7", "us.anthropic.claude-opus-4-7")];
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        let json = run(pairs, |_profile, _beta| Some(false), suffix_map);
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        let ids: Vec<&str> = data.iter().map(|m| m["id"].as_str().unwrap()).collect();
+
+        assert!(
+            ids.contains(&"claude-opus-4-7"),
+            "bare entry must always be present; got ids: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"claude-opus-4-7[1m]"),
+            "[1m] variant must NOT be emitted when cache returns Some(false); got ids: {ids:?}"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 3 [offline]: no variant when cache is absent (None)
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // Bootstrap window safety: when the cache has no entry for a (profile, beta)
+    // pair, the helper must NOT emit a suffix variant. False positives are worse
+    // than false negatives here — advertising a model variant that doesn't work
+    // would break the user's workflow silently.
+    //
+    // Input:  one model pair; cache returns `None` for everything.
+    // Expect: only the bare entry.
+    #[test]
+    fn no_variants_when_cache_absent() {
+        let pairs = &[("claude-opus-4-7", "us.anthropic.claude-opus-4-7")];
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        let json = run(
+            pairs,
+            |_profile, _beta| None, // cache empty — bootstrap window
+            suffix_map,
+        );
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        let ids: Vec<&str> = data.iter().map(|m| m["id"].as_str().unwrap()).collect();
+
+        assert_eq!(
+            ids.len(),
+            1,
+            "only the bare entry must appear when cache is absent (bootstrap window); got ids: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"claude-opus-4-7"),
+            "bare entry must be present; got ids: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"claude-opus-4-7[1m]"),
+            "[1m] variant must NOT be emitted when cache returns None; got ids: {ids:?}"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 4 [offline]: variants emitted per-model independently
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // Input:  two models — opus (1M-capable) and haiku (not capable).
+    // Expect: 3 entries total: opus bare, opus[1m], haiku bare (no haiku[1m]).
+    #[test]
+    fn variants_for_subset_of_models() {
+        let pairs = &[
+            ("claude-opus-4-7", "us.anthropic.claude-opus-4-7"),
+            (
+                "claude-haiku-4-5-20251001",
+                "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            ),
+        ];
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        // Build a lookup map: opus → true, haiku → false
+        let mut cap_map: HashMap<(&str, &str), Option<bool>> = HashMap::new();
+        cap_map.insert(
+            ("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07"),
+            Some(true),
+        );
+        cap_map.insert(
+            (
+                "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+                "context-1m-2025-08-07",
+            ),
+            Some(false),
+        );
+
+        let json = run(
+            pairs,
+            |profile, beta| cap_map.get(&(profile, beta)).copied().unwrap_or(None),
+            suffix_map,
+        );
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        let ids: Vec<&str> = data.iter().map(|m| m["id"].as_str().unwrap()).collect();
+
+        assert_eq!(
+            ids.len(),
+            3,
+            "expected 3 entries: opus bare + opus[1m] + haiku bare; got ids: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"claude-opus-4-7"),
+            "opus bare must be present"
+        );
+        assert!(
+            ids.contains(&"claude-opus-4-7[1m]"),
+            "opus [1m] variant must be present"
+        );
+        assert!(
+            ids.contains(&"claude-haiku-4-5-20251001"),
+            "haiku bare must be present"
+        );
+        assert!(
+            !ids.contains(&"claude-haiku-4-5-20251001[1m]"),
+            "haiku [1m] variant must NOT be present (cache says false)"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 5 [offline]: bare entries appear before any suffix variants
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // Sort contract: all bare entries must appear before any `[...]` suffix
+    // variant, and within each group entries must be alphabetically ordered.
+    //
+    // Input:  two 1M-capable models.
+    // Expect: sorted as [claude-haiku-4-5-..., claude-opus-4-7, claude-haiku-4-5-...[1m], claude-opus-4-7[1m]]
+    #[test]
+    fn bare_entries_first_then_variants() {
+        let pairs = &[
+            ("claude-opus-4-7", "us.anthropic.claude-opus-4-7"),
+            (
+                "claude-haiku-4-5-20251001",
+                "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            ),
+        ];
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        let json = run(
+            pairs,
+            |_profile, _beta| Some(true), // all models are 1M-capable
+            suffix_map,
+        );
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        let ids: Vec<&str> = data.iter().map(|m| m["id"].as_str().unwrap()).collect();
+
+        // All bare entries must appear before any variant entry
+        let first_variant_pos = ids.iter().position(|id| id.contains('['));
+        let last_bare_pos = ids.iter().rposition(|id| !id.contains('['));
+
+        assert!(
+            first_variant_pos.is_some(),
+            "at least one variant must be present in output; got ids: {ids:?}"
+        );
+        assert!(
+            last_bare_pos.is_some(),
+            "at least one bare entry must be present in output; got ids: {ids:?}"
+        );
+
+        assert!(
+            last_bare_pos.unwrap() < first_variant_pos.unwrap(),
+            "all bare entries must precede all suffix variant entries in the sorted output; \
+             got ordering: {ids:?}"
+        );
+
+        // Alphabetic within bare group
+        let bare_ids: Vec<&str> = ids.iter().copied().filter(|id| !id.contains('[')).collect();
+        let mut sorted_bare = bare_ids.clone();
+        sorted_bare.sort_unstable();
+        assert_eq!(
+            bare_ids, sorted_bare,
+            "bare entries must be alphabetically sorted within their group; got: {bare_ids:?}"
+        );
+
+        // Alphabetic within variant group
+        let variant_ids: Vec<&str> = ids.iter().copied().filter(|id| id.contains('[')).collect();
+        let mut sorted_variants = variant_ids.clone();
+        sorted_variants.sort_unstable();
+        assert_eq!(
+            variant_ids, sorted_variants,
+            "suffix variant entries must be alphabetically sorted within their group; got: {variant_ids:?}"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 6 [offline]: variant display name uses display_suffix from suffix_map
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // The display name of a variant entry must be "<existing display> (display_suffix)"
+    // where `display_suffix` comes from the third tuple element of the `suffix_map`
+    // parameter — it is NOT hardcoded as "1M context" in the helper body.
+    //
+    // This test uses a synthetic suffix_map entry with a distinct display label to
+    // prove the label flows from the map, not from a hardcoded string.
+    #[test]
+    fn display_name_includes_capability_suffix() {
+        let pairs = &[("claude-opus-4-7", "us.anthropic.claude-opus-4-7")];
+
+        // Use a recognisably different display suffix to confirm it comes from the map.
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        let json = run(pairs, |_profile, _beta| Some(true), suffix_map);
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        let variant = data
+            .iter()
+            .find(|m| m["id"].as_str() == Some("claude-opus-4-7[1m]"))
+            .expect("[1m] variant entry must be present");
+
+        let display = variant["display_name"]
+            .as_str()
+            .expect("display_name must be a string");
+
+        // Bare display name for claude-opus-4-7 (from model_display_name)
+        let bare_display = model_display_name("claude-opus-4-7");
+
+        let expected = format!("{} (1M context)", bare_display);
+        assert_eq!(
+            display, expected,
+            "variant display_name must be '<base display> (display_suffix)'; got: '{display}'"
+        );
+
+        // Now confirm the label flows from suffix_map by using a different map entry.
+        let custom_suffix_map: &[(&str, &str, &str)] =
+            &[("[1m]", "context-1m-2025-08-07", "Extended Context")];
+
+        let json2 = run(pairs, |_profile, _beta| Some(true), custom_suffix_map);
+
+        let data2 = json2["data"].as_array().unwrap();
+        let variant2 = data2
+            .iter()
+            .find(|m| m["id"].as_str() == Some("claude-opus-4-7[1m]"))
+            .expect("[1m] variant must be present with custom suffix map");
+
+        let display2 = variant2["display_name"].as_str().unwrap();
+        let expected2 = format!("{} (Extended Context)", bare_display);
+        assert_eq!(
+            display2, expected2,
+            "variant display_name must use the display_suffix from the suffix_map parameter, \
+             not a hardcoded string; got: '{display2}'"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 7 [offline]: same Anthropic ID from multiple profiles → no duplicates
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // Mirrors the existing `seen.insert(id.clone())` dedup logic.
+    // Input: the same Anthropic model backed by two different Bedrock profile IDs
+    //        (e.g. us. and global. prefixes). Both profiles say Some(true).
+    // Expect: exactly ONE bare entry and ONE [1m] variant — deduplicated by Anthropic ID.
+    #[test]
+    fn data_has_no_duplicates_when_same_anthropic_id_from_multiple_profiles() {
+        let pairs = &[
+            ("claude-opus-4-7", "us.anthropic.claude-opus-4-7"),
+            ("claude-opus-4-7", "global.anthropic.claude-opus-4-7"),
+        ];
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        let json = run(
+            pairs,
+            |_profile, _beta| Some(true), // both profiles say supported
+            suffix_map,
+        );
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        let ids: Vec<&str> = data.iter().map(|m| m["id"].as_str().unwrap()).collect();
+
+        let bare_count = ids.iter().filter(|&&id| id == "claude-opus-4-7").count();
+        let variant_count = ids
+            .iter()
+            .filter(|&&id| id == "claude-opus-4-7[1m]")
+            .count();
+
+        assert_eq!(
+            bare_count, 1,
+            "claude-opus-4-7 bare entry must appear exactly once even when backed by multiple profiles; \
+             got {bare_count} copies; ids: {ids:?}"
+        );
+        assert_eq!(
+            variant_count, 1,
+            "claude-opus-4-7[1m] variant must appear exactly once even when multiple profiles support it; \
+             got {variant_count} copies; ids: {ids:?}"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 8 [offline]: multiple suffix_map entries emit independent variants
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // Confirms that `suffix_map` is the single source of truth for which variants
+    // to advertise. By injecting a two-entry synthetic slice we verify both
+    // suffix entries are independently processed.
+    //
+    // NOTE: This test is only possible because the helper accepts `suffix_map` as
+    // an explicit parameter rather than reading `crate::endpoint::SUFFIX_BETA_MAP`
+    // directly. If the Builder implements the helper to read the const directly,
+    // this test cannot be written without modifying the const — which would be
+    // a design problem. The parameter approach is the correct design.
+    #[test]
+    fn multiple_suffix_map_entries_emit_independent_variants() {
+        let pairs = &[("claude-opus-4-7", "us.anthropic.claude-opus-4-7")];
+
+        // Synthetic 2-entry suffix map — NOT production constants.
+        let synthetic_suffix_map: &[(&str, &str, &str)] = &[
+            ("[1m]", "context-1m-2025-08-07", "1M context"),
+            ("[2m]", "context-2m-2025-99-99", "2M context"), // hypothetical future beta
+        ];
+
+        // Both betas supported
+        let json = run(pairs, |_profile, _beta| Some(true), synthetic_suffix_map);
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        let ids: Vec<&str> = data.iter().map(|m| m["id"].as_str().unwrap()).collect();
+
+        assert!(
+            ids.contains(&"claude-opus-4-7"),
+            "bare entry must be present"
+        );
+        assert!(
+            ids.contains(&"claude-opus-4-7[1m]"),
+            "[1m] variant must be emitted for first suffix map entry; got ids: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"claude-opus-4-7[2m]"),
+            "[2m] variant must be emitted for second suffix map entry; got ids: {ids:?}"
+        );
+
+        // Only first beta supported → only [1m] variant, not [2m]
+        let json2 = run(
+            pairs,
+            |_profile, beta| {
+                if beta == "context-1m-2025-08-07" {
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            },
+            synthetic_suffix_map,
+        );
+
+        let data2 = json2["data"].as_array().unwrap();
+        let ids2: Vec<&str> = data2.iter().map(|m| m["id"].as_str().unwrap()).collect();
+        assert!(
+            ids2.contains(&"claude-opus-4-7[1m]"),
+            "[1m] must appear when its beta is true"
+        );
+        assert!(
+            !ids2.contains(&"claude-opus-4-7[2m]"),
+            "[2m] must NOT appear when its beta is false; got ids: {ids2:?}"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 9 [offline]: first_id and last_id reflect emitted data after sort
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // The response envelope fields `first_id` and `last_id` must equal
+    // `data[0].id` and `data[data.len()-1].id` after variant emission and sort.
+    #[test]
+    fn first_id_and_last_id_reflect_emitted_data() {
+        let pairs = &[
+            ("claude-opus-4-7", "us.anthropic.claude-opus-4-7"),
+            (
+                "claude-haiku-4-5-20251001",
+                "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            ),
+        ];
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        // Opus is 1M-capable; haiku is not.
+        let json = run(
+            pairs,
+            |profile, beta| {
+                if profile == "us.anthropic.claude-opus-4-7" && beta == "context-1m-2025-08-07" {
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            },
+            suffix_map,
+        );
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        assert!(
+            !data.is_empty(),
+            "data must be non-empty for this test to be meaningful"
+        );
+
+        let first_id_in_data = data.first().unwrap()["id"].as_str().unwrap();
+        let last_id_in_data = data.last().unwrap()["id"].as_str().unwrap();
+
+        assert_eq!(
+            json["first_id"].as_str(),
+            Some(first_id_in_data),
+            "first_id in envelope must equal the id of the first entry in data array; \
+             envelope says '{:?}', data[0].id is '{first_id_in_data}'",
+            json["first_id"]
+        );
+        assert_eq!(
+            json["last_id"].as_str(),
+            Some(last_id_in_data),
+            "last_id in envelope must equal the id of the last entry in data array; \
+             envelope says '{:?}', data[last].id is '{last_id_in_data}'",
+            json["last_id"]
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 10 [offline]: empty input returns empty response
+    // ─────────────────────────────────────────────────────────────────────────────
+    //
+    // When `pairs` is empty (bootstrap window or no endpoints configured),
+    // the helper must return the same empty-list envelope as before.
+    // This verifies that the variant-emission logic does not break the empty case.
+    #[test]
+    fn empty_input_returns_empty_response() {
+        let pairs: &[(&str, &str)] = &[];
+        let suffix_map: &[(&str, &str, &str)] = &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+        let json = run(pairs, |_profile, _beta| Some(true), suffix_map);
+
+        let data = json["data"]
+            .as_array()
+            .expect("response must have 'data' array");
+        assert!(
+            data.is_empty(),
+            "empty input must produce empty 'data' array; got: {data:?}"
+        );
+
+        assert_eq!(
+            json["has_more"], false,
+            "has_more must be false for empty response"
+        );
+        assert!(
+            json["first_id"].is_null(),
+            "first_id must be null for empty response; got: {:?}",
+            json["first_id"]
+        );
+        assert!(
+            json["last_id"].is_null(),
+            "last_id must be null for empty response; got: {:?}",
+            json["last_id"]
         );
     }
 }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -872,6 +872,7 @@ pub async fn messages(
             ws_ctx,
             endpoint_id,
             &websearch_mode,
+            beta_retry_ctx,
         )
         .await
     } else if is_streaming {
@@ -1800,6 +1801,7 @@ async fn handle_with_web_search(
     ws_ctx: &websearch::WebSearchContext,
     endpoint_id: Option<Uuid>,
     websearch_mode: &str,
+    beta_retry_ctx: Option<BetaRetryContext>,
 ) -> Response {
     // Resolve search provider: "global" mode uses admin-configured global provider,
     // otherwise fall back to per-user provider (which defaults to DuckDuckGo).
@@ -1858,9 +1860,102 @@ async fn handle_with_web_search(
             .model_id(bedrock_model)
             .content_type("application/json")
             .accept("application/json")
-            .body(Blob::new(body_bytes))
+            .body(Blob::new(body_bytes.clone()))
             .send()
             .await;
+
+        // On the first iteration, apply the beta retry pattern:
+        // if Bedrock rejects with a ValidationException naming a beta, strip
+        // that beta, mark it unsupported, and retry once.  On success, mark
+        // any unknown betas as supported.
+        let result = if loop_iteration == 1 {
+            if let Err(ref e) = result {
+                use aws_sdk_bedrockruntime::error::SdkError;
+                let is_ve = matches!(
+                    e,
+                    SdkError::ServiceError(svc) if svc.err().is_validation_exception()
+                );
+                if is_ve {
+                    if let Some(ref ctx) = beta_retry_ctx {
+                        let err_str = format!("{e:?}");
+                        let rejected =
+                            beta_filter::parse_rejected_betas(&err_str, &ctx.forwarded_betas);
+                        if !rejected.is_empty() {
+                            tracing::info!(
+                                model = %bedrock_model,
+                                rejected = ?rejected,
+                                "ValidationException named betas (web-search path) — marking unsupported and retrying"
+                            );
+                            for beta in &rejected {
+                                ctx.endpoint_client
+                                    .mark_unsupported(
+                                        &ctx.profile,
+                                        beta,
+                                        ProbeSource::RequestRejection,
+                                    )
+                                    .await;
+                            }
+                            // Strip the rejected betas from bedrock_body for this and
+                            // all subsequent iterations in the loop.
+                            bedrock_body
+                                .anthropic_beta
+                                .retain(|b| !rejected.iter().any(|r| r == b));
+                            let retry_bytes = rebuild_body_without_betas(&body_bytes, &rejected)
+                                .unwrap_or_default();
+                            if !retry_bytes.is_empty() {
+                                let retry_result = runtime_client
+                                    .invoke_model()
+                                    .model_id(bedrock_model)
+                                    .content_type("application/json")
+                                    .accept("application/json")
+                                    .body(Blob::new(retry_bytes))
+                                    .send()
+                                    .await;
+                                if retry_result.is_ok() {
+                                    // Opportunistic learning: remaining unknown betas work.
+                                    let remaining_unknown: Vec<String> = ctx
+                                        .unknown_betas
+                                        .iter()
+                                        .filter(|b| !rejected.contains(b))
+                                        .cloned()
+                                        .collect();
+                                    for beta in &remaining_unknown {
+                                        ctx.endpoint_client
+                                            .mark_supported(
+                                                &ctx.profile,
+                                                beta,
+                                                ProbeSource::RequestSuccess,
+                                            )
+                                            .await;
+                                    }
+                                }
+                                retry_result
+                            } else {
+                                result
+                            }
+                        } else {
+                            result
+                        }
+                    } else {
+                        result
+                    }
+                } else {
+                    result
+                }
+            } else {
+                // First iteration succeeded — opportunistic learning for unknown betas.
+                if let Some(ref ctx) = beta_retry_ctx {
+                    for beta in &ctx.unknown_betas {
+                        ctx.endpoint_client
+                            .mark_supported(&ctx.profile, beta, ProbeSource::RequestSuccess)
+                            .await;
+                    }
+                }
+                result
+            }
+        } else {
+            result
+        };
 
         let resp_value = match result {
             Ok(output) => match serde_json::from_slice::<Value>(output.body().as_ref()) {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -150,6 +150,13 @@ pub fn router(state: Arc<GatewayState>) -> Router {
             "/admin/endpoints/{endpoint_id}/default",
             put(admin::set_default_endpoint),
         )
+        // Admin API — Beta capability overrides
+        .route("/admin/beta-overrides", get(admin::list_beta_overrides))
+        .route("/admin/beta-overrides", post(admin::upsert_beta_override))
+        .route(
+            "/admin/beta-overrides/{endpoint_id}/{profile_id}/{beta_name}",
+            delete(admin::delete_beta_override),
+        )
         // Admin API — Bedrock
         .route("/admin/bedrock/validate", post(admin::validate_bedrock))
         .route("/admin/bedrock/quotas", get(admin::get_bedrock_quotas))

--- a/src/api/proxy_login.sh
+++ b/src/api/proxy_login.sh
@@ -39,6 +39,12 @@ TOKEN_REFRESH_MARGIN=60
 # Don't retry browser flow within this window after a failure
 FAIL_COOLDOWN_SECS=30
 
+# Signal to Claude Code that it should use the gateway's /v1/models endpoint
+# rather than its hardcoded model list. Set here (before any early-return) so
+# every exit path — cached token, fresh login, lock-wait — exports the flag.
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+echo "[ccag] gateway model discovery enabled (CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1)" >&2
+
 # Decode JWT payload and extract a field (no external deps)
 jwt_field() {
     local token="$1" field="$2"

--- a/src/db/beta_overrides.rs
+++ b/src/db/beta_overrides.rs
@@ -39,7 +39,10 @@ pub async fn list_all(pool: &PgPool) -> Result<Vec<BetaOverride>, sqlx::Error> {
 }
 
 /// List all beta overrides for a specific endpoint.
-pub async fn list_for_endpoint(pool: &PgPool, endpoint_id: Uuid) -> Result<Vec<BetaOverride>, sqlx::Error> {
+pub async fn list_for_endpoint(
+    pool: &PgPool,
+    endpoint_id: Uuid,
+) -> Result<Vec<BetaOverride>, sqlx::Error> {
     sqlx::query_as::<_, BetaOverride>(
         "SELECT endpoint_id, profile_id, beta_name, supported, set_at, set_by, reason \
          FROM beta_overrides \

--- a/src/db/beta_overrides.rs
+++ b/src/db/beta_overrides.rs
@@ -1,0 +1,93 @@
+use sqlx::{FromRow, PgPool, Row};
+use uuid::Uuid;
+
+/// A single admin-managed capability override row.
+#[derive(Debug, Clone)]
+pub struct BetaOverride {
+    pub endpoint_id: Uuid,
+    pub profile_id: String,
+    pub beta_name: String,
+    pub supported: bool,
+    pub set_at: chrono::DateTime<chrono::Utc>,
+    pub set_by: String,
+    pub reason: Option<String>,
+}
+
+impl<'r> FromRow<'r, sqlx::postgres::PgRow> for BetaOverride {
+    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
+        Ok(BetaOverride {
+            endpoint_id: row.try_get("endpoint_id")?,
+            profile_id: row.try_get("profile_id")?,
+            beta_name: row.try_get("beta_name")?,
+            supported: row.try_get("supported")?,
+            set_at: row.try_get("set_at")?,
+            set_by: row.try_get("set_by")?,
+            reason: row.try_get("reason")?,
+        })
+    }
+}
+
+/// List all beta overrides across all endpoints.
+pub async fn list_all(pool: &PgPool) -> Result<Vec<BetaOverride>, sqlx::Error> {
+    sqlx::query_as::<_, BetaOverride>(
+        "SELECT endpoint_id, profile_id, beta_name, supported, set_at, set_by, reason \
+         FROM beta_overrides \
+         ORDER BY endpoint_id, profile_id, beta_name",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// List all beta overrides for a specific endpoint.
+pub async fn list_for_endpoint(pool: &PgPool, endpoint_id: Uuid) -> Result<Vec<BetaOverride>, sqlx::Error> {
+    sqlx::query_as::<_, BetaOverride>(
+        "SELECT endpoint_id, profile_id, beta_name, supported, set_at, set_by, reason \
+         FROM beta_overrides \
+         WHERE endpoint_id = $1 \
+         ORDER BY profile_id, beta_name",
+    )
+    .bind(endpoint_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// Insert or update a beta override row (upsert on primary key).
+pub async fn upsert(pool: &PgPool, ovr: &BetaOverride) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO beta_overrides (endpoint_id, profile_id, beta_name, supported, set_at, set_by, reason) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7) \
+         ON CONFLICT (endpoint_id, profile_id, beta_name) \
+         DO UPDATE SET supported = EXCLUDED.supported, \
+                       set_at = EXCLUDED.set_at, \
+                       set_by = EXCLUDED.set_by, \
+                       reason = EXCLUDED.reason",
+    )
+    .bind(ovr.endpoint_id)
+    .bind(&ovr.profile_id)
+    .bind(&ovr.beta_name)
+    .bind(ovr.supported)
+    .bind(ovr.set_at)
+    .bind(&ovr.set_by)
+    .bind(&ovr.reason)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Delete a beta override row. Returns the number of rows deleted (0 or 1).
+pub async fn delete(
+    pool: &PgPool,
+    endpoint_id: Uuid,
+    profile_id: &str,
+    beta_name: &str,
+) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        "DELETE FROM beta_overrides WHERE endpoint_id = $1 AND profile_id = $2 AND beta_name = $3",
+    )
+    .bind(endpoint_id)
+    .bind(profile_id)
+    .bind(beta_name)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub mod beta_overrides;
 pub mod budget;
 pub mod endpoints;
 pub mod idp;

--- a/src/detection/corrections.rs
+++ b/src/detection/corrections.rs
@@ -231,6 +231,7 @@ mod tests {
             top_p: None,
             top_k: None,
             mcp_servers: None,
+            anthropic_beta: vec![],
         }
     }
 

--- a/src/detection/dangerous.rs
+++ b/src/detection/dangerous.rs
@@ -206,6 +206,7 @@ mod tests {
             top_p: None,
             top_k: None,
             mcp_servers: None,
+            anthropic_beta: vec![],
         }
     }
 

--- a/src/detection/discovery.rs
+++ b/src/detection/discovery.rs
@@ -154,6 +154,7 @@ mod tests {
             top_p: None,
             top_k: None,
             mcp_servers: None,
+            anthropic_beta: vec![],
         }
     }
 

--- a/src/detection/mod.rs
+++ b/src/detection/mod.rs
@@ -57,6 +57,7 @@ mod tests {
             top_p: None,
             top_k: None,
             mcp_servers: None,
+            anthropic_beta: vec![],
         }
     }
 

--- a/src/detection/secrets.rs
+++ b/src/detection/secrets.rs
@@ -224,6 +224,7 @@ mod tests {
             top_p: None,
             top_k: None,
             mcp_servers: None,
+            anthropic_beta: vec![],
         }
     }
 

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicUsize, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -9,6 +9,39 @@ use uuid::Uuid;
 use crate::db::schema::Endpoint;
 
 pub mod stats;
+
+/// TTL for non-`AdminOverride` capability cache entries.
+pub const CAPABILITY_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Map from model-ID suffix to `(suffix, beta_name, display_label)`.
+///
+/// Used by:
+/// - Health-loop seed probing (iterates beta_name across every available profile).
+/// - `/v1/models` advertising (emits a suffixed variant for every `Some(true)` cache entry).
+pub const SUFFIX_BETA_MAP: &[(&str, &str, &str)] =
+    &[("[1m]", "context-1m-2025-08-07", "1M context")];
+
+/// Who set a capability cache entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeSource {
+    /// Written by the health-loop seed probe.
+    SeedProbe,
+    /// Written opportunistically when a real request succeeds with this beta.
+    RequestSuccess,
+    /// Written when Bedrock returns a ValidationException naming the beta.
+    RequestRejection,
+    /// Written by an operator via admin API / CLI. Ignores TTL and is never
+    /// overwritten by automatic probing.
+    AdminOverride,
+}
+
+/// One entry in the per-`(profile, beta)` capability cache.
+#[derive(Debug, Clone)]
+pub struct CapabilityEntry {
+    pub supported: bool,
+    pub learned_at: Instant,
+    pub source: ProbeSource,
+}
 
 /// A Bedrock client for a specific endpoint (account/region).
 pub struct EndpointClient {
@@ -21,6 +54,14 @@ pub struct EndpointClient {
     /// Bedrock inference profile IDs available on this endpoint (e.g. `us.anthropic.claude-opus-4-7`).
     /// Populated by the health check loop; empty until the first successful tick.
     pub available_models: Arc<RwLock<Vec<String>>>,
+    /// Per-`(profile_id, beta_name)` capability cache.
+    ///
+    /// Key:   `(profile_id, beta_name)` — e.g. `("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")`.
+    /// Value: `CapabilityEntry` — most recent probe outcome with TTL and source.
+    ///
+    /// `AdminOverride` entries ignore TTL and are never overwritten by automatic probing.
+    /// Non-override entries expire after `CAPABILITY_TTL` (24 h).
+    pub beta_capabilities: Arc<RwLock<HashMap<(String, String), CapabilityEntry>>>,
 }
 
 impl EndpointClient {
@@ -33,6 +74,165 @@ impl EndpointClient {
     pub async fn supports_model(&self, bedrock_model_id: &str) -> bool {
         let models = self.available_models.read().await;
         models.iter().any(|m| m.ends_with(bedrock_model_id))
+    }
+
+    /// Query the beta capability cache for `(profile, beta)`.
+    ///
+    /// Returns:
+    /// - `Some(true)` — entry exists, supported, and either `AdminOverride` or not yet expired.
+    /// - `Some(false)` — entry exists, not supported, and either `AdminOverride` or not yet expired.
+    /// - `None` — entry absent, or non-`AdminOverride` entry whose TTL has elapsed.
+    pub async fn is_beta_supported(&self, profile: &str, beta: &str) -> Option<bool> {
+        let map = self.beta_capabilities.read().await;
+        let key = (profile.to_string(), beta.to_string());
+        match map.get(&key) {
+            None => None,
+            Some(entry) => {
+                if entry.source == ProbeSource::AdminOverride {
+                    // Admin overrides never expire.
+                    Some(entry.supported)
+                } else if entry.learned_at + CAPABILITY_TTL <= Instant::now() {
+                    // Expired non-override entry — treat as absent.
+                    None
+                } else {
+                    Some(entry.supported)
+                }
+            }
+        }
+    }
+
+    /// Record that `(profile, beta)` is supported.
+    pub async fn mark_supported(&self, profile: &str, beta: &str, source: ProbeSource) {
+        let mut map = self.beta_capabilities.write().await;
+        map.insert(
+            (profile.to_string(), beta.to_string()),
+            CapabilityEntry {
+                supported: true,
+                learned_at: Instant::now(),
+                source,
+            },
+        );
+    }
+
+    /// Record that `(profile, beta)` is NOT supported.
+    pub async fn mark_unsupported(&self, profile: &str, beta: &str, source: ProbeSource) {
+        let mut map = self.beta_capabilities.write().await;
+        map.insert(
+            (profile.to_string(), beta.to_string()),
+            CapabilityEntry {
+                supported: false,
+                learned_at: Instant::now(),
+                source,
+            },
+        );
+    }
+
+    /// Return `(profile, beta)` pairs that the health loop should seed-probe.
+    ///
+    /// A pair is included when:
+    /// - No cache entry exists for it, OR
+    /// - The entry exists, is not `AdminOverride`, and its TTL has elapsed.
+    ///
+    /// `AdminOverride` entries are never re-probed; they stay until explicitly cleared.
+    pub async fn expired_seed_pairs(&self, profiles: &[String]) -> Vec<(String, String)> {
+        let map = self.beta_capabilities.read().await;
+        let now = Instant::now();
+        let mut pairs = Vec::new();
+        for profile in profiles {
+            for &(_, beta_name, _) in SUFFIX_BETA_MAP {
+                let key = (profile.clone(), beta_name.to_string());
+                match map.get(&key) {
+                    None => {
+                        // Absent — must probe.
+                        pairs.push((profile.clone(), beta_name.to_string()));
+                    }
+                    Some(entry) => {
+                        if entry.source == ProbeSource::AdminOverride {
+                            // Admin overrides are never re-probed.
+                        } else if entry.learned_at + CAPABILITY_TTL <= now {
+                            // Expired non-override — needs re-probe.
+                            pairs.push((profile.clone(), beta_name.to_string()));
+                        }
+                        // Fresh non-override — skip.
+                    }
+                }
+            }
+        }
+        pairs
+    }
+}
+
+// ── Seed-probe helpers ────────────────────────────────────────────────────────
+
+/// Outcome of a single seed-probe InvokeModel call.
+///
+/// Used by the health loop to determine how to update the beta capability cache.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// The model accepted the beta (HTTP 200).
+    Supported,
+    /// The model rejected the beta with a ValidationException that names it.
+    Unsupported,
+    /// The result was inconclusive: throttle, 5xx, network error, or a
+    /// ValidationException that does NOT name the beta. Cache is unchanged;
+    /// the pair will be re-probed on the next health-loop tick.
+    Inconclusive,
+}
+
+/// Classify a raw `InvokeModel` probe result into a `ProbeOutcome`.
+///
+/// This is a pure function — no I/O, no `async`.
+///
+/// Arguments:
+/// - `success`: `true` when `invoke_model().send().await` returned `Ok(_)`.
+/// - `is_validation_exception`: `true` when the SDK error is a `ValidationException`.
+/// - `error_message`: the full Debug-formatted SDK error string (used for beta-name matching).
+/// - `beta`: the beta name we probed (e.g. `"context-1m-2025-08-07"`).
+///
+/// Mapping:
+/// - `success == true` → `Supported`
+/// - `is_validation_exception == true` AND `error_message` contains `beta` (case-insensitive) → `Unsupported`
+/// - anything else → `Inconclusive`
+pub fn classify_probe_outcome(
+    success: bool,
+    is_validation_exception: bool,
+    error_message: &str,
+    beta: &str,
+) -> ProbeOutcome {
+    if success {
+        return ProbeOutcome::Supported;
+    }
+    if is_validation_exception && error_message.to_lowercase().contains(&beta.to_lowercase()) {
+        return ProbeOutcome::Unsupported;
+    }
+    ProbeOutcome::Inconclusive
+}
+
+/// Apply a probe outcome to an `EndpointClient`'s beta capability cache.
+///
+/// - `Supported` → `mark_supported(profile, beta, SeedProbe)`
+/// - `Unsupported` → `mark_unsupported(profile, beta, SeedProbe)`
+/// - `Inconclusive` → no-op (cache unchanged)
+pub async fn apply_probe_outcome(
+    client: &EndpointClient,
+    profile: &str,
+    beta: &str,
+    outcome: ProbeOutcome,
+) {
+    match outcome {
+        ProbeOutcome::Supported => {
+            client
+                .mark_supported(profile, beta, ProbeSource::SeedProbe)
+                .await;
+        }
+        ProbeOutcome::Unsupported => {
+            client
+                .mark_unsupported(profile, beta, ProbeSource::SeedProbe)
+                .await;
+        }
+        ProbeOutcome::Inconclusive => {
+            // No cache change — retry next tick.
+        }
     }
 }
 
@@ -145,6 +345,7 @@ impl EndpointPool {
             healthy: AtomicBool::new(false),
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
+            beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
@@ -396,6 +597,7 @@ mod tests {
             healthy: AtomicBool::new(true),
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
+            beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -1105,6 +1307,7 @@ mod tests_slice2 {
             healthy: AtomicBool::new(true),
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
+            beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -1410,6 +1613,7 @@ mod tests_slice3 {
             healthy: AtomicBool::new(true),
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
+            beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -1850,6 +2054,7 @@ mod tests_dynamic_model_slice1 {
             healthy: AtomicBool::new(true),
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(tokio::sync::RwLock::new(models)),
+            beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
         }
     }
 
@@ -2033,6 +2238,7 @@ mod tests_model_filtering_slice3 {
             healthy: AtomicBool::new(true),
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(models)),
+            beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -2342,6 +2548,7 @@ mod tests_slice5 {
             healthy: AtomicBool::new(true),
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
+            beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -2446,6 +2653,693 @@ mod tests_slice5 {
         assert_eq!(
             selected.config.id, ids[0],
             "unknown strategy must fall through to primary_fallback behavior (first healthy endpoint)"
+        );
+    }
+}
+
+// ── 1M context / capability-cache — Slice 1 contract tests ──
+//
+// These tests are written BEFORE the production types exist. They will
+// fail to compile until the Builder adds:
+//   - `pub struct CapabilityEntry { pub supported: bool, pub learned_at: Instant, pub source: ProbeSource }`
+//   - `pub enum ProbeSource { SeedProbe, RequestSuccess, RequestRejection, AdminOverride }`
+//   - `pub const CAPABILITY_TTL: Duration`
+//   - `pub const SUFFIX_BETA_MAP: &[(&str, &str, &str)]`
+//   - Field `pub beta_capabilities: Arc<RwLock<HashMap<(String, String), CapabilityEntry>>>` on `EndpointClient`
+//   - Methods `is_beta_supported`, `mark_supported`, `mark_unsupported`, `expired_seed_pairs`
+//     on `EndpointClient`
+
+#[cfg(test)]
+mod tests_1m_capability_cache {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::time::{Duration, Instant};
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    fn make_test_endpoint_for_cache(id: uuid::Uuid) -> crate::db::schema::Endpoint {
+        crate::db::schema::Endpoint {
+            id,
+            name: "test-ep".to_string(),
+            role_arn: None,
+            external_id: None,
+            inference_profile_arn: None,
+            region: "us-east-1".to_string(),
+            routing_prefix: "us".to_string(),
+            priority: 0,
+            is_default: false,
+            enabled: true,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    /// Build a minimal `EndpointClient` with no real AWS credentials.
+    /// Only the `beta_capabilities` field is exercised in these tests.
+    fn make_cache_client() -> EndpointClient {
+        let ep = make_test_endpoint_for_cache(uuid::Uuid::new_v4());
+        let runtime_client = aws_sdk_bedrockruntime::Client::from_conf(
+            aws_sdk_bedrockruntime::Config::builder()
+                .behavior_version(aws_sdk_bedrockruntime::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+        let control_client = aws_sdk_bedrock::Client::from_conf(
+            aws_sdk_bedrock::Config::builder()
+                .behavior_version(aws_sdk_bedrock::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+        let quota_client = aws_sdk_servicequotas::Client::from_conf(
+            aws_sdk_servicequotas::Config::builder()
+                .behavior_version(aws_sdk_servicequotas::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+        EndpointClient {
+            config: ep,
+            runtime_client,
+            control_client,
+            quota_cache: crate::quota::QuotaCache::new(quota_client),
+            healthy: AtomicBool::new(true),
+            last_health_check: std::sync::atomic::AtomicI64::new(0),
+            available_models: Arc::new(tokio::sync::RwLock::new(vec![])),
+            // Builder must add this field:
+            beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+        }
+    }
+
+    // ── Test 1 ─────────────────────────────────────────────────────────────
+
+    /// Querying a key that was never inserted must return `None`.
+    #[tokio::test]
+    async fn is_beta_supported_returns_none_when_absent() {
+        let client = make_cache_client();
+        let result = client
+            .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+            .await;
+        assert_eq!(
+            result, None,
+            "is_beta_supported must return None for a key that has never been inserted"
+        );
+    }
+
+    // ── Test 2 ─────────────────────────────────────────────────────────────
+
+    /// After `mark_supported`, querying the same key must return `Some(true)`.
+    #[tokio::test]
+    async fn mark_supported_then_query_returns_some_true() {
+        let client = make_cache_client();
+        client
+            .mark_supported(
+                "us.anthropic.claude-opus-4-7",
+                "context-1m-2025-08-07",
+                ProbeSource::SeedProbe,
+            )
+            .await;
+        let result = client
+            .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+            .await;
+        assert_eq!(
+            result,
+            Some(true),
+            "is_beta_supported must return Some(true) immediately after mark_supported"
+        );
+    }
+
+    // ── Test 3 ─────────────────────────────────────────────────────────────
+
+    /// Last writer wins: `mark_unsupported` after `mark_supported` on the same
+    /// key must leave the cache reflecting `supported = false`.
+    #[tokio::test]
+    async fn mark_unsupported_overrides_earlier_supported() {
+        let client = make_cache_client();
+        client
+            .mark_supported(
+                "us.anthropic.claude-sonnet-4-6",
+                "context-1m-2025-08-07",
+                ProbeSource::SeedProbe,
+            )
+            .await;
+        client
+            .mark_unsupported(
+                "us.anthropic.claude-sonnet-4-6",
+                "context-1m-2025-08-07",
+                ProbeSource::RequestRejection,
+            )
+            .await;
+        let result = client
+            .is_beta_supported("us.anthropic.claude-sonnet-4-6", "context-1m-2025-08-07")
+            .await;
+        assert_eq!(
+            result,
+            Some(false),
+            "mark_unsupported after mark_supported must yield Some(false) — last writer wins"
+        );
+    }
+
+    // ── Test 4 ─────────────────────────────────────────────────────────────
+
+    /// Last writer wins (opposite direction): `mark_supported` after
+    /// `mark_unsupported` on the same key must yield `Some(true)`.
+    #[tokio::test]
+    async fn mark_supported_overrides_earlier_unsupported() {
+        let client = make_cache_client();
+        client
+            .mark_unsupported(
+                "us.anthropic.claude-haiku-4-5",
+                "context-1m-2025-08-07",
+                ProbeSource::SeedProbe,
+            )
+            .await;
+        client
+            .mark_supported(
+                "us.anthropic.claude-haiku-4-5",
+                "context-1m-2025-08-07",
+                ProbeSource::RequestSuccess,
+            )
+            .await;
+        let result = client
+            .is_beta_supported("us.anthropic.claude-haiku-4-5", "context-1m-2025-08-07")
+            .await;
+        assert_eq!(
+            result,
+            Some(true),
+            "mark_supported after mark_unsupported must yield Some(true) — last writer wins"
+        );
+    }
+
+    // ── Test 5 ─────────────────────────────────────────────────────────────
+
+    /// A non-`AdminOverride` entry with `learned_at` older than `CAPABILITY_TTL`
+    /// must be treated as absent — `is_beta_supported` must return `None`.
+    #[tokio::test]
+    async fn non_override_entry_expires_after_ttl() {
+        let client = make_cache_client();
+        // Directly insert a backdated entry (learned_at = now - TTL - 1s)
+        {
+            let mut map = client.beta_capabilities.write().await;
+            map.insert(
+                (
+                    "us.anthropic.claude-opus-4-7".to_string(),
+                    "context-1m-2025-08-07".to_string(),
+                ),
+                CapabilityEntry {
+                    supported: true,
+                    learned_at: Instant::now() - (CAPABILITY_TTL + Duration::from_secs(1)),
+                    source: ProbeSource::SeedProbe,
+                },
+            );
+        }
+        let result = client
+            .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+            .await;
+        assert_eq!(
+            result, None,
+            "is_beta_supported must return None for a SeedProbe entry whose TTL has elapsed"
+        );
+    }
+
+    // ── Test 6 ─────────────────────────────────────────────────────────────
+
+    /// An `AdminOverride` entry must be returned even when `learned_at` is far
+    /// in the past (TTL is ignored for admin overrides).
+    #[tokio::test]
+    async fn admin_override_ignores_ttl() {
+        let client = make_cache_client();
+        // Directly insert a backdated AdminOverride entry (learned_at = now - 48h)
+        {
+            let mut map = client.beta_capabilities.write().await;
+            map.insert(
+                (
+                    "us.anthropic.claude-opus-4-7".to_string(),
+                    "context-1m-2025-08-07".to_string(),
+                ),
+                CapabilityEntry {
+                    supported: true,
+                    learned_at: Instant::now() - Duration::from_secs(48 * 3600),
+                    source: ProbeSource::AdminOverride,
+                },
+            );
+        }
+        let result = client
+            .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+            .await;
+        assert_eq!(
+            result,
+            Some(true),
+            "AdminOverride entries must not expire regardless of learned_at age"
+        );
+    }
+
+    // ── Test 7 ─────────────────────────────────────────────────────────────
+
+    /// A fresh client with no cache entries must report every
+    /// `(profile, beta)` pair from `SUFFIX_BETA_MAP` as needing a seed probe.
+    #[tokio::test]
+    async fn expired_seed_pairs_returns_absent_pairs() {
+        let client = make_cache_client();
+        let profiles = vec!["us.anthropic.claude-opus-4-7".to_string()];
+        let pairs = client.expired_seed_pairs(&profiles).await;
+
+        // SUFFIX_BETA_MAP currently has one entry: ("[1m]", "context-1m-2025-08-07", "1M context")
+        // So for one profile we expect exactly one pair.
+        assert_eq!(
+            pairs.len(),
+            1,
+            "fresh client must report one pair per profile × SUFFIX_BETA_MAP entry"
+        );
+        assert!(
+            pairs.contains(&(
+                "us.anthropic.claude-opus-4-7".to_string(),
+                "context-1m-2025-08-07".to_string()
+            )),
+            "the absent pair must be (profile, context-1m-2025-08-07)"
+        );
+    }
+
+    // ── Test 8 ─────────────────────────────────────────────────────────────
+
+    /// A pair with a fresh (non-expired) entry must NOT appear in
+    /// `expired_seed_pairs`.
+    #[tokio::test]
+    async fn expired_seed_pairs_skips_fresh_entries() {
+        let client = make_cache_client();
+        // Pre-populate with a fresh SeedProbe entry (just now)
+        client
+            .mark_supported(
+                "us.anthropic.claude-opus-4-7",
+                "context-1m-2025-08-07",
+                ProbeSource::SeedProbe,
+            )
+            .await;
+
+        let profiles = vec!["us.anthropic.claude-opus-4-7".to_string()];
+        let pairs = client.expired_seed_pairs(&profiles).await;
+
+        assert!(
+            pairs.is_empty(),
+            "expired_seed_pairs must return empty when all pairs have fresh cache entries"
+        );
+    }
+
+    // ── Test 9 ─────────────────────────────────────────────────────────────
+
+    /// A `SeedProbe` entry whose TTL has elapsed must re-appear in
+    /// `expired_seed_pairs` (re-probe is needed).
+    #[tokio::test]
+    async fn expired_seed_pairs_returns_expired_non_override() {
+        let client = make_cache_client();
+        // Directly insert a backdated SeedProbe entry
+        {
+            let mut map = client.beta_capabilities.write().await;
+            map.insert(
+                (
+                    "us.anthropic.claude-opus-4-7".to_string(),
+                    "context-1m-2025-08-07".to_string(),
+                ),
+                CapabilityEntry {
+                    supported: true,
+                    learned_at: Instant::now() - (CAPABILITY_TTL + Duration::from_secs(60)),
+                    source: ProbeSource::SeedProbe,
+                },
+            );
+        }
+
+        let profiles = vec!["us.anthropic.claude-opus-4-7".to_string()];
+        let pairs = client.expired_seed_pairs(&profiles).await;
+
+        assert_eq!(
+            pairs.len(),
+            1,
+            "expired SeedProbe entry must appear in expired_seed_pairs (re-probe needed)"
+        );
+        assert!(
+            pairs.contains(&(
+                "us.anthropic.claude-opus-4-7".to_string(),
+                "context-1m-2025-08-07".to_string()
+            )),
+            "the expired pair must be (profile, context-1m-2025-08-07)"
+        );
+    }
+
+    // ── Test 10 ────────────────────────────────────────────────────────────
+
+    /// An `AdminOverride` entry must NEVER appear in `expired_seed_pairs`,
+    /// even when its `learned_at` is far in the past. Admin overrides are set
+    /// explicitly by an operator and must not be re-probed automatically.
+    #[tokio::test]
+    async fn expired_seed_pairs_skips_admin_overrides() {
+        let client = make_cache_client();
+        // Directly insert a backdated AdminOverride entry
+        {
+            let mut map = client.beta_capabilities.write().await;
+            map.insert(
+                (
+                    "us.anthropic.claude-opus-4-7".to_string(),
+                    "context-1m-2025-08-07".to_string(),
+                ),
+                CapabilityEntry {
+                    supported: false,
+                    learned_at: Instant::now() - Duration::from_secs(48 * 3600),
+                    source: ProbeSource::AdminOverride,
+                },
+            );
+        }
+
+        let profiles = vec!["us.anthropic.claude-opus-4-7".to_string()];
+        let pairs = client.expired_seed_pairs(&profiles).await;
+
+        assert!(
+            pairs.is_empty(),
+            "AdminOverride entries must not appear in expired_seed_pairs — operators set them explicitly"
+        );
+    }
+}
+
+// ── Task 2: Health-loop seed probing — contract tests ──
+//
+// These tests are written BEFORE the production types exist. They will fail to
+// compile until the Builder adds, somewhere in `src/endpoint/mod.rs` (or a
+// sibling module `src/endpoint/probe.rs` re-exported from here):
+//
+//   pub enum ProbeOutcome { Supported, Unsupported, Inconclusive }
+//
+//   pub fn classify_probe_outcome(
+//       success: bool,
+//       is_validation_exception: bool,
+//       error_message: &str,
+//       beta: &str,
+//   ) -> ProbeOutcome { ... }
+//
+//   pub async fn apply_probe_outcome(
+//       client: &EndpointClient,
+//       profile: &str,
+//       beta: &str,
+//       outcome: ProbeOutcome,
+//   ) { ... }
+//
+// `classify_probe_outcome` is a pure function — no await, no I/O.
+// `apply_probe_outcome` calls `mark_supported` / `mark_unsupported` on the
+// client, or does nothing for `Inconclusive`.
+
+#[cfg(test)]
+mod tests_seed_probe {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+
+    // ── helper: build a minimal EndpointClient (same pattern as tests_1m_capability_cache) ──
+
+    fn make_cache_client() -> EndpointClient {
+        let ep = crate::db::schema::Endpoint {
+            id: uuid::Uuid::new_v4(),
+            name: "probe-test-ep".to_string(),
+            role_arn: None,
+            external_id: None,
+            inference_profile_arn: None,
+            region: "us-east-1".to_string(),
+            routing_prefix: "us".to_string(),
+            priority: 0,
+            is_default: false,
+            enabled: true,
+            created_at: chrono::Utc::now(),
+        };
+        let runtime_client = aws_sdk_bedrockruntime::Client::from_conf(
+            aws_sdk_bedrockruntime::Config::builder()
+                .behavior_version(aws_sdk_bedrockruntime::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+        let control_client = aws_sdk_bedrock::Client::from_conf(
+            aws_sdk_bedrock::Config::builder()
+                .behavior_version(aws_sdk_bedrock::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+        let quota_client = aws_sdk_servicequotas::Client::from_conf(
+            aws_sdk_servicequotas::Config::builder()
+                .behavior_version(aws_sdk_servicequotas::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+        EndpointClient {
+            config: ep,
+            runtime_client,
+            control_client,
+            quota_cache: crate::quota::QuotaCache::new(quota_client),
+            healthy: AtomicBool::new(true),
+            last_health_check: std::sync::atomic::AtomicI64::new(0),
+            available_models: Arc::new(tokio::sync::RwLock::new(vec![])),
+            beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+        }
+    }
+
+    // ── Tests 1-7: classify_probe_outcome — pure function, no async ──
+
+    /// Test 1: HTTP 200 (success=true) must always yield `ProbeOutcome::Supported`,
+    /// regardless of the error_message and is_validation_exception values.
+    #[test]
+    fn classify_success_returns_supported() {
+        let outcome = classify_probe_outcome(true, false, "", "context-1m-2025-08-07");
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Supported,
+            "success=true must yield ProbeOutcome::Supported"
+        );
+    }
+
+    /// Test 2: ValidationException whose message contains the exact beta name
+    /// must yield `ProbeOutcome::Unsupported`.
+    #[test]
+    fn classify_validation_with_beta_named_returns_unsupported() {
+        let outcome = classify_probe_outcome(
+            false,
+            true,
+            "ValidationException: Invalid beta flag context-1m-2025-08-07 for model X",
+            "context-1m-2025-08-07",
+        );
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Unsupported,
+            "ValidationException whose message names the beta must yield ProbeOutcome::Unsupported"
+        );
+    }
+
+    /// Test 3: Beta name matching must be case-insensitive.
+    ///
+    /// Bedrock's error format is not contractually cased; CCAG must not miss a
+    /// rejection because the SDK upcased the beta name.
+    #[test]
+    fn classify_validation_with_beta_named_case_insensitive() {
+        // Beta name in the error message is uppercased — must still match.
+        let outcome = classify_probe_outcome(
+            false,
+            true,
+            "ValidationException: Invalid beta flag CONTEXT-1M-2025-08-07 for model X",
+            "context-1m-2025-08-07",
+        );
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Unsupported,
+            "classify_probe_outcome must match the beta name case-insensitively"
+        );
+    }
+
+    /// Test 4: A ValidationException that does NOT name the beta must yield
+    /// `ProbeOutcome::Inconclusive`.
+    ///
+    /// Rationale: a validation error unrelated to the beta (e.g. quota,
+    /// malformed input, access denied) must not poison the cache as
+    /// "unsupported". We cannot distinguish the cause, so we leave the cache
+    /// unchanged and retry on the next tick.
+    #[test]
+    fn classify_validation_without_beta_named_returns_inconclusive() {
+        let outcome = classify_probe_outcome(
+            false,
+            true,
+            "ValidationException: AccessDeniedException: User is not authorized",
+            "context-1m-2025-08-07",
+        );
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Inconclusive,
+            "ValidationException that does not name the beta must yield ProbeOutcome::Inconclusive"
+        );
+    }
+
+    /// Test 5: ThrottlingException must yield `ProbeOutcome::Inconclusive`.
+    ///
+    /// Throttling tells us nothing about beta support; we must retry next tick
+    /// rather than caching a false negative.
+    #[test]
+    fn classify_throttling_returns_inconclusive() {
+        let outcome = classify_probe_outcome(
+            false,
+            false,
+            "ThrottlingException: Rate exceeded",
+            "context-1m-2025-08-07",
+        );
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Inconclusive,
+            "ThrottlingException must yield ProbeOutcome::Inconclusive"
+        );
+    }
+
+    /// Test 6: InternalServerError / 5xx must yield `ProbeOutcome::Inconclusive`.
+    ///
+    /// Transient server-side errors must not be recorded as definitive
+    /// unsupported evidence.
+    #[test]
+    fn classify_5xx_returns_inconclusive() {
+        let outcome = classify_probe_outcome(
+            false,
+            false,
+            "InternalServerError: An internal server error occurred",
+            "context-1m-2025-08-07",
+        );
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Inconclusive,
+            "InternalServerError must yield ProbeOutcome::Inconclusive"
+        );
+    }
+
+    /// Test 7: Network/dispatch failures must yield `ProbeOutcome::Inconclusive`.
+    ///
+    /// A connection reset or DNS failure is not evidence of beta support or
+    /// rejection — it means we could not reach Bedrock at all.
+    #[test]
+    fn classify_network_error_returns_inconclusive() {
+        let outcome = classify_probe_outcome(
+            false,
+            false,
+            "dispatch failure: connection reset by peer",
+            "context-1m-2025-08-07",
+        );
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Inconclusive,
+            "Network/dispatch failure must yield ProbeOutcome::Inconclusive"
+        );
+    }
+
+    // ── Tests 8-11: apply_probe_outcome — integration-shaped, drives EndpointClient ──
+
+    /// Test 8: `ProbeOutcome::Supported` must write `(supported=true, source=SeedProbe)`
+    /// into the client's beta capability cache.
+    #[tokio::test]
+    async fn probe_outcome_supported_marks_cache() {
+        let client = make_cache_client();
+        let profile = "us.anthropic.claude-opus-4-7";
+        let beta = "context-1m-2025-08-07";
+
+        // Pre-condition: cache is empty
+        assert_eq!(
+            client.is_beta_supported(profile, beta).await,
+            None,
+            "cache must be empty before apply_probe_outcome"
+        );
+
+        apply_probe_outcome(&client, profile, beta, ProbeOutcome::Supported).await;
+
+        let result = client.is_beta_supported(profile, beta).await;
+        assert_eq!(
+            result,
+            Some(true),
+            "ProbeOutcome::Supported must write Some(true) into the cache"
+        );
+
+        // Also verify source is SeedProbe
+        let map = client.beta_capabilities.read().await;
+        let entry = map
+            .get(&(profile.to_string(), beta.to_string()))
+            .expect("entry must exist after Supported outcome");
+        assert_eq!(
+            entry.source,
+            ProbeSource::SeedProbe,
+            "apply_probe_outcome(Supported) must record source=SeedProbe"
+        );
+    }
+
+    /// Test 9: `ProbeOutcome::Unsupported` must write `(supported=false, source=SeedProbe)`
+    /// into the client's beta capability cache.
+    #[tokio::test]
+    async fn probe_outcome_unsupported_marks_cache_false() {
+        let client = make_cache_client();
+        let profile = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+        let beta = "context-1m-2025-08-07";
+
+        apply_probe_outcome(&client, profile, beta, ProbeOutcome::Unsupported).await;
+
+        let result = client.is_beta_supported(profile, beta).await;
+        assert_eq!(
+            result,
+            Some(false),
+            "ProbeOutcome::Unsupported must write Some(false) into the cache"
+        );
+
+        let map = client.beta_capabilities.read().await;
+        let entry = map
+            .get(&(profile.to_string(), beta.to_string()))
+            .expect("entry must exist after Unsupported outcome");
+        assert_eq!(
+            entry.source,
+            ProbeSource::SeedProbe,
+            "apply_probe_outcome(Unsupported) must record source=SeedProbe"
+        );
+    }
+
+    /// Test 10: `ProbeOutcome::Inconclusive` on a fresh (empty) cache must leave
+    /// the cache unchanged — `is_beta_supported` must still return `None`.
+    ///
+    /// This is the "throttling / 5xx / network error" path: we learned nothing,
+    /// so we do not touch the cache and the pair will be re-probed next tick.
+    #[tokio::test]
+    async fn probe_outcome_inconclusive_leaves_cache_unchanged() {
+        let client = make_cache_client();
+        let profile = "us.anthropic.claude-sonnet-4-6-20250514";
+        let beta = "context-1m-2025-08-07";
+
+        apply_probe_outcome(&client, profile, beta, ProbeOutcome::Inconclusive).await;
+
+        let result = client.is_beta_supported(profile, beta).await;
+        assert_eq!(
+            result, None,
+            "ProbeOutcome::Inconclusive on empty cache must leave it empty (still None)"
+        );
+    }
+
+    /// Test 11: `ProbeOutcome::Inconclusive` must NOT overwrite an existing cache
+    /// entry.
+    ///
+    /// Scenario: a previous successful probe wrote `Some(true)`. Then a
+    /// throttling event fires before the 24h TTL expires. The `Inconclusive`
+    /// outcome must not clobber the earlier `Supported` value.
+    #[tokio::test]
+    async fn probe_outcome_inconclusive_does_not_overwrite_existing() {
+        let client = make_cache_client();
+        let profile = "us.anthropic.claude-opus-4-7";
+        let beta = "context-1m-2025-08-07";
+
+        // Pre-populate with a supported entry (simulates prior successful probe)
+        client
+            .mark_supported(profile, beta, ProbeSource::SeedProbe)
+            .await;
+
+        assert_eq!(
+            client.is_beta_supported(profile, beta).await,
+            Some(true),
+            "pre-condition: cache must have Some(true) before Inconclusive outcome"
+        );
+
+        // Apply an Inconclusive outcome (e.g. throttling on re-probe attempt)
+        apply_probe_outcome(&client, profile, beta, ProbeOutcome::Inconclusive).await;
+
+        let result = client.is_beta_supported(profile, beta).await;
+        assert_eq!(
+            result,
+            Some(true),
+            "ProbeOutcome::Inconclusive must not overwrite an existing Some(true) cache entry"
         );
     }
 }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -10,6 +10,14 @@ use crate::db::schema::Endpoint;
 
 pub mod stats;
 
+/// Shared capability map type — maps `(profile_id, beta_name)` to `CapabilityEntry`.
+type BetaCapabilityMap = Arc<RwLock<HashMap<(String, String), CapabilityEntry>>>;
+
+/// Pair of preserved cache Arcs carried from an existing `EndpointClient` into
+/// a reloaded one so that learned capability data and model lists survive
+/// routine `cache_version`-triggered reloads.
+type PreservedCaches = (BetaCapabilityMap, Arc<RwLock<Vec<String>>>);
+
 /// TTL for non-`AdminOverride` capability cache entries.
 pub const CAPABILITY_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
@@ -102,10 +110,22 @@ impl EndpointClient {
     }
 
     /// Record that `(profile, beta)` is supported.
+    ///
+    /// If the existing entry was written by `AdminOverride` and the incoming
+    /// `source` is anything other than `AdminOverride`, the call is a no-op.
+    /// Admin overrides stay until explicitly cleared via `forget_capability`.
     pub async fn mark_supported(&self, profile: &str, beta: &str, source: ProbeSource) {
         let mut map = self.beta_capabilities.write().await;
+        let key = (profile.to_string(), beta.to_string());
+        // Never overwrite an admin override from any other source.
+        if let Some(existing) = map.get(&key)
+            && existing.source == ProbeSource::AdminOverride
+            && source != ProbeSource::AdminOverride
+        {
+            return;
+        }
         map.insert(
-            (profile.to_string(), beta.to_string()),
+            key,
             CapabilityEntry {
                 supported: true,
                 learned_at: Instant::now(),
@@ -125,10 +145,22 @@ impl EndpointClient {
     }
 
     /// Record that `(profile, beta)` is NOT supported.
+    ///
+    /// If the existing entry was written by `AdminOverride` and the incoming
+    /// `source` is anything other than `AdminOverride`, the call is a no-op.
+    /// Admin overrides stay until explicitly cleared via `forget_capability`.
     pub async fn mark_unsupported(&self, profile: &str, beta: &str, source: ProbeSource) {
         let mut map = self.beta_capabilities.write().await;
+        let key = (profile.to_string(), beta.to_string());
+        // Never overwrite an admin override from any other source.
+        if let Some(existing) = map.get(&key)
+            && existing.source == ProbeSource::AdminOverride
+            && source != ProbeSource::AdminOverride
+        {
+            return;
+        }
         map.insert(
-            (profile.to_string(), beta.to_string()),
+            key,
             CapabilityEntry {
                 supported: false,
                 learned_at: Instant::now(),
@@ -286,6 +318,11 @@ impl EndpointPool {
     /// Load/reload endpoint clients from database endpoint configs.
     /// For endpoints with role_arn, uses STS AssumeRole (via AssumeRoleProvider).
     /// For endpoints without role_arn (NULL), uses the gateway's own credentials.
+    ///
+    /// Existing `beta_capabilities` and `available_models` Arcs are preserved for
+    /// endpoints that are already in the pool (matched by UUID), so that learned
+    /// capability data survives routine config reloads triggered by cache_version bumps.
+    /// Only genuinely new endpoints get a fresh empty cache.
     pub async fn load_endpoints(
         &self,
         endpoints: Vec<Endpoint>,
@@ -294,11 +331,30 @@ impl EndpointPool {
         let mut new_clients = HashMap::new();
         let mut new_default: Option<Uuid> = None;
 
+        // Snapshot the current pool so we can preserve cache Arcs for unchanged endpoints.
+        let preserved: HashMap<Uuid, PreservedCaches> = {
+            let old_clients = self.clients.read().await;
+            old_clients
+                .iter()
+                .map(|(id, c)| {
+                    (
+                        *id,
+                        (
+                            Arc::clone(&c.beta_capabilities),
+                            Arc::clone(&c.available_models),
+                        ),
+                    )
+                })
+                .collect()
+        };
+
         for ep in endpoints {
             if ep.is_default {
                 new_default = Some(ep.id);
             }
-            let client = Self::create_client(&ep, base_aws_config).await;
+            let preserved_caches = preserved.get(&ep.id).cloned();
+            let client =
+                Self::create_client_with_caches(&ep, base_aws_config, preserved_caches).await;
             if let Some(c) = client {
                 new_clients.insert(ep.id, Arc::new(c));
             }
@@ -312,9 +368,10 @@ impl EndpointPool {
         *default_id = new_default;
     }
 
-    async fn create_client(
+    async fn create_client_with_caches(
         endpoint: &Endpoint,
         _base_config: &aws_config::SdkConfig,
+        preserved_caches: Option<PreservedCaches>,
     ) -> Option<EndpointClient> {
         let region = aws_config::Region::new(endpoint.region.clone());
 
@@ -347,6 +404,16 @@ impl EndpointPool {
         let control_client = aws_sdk_bedrock::Client::new(&sdk_config);
         let quota_client = aws_sdk_servicequotas::Client::new(&sdk_config);
 
+        // Reuse existing cache Arcs when reloading a known endpoint, so that
+        // learned capability data and available-model lists survive config reloads.
+        let (beta_capabilities, available_models) = match preserved_caches {
+            Some((beta_cap, avail_models)) => (beta_cap, avail_models),
+            None => (
+                Arc::new(RwLock::new(HashMap::new())),
+                Arc::new(RwLock::new(vec![])),
+            ),
+        };
+
         Some(EndpointClient {
             config: endpoint.clone(),
             runtime_client,
@@ -354,8 +421,8 @@ impl EndpointPool {
             quota_cache: crate::quota::QuotaCache::new(quota_client),
             healthy: AtomicBool::new(false),
             last_health_check: AtomicI64::new(0),
-            available_models: Arc::new(RwLock::new(vec![])),
-            beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
+            available_models,
+            beta_capabilities,
         })
     }
 

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -114,6 +114,16 @@ impl EndpointClient {
         );
     }
 
+    /// Remove the `(profile, beta)` entry from the capability cache entirely.
+    ///
+    /// After this call, `is_beta_supported(profile, beta)` returns `None`.
+    /// Used by the admin DELETE handler to clear an override and let the
+    /// health-loop re-probe on the next cycle.
+    pub async fn forget_capability(&self, profile: &str, beta: &str) {
+        let mut map = self.beta_capabilities.write().await;
+        map.remove(&(profile.to_string(), beta.to_string()));
+    }
+
     /// Record that `(profile, beta)` is NOT supported.
     pub async fn mark_unsupported(&self, profile: &str, beta: &str, source: ProbeSource) {
         let mut map = self.beta_capabilities.write().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,51 @@ pub mod spend;
 pub mod telemetry;
 pub mod translate;
 pub mod websearch;
+
+/// Replay all admin beta overrides from `beta_overrides` table into the in-memory
+/// endpoint pool.
+///
+/// Called at boot (before the gateway starts serving traffic) and on every
+/// `cache_version` bump (so overrides written on one replica propagate to all).
+///
+/// Returns the number of overrides successfully applied (i.e. where
+/// `endpoint_pool.get_client(ovr.endpoint_id)` returned `Some`).
+/// Rows whose endpoint is not in the pool are silently skipped with a debug log.
+pub async fn apply_overrides_to_pool(
+    pool: &sqlx::PgPool,
+    endpoint_pool: &crate::endpoint::EndpointPool,
+) -> Result<usize, sqlx::Error> {
+    let overrides = crate::db::beta_overrides::list_all(pool).await?;
+    let mut applied = 0usize;
+    for ovr in &overrides {
+        if let Some(client) = endpoint_pool.get_client(ovr.endpoint_id).await {
+            if ovr.supported {
+                client
+                    .mark_supported(
+                        &ovr.profile_id,
+                        &ovr.beta_name,
+                        crate::endpoint::ProbeSource::AdminOverride,
+                    )
+                    .await;
+            } else {
+                client
+                    .mark_unsupported(
+                        &ovr.profile_id,
+                        &ovr.beta_name,
+                        crate::endpoint::ProbeSource::AdminOverride,
+                    )
+                    .await;
+            }
+            applied += 1;
+        } else {
+            tracing::debug!(
+                endpoint_id = %ovr.endpoint_id,
+                profile = %ovr.profile_id,
+                beta = %ovr.beta_name,
+                "Skipping override replay: endpoint not in pool"
+            );
+        }
+    }
+    tracing::info!(total = overrides.len(), applied, "Replayed beta overrides");
+    Ok(applied)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,6 +326,12 @@ async fn main() -> anyhow::Result<()> {
             }
             Err(e) => tracing::warn!(%e, "Failed to load endpoints"),
         }
+
+        // Replay admin beta overrides into in-memory cache before serving traffic.
+        match ccag::apply_overrides_to_pool(&pool, &state.endpoint_pool).await {
+            Ok(count) => tracing::info!(count, "Boot: replayed beta overrides"),
+            Err(e) => tracing::warn!(%e, "Boot: failed to replay beta overrides"),
+        }
     }
 
     // Start cache version polling loop (5s interval)
@@ -932,6 +938,15 @@ fn start_cache_poll_loop(state: Arc<proxy::GatewayState>) {
                         tracing::debug!(count, "Reloaded endpoints");
                     }
                     Err(e) => tracing::warn!(%e, "Failed to reload endpoints"),
+                }
+
+                // Re-replay admin beta overrides so changes made via API on one
+                // replica propagate to all gateway replicas within the 5s poll window.
+                match ccag::apply_overrides_to_pool(pool, &state.endpoint_pool).await {
+                    Ok(n) => {
+                        tracing::debug!(n, "Re-replayed beta overrides after cache version bump")
+                    }
+                    Err(e) => tracing::warn!(%e, "Failed to re-replay beta overrides"),
                 }
 
                 // Reload settings

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,6 +377,10 @@ async fn main() -> anyhow::Result<()> {
                         .write()
                         .await;
                     *models = profile_ids;
+                    // TODO(1m-context): probe gateway default client too — currently relies on
+                    // per-endpoint clients. Default client has no EndpointClient, so it cannot
+                    // hold beta_capabilities state. Defer until we extract the cache to a shared
+                    // trait or add default_beta_capabilities to EndpointPool.
                 }
 
                 if ok != was_healthy {
@@ -415,8 +419,85 @@ async fn main() -> anyhow::Result<()> {
                                     .map(|p| p.inference_profile_id().to_string())
                                     .filter(|id| id.starts_with(&prefix_dot))
                                     .collect();
+                                // Snapshot profiles for seed probing before releasing the lock.
+                                let profiles_snapshot = profile_ids.clone();
                                 let mut models = client.available_models.write().await;
                                 *models = profile_ids;
+                                drop(models);
+
+                                // ── 1M context seed probe step ──────────────────────────
+                                // For each (profile, beta) pair that is absent or expired,
+                                // fire a synthetic 1-token InvokeModel to learn whether
+                                // the beta is supported on this endpoint.
+                                // Probes are sequenced sequentially (no join_all) — the
+                                // total load is bounded by |profiles| × |SUFFIX_BETA_MAP|.
+                                let pairs = client.expired_seed_pairs(&profiles_snapshot).await;
+                                for (profile, beta) in &pairs {
+                                    // Build Bedrock request body directly — NOT via translate().
+                                    let probe_body = format!(
+                                        r#"{{"anthropic_version":"bedrock-2023-05-31","anthropic_beta":["{beta}"],"max_tokens":1,"messages":[{{"role":"user","content":"hi"}}]}}"#
+                                    );
+                                    let probe_result = client
+                                        .runtime_client
+                                        .invoke_model()
+                                        .model_id(profile)
+                                        .content_type("application/json")
+                                        .accept("application/json")
+                                        .body(aws_sdk_bedrockruntime::primitives::Blob::new(
+                                            probe_body.into_bytes(),
+                                        ))
+                                        .send()
+                                        .await;
+
+                                    let (success, is_validation_exception, error_message) =
+                                        match probe_result {
+                                            Ok(_) => (true, false, String::new()),
+                                            Err(ref sdk_err) => {
+                                                use aws_sdk_bedrockruntime::error::SdkError;
+                                                let err_str = format!("{sdk_err:?}");
+                                                let is_ve = matches!(
+                                                    sdk_err,
+                                                    SdkError::ServiceError(svc)
+                                                    if svc.err().is_validation_exception()
+                                                );
+                                                (false, is_ve, err_str)
+                                            }
+                                        };
+
+                                    let outcome = ccag::endpoint::classify_probe_outcome(
+                                        success,
+                                        is_validation_exception,
+                                        &error_message,
+                                        beta,
+                                    );
+
+                                    if !success
+                                        && matches!(
+                                            outcome,
+                                            ccag::endpoint::ProbeOutcome::Inconclusive
+                                        )
+                                    {
+                                        tracing::warn!(
+                                            profile = %profile,
+                                            beta = %beta,
+                                            err = %error_message,
+                                            "1m_probe failed to invoke (inconclusive)"
+                                        );
+                                    }
+
+                                    tracing::info!(
+                                        profile = %profile,
+                                        beta = %beta,
+                                        outcome = ?outcome,
+                                        "1m_probe outcome"
+                                    );
+
+                                    ccag::endpoint::apply_probe_outcome(
+                                        client, profile, beta, outcome,
+                                    )
+                                    .await;
+                                }
+
                                 true
                             }
                             Err(_) => false,

--- a/src/translate/betas.rs
+++ b/src/translate/betas.rs
@@ -1,0 +1,136 @@
+//! Cache-aware beta filtering and Bedrock ValidationException parsing.
+
+use crate::endpoint::EndpointClient;
+
+/// Extract beta names from a Bedrock `ValidationException` error message.
+///
+/// Scans `error_message` for any substring in `candidates` (case-insensitive).
+/// Returns the matched candidates — these are the betas Bedrock rejected.
+///
+/// Intentionally uses substring search rather than a regex so the logic is
+/// robust to minor Bedrock error-message format drift.
+pub fn parse_rejected_betas(error_message: &str, candidates: &[String]) -> Vec<String> {
+    let lower = error_message.to_lowercase();
+    candidates
+        .iter()
+        .filter(|c| lower.contains(&c.to_lowercase()))
+        .cloned()
+        .collect()
+}
+
+/// Result of filtering a beta list through the per-endpoint capability cache.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BetaFilterResult {
+    /// Betas to include in the forwarded request (cache says supported OR unknown).
+    pub kept: Vec<String>,
+    /// Betas dropped because the cache recorded `Some(false)` for this endpoint+profile.
+    pub dropped: Vec<String>,
+    /// Subset of `kept` whose cache state was `None` (absent or expired) at filter time.
+    /// On a successful response these should be opportunistically marked as supported.
+    pub unknown: Vec<String>,
+}
+
+/// Filter `incoming` betas through the per-endpoint capability cache.
+///
+/// - `Some(true)`  → kept, not unknown
+/// - `Some(false)` → dropped
+/// - `None`        → kept AND placed in `unknown` (optimistic; learn on success)
+pub async fn filter_betas_by_cache(
+    client: &EndpointClient,
+    profile: &str,
+    incoming: &[String],
+) -> BetaFilterResult {
+    let mut kept = Vec::new();
+    let mut dropped = Vec::new();
+    let mut unknown = Vec::new();
+
+    for b in incoming {
+        match client.is_beta_supported(profile, b).await {
+            Some(true) => kept.push(b.clone()),
+            Some(false) => dropped.push(b.clone()),
+            None => {
+                kept.push(b.clone());
+                unknown.push(b.clone());
+            }
+        }
+    }
+
+    BetaFilterResult {
+        kept,
+        dropped,
+        unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidates() -> Vec<String> {
+        vec![
+            "context-1m-2025-08-07".to_string(),
+            "interleaved-thinking-2025-05-14".to_string(),
+            "claude-code-x".to_string(),
+        ]
+    }
+
+    // ── parse_rejected_betas ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_empty_message_returns_empty() {
+        let result = parse_rejected_betas("", &candidates());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_no_match_returns_empty() {
+        let result = parse_rejected_betas(
+            "The request is invalid for some unrelated reason.",
+            &candidates(),
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_single_beta_named_in_error() {
+        let msg =
+            "ValidationException: The beta feature 'claude-code-x' is not supported on this model.";
+        let result = parse_rejected_betas(msg, &candidates());
+        assert_eq!(result, vec!["claude-code-x".to_string()]);
+    }
+
+    #[test]
+    fn parse_multiple_betas_named_in_error() {
+        let msg = "ValidationException: features context-1m-2025-08-07 and claude-code-x are not supported.";
+        let mut result = parse_rejected_betas(msg, &candidates());
+        result.sort();
+        let mut expected = vec![
+            "context-1m-2025-08-07".to_string(),
+            "claude-code-x".to_string(),
+        ];
+        expected.sort();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn parse_case_insensitive_match() {
+        // Bedrock might capitalise or alter casing in error messages.
+        let msg = "Unsupported beta: CONTEXT-1M-2025-08-07";
+        let result = parse_rejected_betas(msg, &candidates());
+        assert_eq!(result, vec!["context-1m-2025-08-07".to_string()]);
+    }
+
+    #[test]
+    fn parse_empty_candidates_returns_empty() {
+        let result = parse_rejected_betas("context-1m-2025-08-07 is not supported", &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_does_not_duplicate_when_beta_appears_twice_in_message() {
+        // The beta appears twice but candidates only contains it once — result should have one entry.
+        let msg = "context-1m-2025-08-07 context-1m-2025-08-07 rejected";
+        let result = parse_rejected_betas(msg, &candidates());
+        assert_eq!(result, vec!["context-1m-2025-08-07".to_string()]);
+    }
+}

--- a/src/translate/mod.rs
+++ b/src/translate/mod.rs
@@ -1,3 +1,4 @@
+pub mod betas;
 pub mod model_seed;
 pub mod models;
 pub mod request;

--- a/src/translate/models.rs
+++ b/src/translate/models.rs
@@ -1221,8 +1221,7 @@ mod tests_t4_suffix_strip {
     /// Result equals the bare Bedrock ID with no suffix.
     #[test]
     fn strips_suffix_on_bedrock_style_id() {
-        let with_suffix =
-            anthropic_to_bedrock("us.anthropic.claude-opus-4-7[1m]", "us", None);
+        let with_suffix = anthropic_to_bedrock("us.anthropic.claude-opus-4-7[1m]", "us", None);
         assert_eq!(
             with_suffix, "us.anthropic.claude-opus-4-7",
             "strip must run before the dot-passthrough check so Bedrock-style IDs with suffix also work"

--- a/src/translate/models.rs
+++ b/src/translate/models.rs
@@ -292,7 +292,25 @@ pub async fn discover_model(
 /// profile IDs using the configured region prefix.
 ///
 /// Checks the dynamic cache first, falls back to hardcoded mappings.
+///
+/// **Suffix stripping (Slice 4):** if the model ID ends with `[\w+]` (e.g. `[1m]`,
+/// `[2m]`, `[batch]`, `[v2_0]`), that suffix is stripped before all other logic.
+/// The suffix is discarded — no beta is auto-injected here. Capability for any
+/// specific suffix is determined at the `/v1/models` advertising layer via
+/// `SUFFIX_BETA_MAP` (defined in `src/endpoint/mod.rs`).
 pub fn anthropic_to_bedrock(model: &str, prefix: &str, model_cache: Option<&ModelCache>) -> String {
+    // Strip trailing [\w+] suffix (e.g. [1m], [2m], [batch], [v2_0]) before any
+    // other logic. Compiled once via OnceLock.
+    static SUFFIX_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = SUFFIX_RE.get_or_init(|| regex::Regex::new(r"\[\w+\]$").unwrap());
+    let model_owned;
+    let model: &str = if re.is_match(model) {
+        model_owned = re.replace(model, "").into_owned();
+        &model_owned
+    } else {
+        model
+    };
+
     // If it already looks like a Bedrock ID (contains a dot prefix), pass through
     if model.contains('.') {
         return model.to_string();
@@ -1125,6 +1143,155 @@ mod tests {
         assert_eq!(
             profile_prefix, "malformed-profile-id",
             "profile_prefix fallback: entire string when no dot found"
+        );
+    }
+}
+
+/// Task 4 — Generic `[\w+]` suffix stripping in `anthropic_to_bedrock`.
+///
+/// The function must strip a trailing `[\w+]` (regex `\[\w+\]$`) from the
+/// model ID before all other logic (dot-passthrough check, cache lookup,
+/// hardcoded match, discovery fallback).
+///
+/// The suffix is silently discarded — it is not used to inject betas.
+/// That remains the responsibility of the client (CC sends the beta header;
+/// the gateway forwards it via the Slice 3 mechanism).
+#[cfg(test)]
+mod tests_t4_suffix_strip {
+    use super::*;
+
+    /// T4-1: `[1m]` suffix is stripped; result equals the bare Bedrock ID.
+    /// `claude-opus-4-7[1m]` → same as `claude-opus-4-7` (hardcoded mapping).
+    #[test]
+    fn strips_1m_suffix_from_anthropic_id() {
+        let with_suffix = anthropic_to_bedrock("claude-opus-4-7[1m]", "us", None);
+        let bare = anthropic_to_bedrock("claude-opus-4-7", "us", None);
+        assert_eq!(
+            with_suffix, bare,
+            "anthropic_to_bedrock must strip [1m] and produce the same result as the bare ID"
+        );
+        assert_eq!(
+            with_suffix, "us.anthropic.claude-opus-4-7",
+            "stripped [1m] from claude-opus-4-7 should map to us.anthropic.claude-opus-4-7"
+        );
+    }
+
+    /// T4-2: `[2m]` suffix is stripped generically — no validation at this layer.
+    /// The regex strips any `[\w+]` regardless of whether the suffix is in SUFFIX_BETA_MAP.
+    #[test]
+    fn strips_2m_suffix_generically() {
+        let with_suffix = anthropic_to_bedrock("claude-opus-4-7[2m]", "us", None);
+        let bare = anthropic_to_bedrock("claude-opus-4-7", "us", None);
+        assert_eq!(
+            with_suffix, bare,
+            "anthropic_to_bedrock must strip [2m] generically (no validation against SUFFIX_BETA_MAP)"
+        );
+        assert_eq!(with_suffix, "us.anthropic.claude-opus-4-7");
+    }
+
+    /// T4-3: Alphabetic suffix `[batch]` is stripped.
+    #[test]
+    fn strips_alphanumeric_suffix() {
+        let with_suffix = anthropic_to_bedrock("claude-opus-4-7[batch]", "us", None);
+        let bare = anthropic_to_bedrock("claude-opus-4-7", "us", None);
+        assert_eq!(
+            with_suffix, bare,
+            "anthropic_to_bedrock must strip [batch] suffix"
+        );
+    }
+
+    /// T4-4: Underscore suffix `[v2_0]` is stripped.
+    /// `\w+` matches `[a-zA-Z0-9_]+`, so underscores are valid inside the brackets.
+    #[test]
+    fn strips_underscore_suffix() {
+        let with_suffix = anthropic_to_bedrock("claude-opus-4-7[v2_0]", "us", None);
+        let bare = anthropic_to_bedrock("claude-opus-4-7", "us", None);
+        assert_eq!(
+            with_suffix, bare,
+            "anthropic_to_bedrock must strip [v2_0] suffix (underscore is valid \\w)"
+        );
+    }
+
+    /// T4-5: Suffix on an already-Bedrock-style ID (`us.anthropic.claude-opus-4-7[1m]`).
+    ///
+    /// The dot-passthrough check runs AFTER the strip, so:
+    ///   1. Strip `[1m]` → `us.anthropic.claude-opus-4-7`
+    ///   2. Contains dot → passthrough → `us.anthropic.claude-opus-4-7`
+    ///
+    /// Result equals the bare Bedrock ID with no suffix.
+    #[test]
+    fn strips_suffix_on_bedrock_style_id() {
+        let with_suffix =
+            anthropic_to_bedrock("us.anthropic.claude-opus-4-7[1m]", "us", None);
+        assert_eq!(
+            with_suffix, "us.anthropic.claude-opus-4-7",
+            "strip must run before the dot-passthrough check so Bedrock-style IDs with suffix also work"
+        );
+    }
+
+    /// T4-6: No suffix on an unknown/future model ID — behavior unchanged.
+    /// `claude-future-9-9` has no hardcoded mapping and no cache, so it passes
+    /// through the `other =>` arm and is returned dotless (for discovery).
+    #[test]
+    fn no_suffix_unchanged_unknown_model() {
+        let result = anthropic_to_bedrock("claude-future-9-9", "us", None);
+        assert_eq!(
+            result, "claude-future-9-9",
+            "Unknown model without suffix must still pass through dotless (discovery path)"
+        );
+    }
+
+    /// T4-7: No suffix on a known model — existing hardcoded mapping is unaffected.
+    #[test]
+    fn no_suffix_unchanged_known_model() {
+        let result = anthropic_to_bedrock("claude-sonnet-4-6-20250514", "us", None);
+        assert_eq!(
+            result, "us.anthropic.claude-sonnet-4-6",
+            "Existing hardcoded mapping must be unaffected after adding strip logic"
+        );
+    }
+
+    /// T4-8: Empty brackets `[]` must NOT be stripped.
+    /// The regex `\[\w+\]$` requires at least one word character inside brackets.
+    /// `claude-opus-4-7[]` has no known hardcoded mapping, so it passes through
+    /// the `other =>` arm and is returned verbatim (dotless pass-through).
+    ///
+    /// This is defensive: we don't want accidental stripping of model IDs that
+    /// happen to end with `[]`.
+    #[test]
+    fn empty_brackets_not_stripped() {
+        let result = anthropic_to_bedrock("claude-opus-4-7[]", "us", None);
+        // `[]` does NOT match `\[\w+\]$` — the empty bracket falls to `other =>` arm
+        // and is returned verbatim (dotless). This is intentional: `[]` is not a
+        // valid suffix per the spec; `\w+` requires ≥1 word char.
+        assert_eq!(
+            result, "claude-opus-4-7[]",
+            "Empty brackets [] must NOT be stripped (\\w+ requires ≥1 char)"
+        );
+    }
+
+    /// T4-9: Unbalanced brackets (missing close) must NOT be stripped.
+    /// `claude-opus-4-7[1m` has no closing `]`, so the regex does not match.
+    /// Falls through to `other =>` arm and is returned verbatim.
+    #[test]
+    fn unbalanced_brackets_not_stripped() {
+        let result = anthropic_to_bedrock("claude-opus-4-7[1m", "us", None);
+        assert_eq!(
+            result, "claude-opus-4-7[1m",
+            "Missing close bracket must NOT be stripped"
+        );
+    }
+
+    /// T4-10: Bracket not at end-of-string must NOT be stripped.
+    /// `claude[1m]-opus-4-7` — the `[1m]` is mid-string, not at the end.
+    /// The regex is anchored with `$`, so this must not match.
+    /// Falls through to `other =>` arm and is returned verbatim.
+    #[test]
+    fn bracket_not_at_end_not_stripped() {
+        let result = anthropic_to_bedrock("claude[1m]-opus-4-7", "us", None);
+        assert_eq!(
+            result, "claude[1m]-opus-4-7",
+            "Bracket not at end of string must NOT be stripped (regex is end-anchored)"
         );
     }
 }

--- a/src/translate/request.rs
+++ b/src/translate/request.rs
@@ -35,6 +35,13 @@ pub struct AnthropicRequest {
     #[serde(default)]
     #[allow(dead_code)]
     pub mcp_servers: Option<Vec<Value>>,
+    /// Beta flags from the client. CC sends them under the JSON key `"betas"`; the
+    /// `anthropic-beta` HTTP header is merged in at the handler layer before calling
+    /// `translate()`. Two aliases accepted: `"betas"` (CC wire format) and
+    /// `"anthropic_beta"` (internal/legacy). Filtered through the capability cache
+    /// at the handler boundary, not here — `translate()` is a pure passthrough.
+    #[serde(default, alias = "betas", alias = "anthropic_beta")]
+    pub anthropic_beta: Vec<String>,
 }
 
 /// Request body for Bedrock InvokeModel.
@@ -113,7 +120,10 @@ pub fn translate(
 ) -> (String, BedrockRequest, Option<websearch::WebSearchContext>) {
     let bedrock_model = models::anthropic_to_bedrock(&req.model, model_prefix, model_cache);
 
-    let betas: Vec<String> = Vec::new();
+    // Pure passthrough: betas are forwarded as-is from the client.
+    // Cache-based filtering happens at the handler boundary (src/api/handlers.rs),
+    // not here. translate() must not strip or inject betas.
+    let betas = req.anthropic_beta.clone();
 
     // Extract web_search server tool (if present) and replace with regular tool definition.
     // The mode controls behavior: "disabled" strips tools, "enabled"/"global" processes them.
@@ -174,6 +184,7 @@ mod tests {
             top_p: None,
             top_k: None,
             mcp_servers: None,
+            anthropic_beta: vec![],
         }
     }
 

--- a/tests/integration/beta_overrides_admin_tests.rs
+++ b/tests/integration/beta_overrides_admin_tests.rs
@@ -137,7 +137,10 @@ async fn create_fixture_endpoint(pool: &sqlx::PgPool, name: &str) -> Uuid {
 // we call `load_endpoints` on it after the endpoint is in the DB.
 // ---------------------------------------------------------------------------
 
-async fn build_app_with_endpoint(pool: &sqlx::PgPool, ep_name: &str) -> (axum::Router, String, Uuid, Arc<ccag::proxy::GatewayState>) {
+async fn build_app_with_endpoint(
+    pool: &sqlx::PgPool,
+    ep_name: &str,
+) -> (axum::Router, String, Uuid, Arc<ccag::proxy::GatewayState>) {
     use std::sync::atomic::AtomicI64;
 
     let ep_id = create_fixture_endpoint(pool, ep_name).await;
@@ -279,7 +282,9 @@ async fn list_returns_all_overrides_admin_only() {
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
-    let overrides = json["overrides"].as_array().expect("response must have 'overrides' array");
+    let overrides = json["overrides"]
+        .as_array()
+        .expect("response must have 'overrides' array");
     assert_eq!(overrides.len(), 1, "should return 1 override");
     assert_eq!(overrides[0]["profile_id"], "us.anthropic.claude-opus-4-7");
     assert_eq!(overrides[0]["beta_name"], "context-1m-2025-08-07");
@@ -431,7 +436,11 @@ async fn upsert_with_supported_false_caches_in_memory_as_false() {
         .await
         .unwrap();
 
-    assert_eq!(resp.status(), StatusCode::OK, "upsert supported=false should return 200");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "upsert supported=false should return 200"
+    );
 
     // DB must have supported=false
     let db_rows = db::beta_overrides::list_for_endpoint(&pool, ep_id)
@@ -462,8 +471,7 @@ async fn upsert_with_supported_false_caches_in_memory_as_false() {
 #[tokio::test]
 async fn upsert_admin_override_wins_over_existing_seedprobe() {
     let pool = helpers::setup_test_db().await;
-    let (app, admin_token, ep_id, state) =
-        build_app_with_endpoint(&pool, "ep-override-wins").await;
+    let (app, admin_token, ep_id, state) = build_app_with_endpoint(&pool, "ep-override-wins").await;
 
     let profile = "us.anthropic.claude-opus-4-7";
     let beta = "context-1m-2025-08-07";
@@ -474,7 +482,9 @@ async fn upsert_admin_override_wins_over_existing_seedprobe() {
         .get_client(ep_id)
         .await
         .expect("endpoint must be in pool");
-    client.mark_supported(profile, beta, ProbeSource::SeedProbe).await;
+    client
+        .mark_supported(profile, beta, ProbeSource::SeedProbe)
+        .await;
 
     // Verify the seed-probe entry is there
     assert_eq!(
@@ -535,8 +545,7 @@ async fn upsert_admin_override_wins_over_existing_seedprobe() {
 #[tokio::test]
 async fn delete_removes_db_row_and_in_memory_cache() {
     let pool = helpers::setup_test_db().await;
-    let (app, admin_token, ep_id, state) =
-        build_app_with_endpoint(&pool, "ep-delete-cache").await;
+    let (app, admin_token, ep_id, state) = build_app_with_endpoint(&pool, "ep-delete-cache").await;
 
     let profile = "us.anthropic.claude-opus-4-7";
     let beta = "context-1m-2025-08-07";
@@ -563,10 +572,16 @@ async fn delete_removes_db_row_and_in_memory_cache() {
         )
         .await
         .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK, "upsert before delete should succeed");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "upsert before delete should succeed"
+    );
 
     // Verify it's in DB and cache
-    let rows = db::beta_overrides::list_for_endpoint(&pool, ep_id).await.unwrap();
+    let rows = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
     assert_eq!(rows.len(), 1, "sanity: DB row exists before delete");
 
     let client = state
@@ -583,10 +598,7 @@ async fn delete_removes_db_row_and_in_memory_cache() {
     // Now: DELETE via admin API
     // URL encoding: profile_id and beta_name are path segments; they may contain dots
     // (which are valid in URL paths) but the router must handle them as-is.
-    let delete_uri = format!(
-        "/admin/beta-overrides/{}/{}/{}",
-        ep_id, profile, beta
-    );
+    let delete_uri = format!("/admin/beta-overrides/{}/{}/{}", ep_id, profile, beta);
 
     let resp = app
         .clone()
@@ -608,14 +620,15 @@ async fn delete_removes_db_row_and_in_memory_cache() {
     );
 
     // DB row must be gone
-    let rows_after = db::beta_overrides::list_for_endpoint(&pool, ep_id).await.unwrap();
+    let rows_after = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
     assert_eq!(rows_after.len(), 0, "DB row must be deleted");
 
     // In-memory cache must return None (forget_capability removes the entry)
     let cached_after = client.is_beta_supported(profile, beta).await;
     assert_eq!(
-        cached_after,
-        None,
+        cached_after, None,
         "is_beta_supported must return None after the override is deleted"
     );
 }
@@ -662,8 +675,8 @@ async fn delete_404_for_nonexistent() {
     let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
         .await
         .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body)
-        .expect("DELETE 404 response must be valid JSON");
+    let json: serde_json::Value =
+        serde_json::from_slice(&body).expect("DELETE 404 response must be valid JSON");
     assert!(
         json["error"].is_object(),
         "DELETE 404 response must have 'error' object, got: {json}"
@@ -725,8 +738,8 @@ async fn upsert_validates_endpoint_exists() {
     let body_bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
         .await
         .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body_bytes)
-        .expect("404 response body must be valid JSON");
+    let json: serde_json::Value =
+        serde_json::from_slice(&body_bytes).expect("404 response body must be valid JSON");
     assert!(
         json["error"].is_object(),
         "404 response must contain 'error' object, got: {json}"
@@ -768,16 +781,15 @@ async fn forget_capability_removes_entry_from_cache() {
     let endpoints = vec![ep.clone()];
     pool.load_endpoints(endpoints, &aws_config).await;
 
-    let client = pool
-        .get_client(ep.id)
-        .await
-        .expect("client must be loaded");
+    let client = pool.get_client(ep.id).await.expect("client must be loaded");
 
     let profile = "us.anthropic.claude-opus-4-7";
     let beta = "context-1m-2025-08-07";
 
     // Pre-populate cache
-    client.mark_supported(profile, beta, ProbeSource::AdminOverride).await;
+    client
+        .mark_supported(profile, beta, ProbeSource::AdminOverride)
+        .await;
     assert_eq!(
         client.is_beta_supported(profile, beta).await,
         Some(true),

--- a/tests/integration/beta_overrides_admin_tests.rs
+++ b/tests/integration/beta_overrides_admin_tests.rs
@@ -1,0 +1,795 @@
+/// Integration tests for admin API handlers related to beta overrides.
+///
+/// The Builder must create:
+///   - `src/db/beta_overrides.rs` — DB module (see beta_overrides_db_tests.rs)
+///   - `src/api/admin.rs` — three new handlers:
+///       `list_beta_overrides`, `upsert_beta_override`, `delete_beta_override`
+///   - `src/api/mod.rs` — three new routes:
+///       GET  /admin/beta-overrides
+///       POST /admin/beta-overrides
+///       DELETE /admin/beta-overrides/{endpoint_id}/{profile_id}/{beta_name}
+///   - `src/endpoint/mod.rs` — new method `forget_capability(&self, profile, beta)` on
+///     `EndpointClient` that removes the entry from `beta_capabilities`.
+///
+/// Design decisions documented here:
+/// - DELETE a nonexistent override → **404** (not idempotent 200). Rationale:
+///   the DELETE path encodes (endpoint_id, profile_id, beta_name) all in the URL,
+///   making a 200 idempotent response a silent success that could mask operator
+///   typos (e.g. wrong endpoint UUID). A 404 forces the caller to verify.
+/// - Upsert with nonexistent endpoint_id → **404** (FK violation surfaced as
+///   structured client error, not 500). The handler must catch the FK constraint
+///   error from sqlx and return a 404 with `{"error": {...}}` body.
+///
+/// Test isolation: each test calls `helpers::setup_test_db()` which creates a
+/// fresh `test_{uuid}` DB and runs all migrations. The `test_app` helper below
+/// mirrors the pattern from `admin_tests.rs`.
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI64};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use ccag::db;
+use ccag::endpoint::{EndpointClient, ProbeSource};
+
+use crate::helpers;
+
+// ---------------------------------------------------------------------------
+// Test app bootstrap (mirrors admin_tests.rs::test_app)
+// ---------------------------------------------------------------------------
+
+async fn test_app(pool: &sqlx::PgPool) -> (axum::Router, String) {
+    let config = ccag::config::GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 9999,
+        admin_username: "admin".to_string(),
+        admin_password: "admin".to_string(),
+        bedrock_routing_prefix: "us".to_string(),
+        database_url: "postgres://test@localhost/test".to_string(),
+        admin_users: vec![],
+        notification_url: None,
+        rds_iam_auth: false,
+        database_host: None,
+        database_port: 5432,
+        database_name: "test".to_string(),
+        database_user: "test".to_string(),
+        pricing_refresh_interval: 86400,
+        pricing_refresh_enabled: true,
+    };
+
+    let signing_key = "test-signing-key-for-integration-tests";
+
+    let _ = ccag::db::users::create_user(pool, "admin", None, "admin").await;
+
+    let identity = ccag::auth::oidc::OidcIdentity {
+        sub: "admin".to_string(),
+        email: None,
+        idp_name: "Local".to_string(),
+    };
+    let admin_token = ccag::auth::session::issue(signing_key, &identity, 24);
+
+    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let bedrock_client = aws_sdk_bedrockruntime::Client::new(&aws_config);
+    let bedrock_control_client = aws_sdk_bedrock::Client::new(&aws_config);
+
+    let (metrics, _provider) = ccag::telemetry::Metrics::new(None).unwrap();
+    let metrics = Arc::new(metrics);
+
+    let db_pool = Arc::new(tokio::sync::RwLock::new(pool.clone()));
+    let state = Arc::new(ccag::proxy::GatewayState {
+        bedrock_client,
+        bedrock_control_client,
+        model_cache: ccag::translate::models::ModelCache::new(),
+        config,
+        key_cache: ccag::auth::KeyCache::new(),
+        rate_limiter: ccag::ratelimit::RateLimiter::new(),
+        idp_validator: Arc::new(ccag::auth::oidc::MultiIdpValidator::new()),
+        db_pool: db_pool.clone(),
+        spend_tracker: Arc::new(ccag::spend::SpendTracker::new(db_pool, metrics.clone())),
+        metrics,
+        virtual_keys_enabled: AtomicBool::new(true),
+        admin_login_enabled: AtomicBool::new(true),
+        cache_version: AtomicI64::new(1),
+        session_token_ttl_hours: AtomicI64::new(24),
+        session_signing_key: signing_key.to_string(),
+        cli_sessions: ccag::api::cli_auth::new_session_store(),
+        setup_tokens: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+        http_client: reqwest::Client::new(),
+        budget_cache: Arc::new(ccag::budget::BudgetSpendCache::new(30)),
+        sns_client: None,
+        eb_client: None,
+        quota_cache: None,
+        aws_config: aws_config.clone(),
+        bedrock_health: tokio::sync::RwLock::new(None),
+        endpoint_pool: Arc::new(ccag::endpoint::EndpointPool::new()),
+        endpoint_stats: Arc::new(ccag::endpoint::stats::EndpointStats::new()),
+        started_at: std::time::Instant::now(),
+        login_attempts: tokio::sync::Mutex::new(Vec::new()),
+        pricing_client: std::sync::Arc::new(aws_sdk_pricing::Client::new(&aws_config)),
+    });
+
+    let router = ccag::api::router(state);
+    (router, admin_token)
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create a DB endpoint and load it into the endpoint pool on `state`.
+//
+// Returns `(endpoint_id, Arc<EndpointClient>)` so tests can inspect the
+// in-memory cache after admin API calls.
+// ---------------------------------------------------------------------------
+
+async fn create_fixture_endpoint(pool: &sqlx::PgPool, name: &str) -> Uuid {
+    db::endpoints::create_endpoint(pool, name, None, None, None, "us-east-1", "us", 0)
+        .await
+        .unwrap_or_else(|e| panic!("create_fixture_endpoint({name}): {e}"))
+        .id
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract the endpoint pool from the running app so tests can inspect
+// the in-memory beta_capabilities cache directly.
+//
+// The `test_app` helper builds a GatewayState with an empty EndpointPool.
+// To make the pool hold a real `EndpointClient` that the handler can look up,
+// we call `load_endpoints` on it after the endpoint is in the DB.
+// ---------------------------------------------------------------------------
+
+async fn build_app_with_endpoint(pool: &sqlx::PgPool, ep_name: &str) -> (axum::Router, String, Uuid, Arc<ccag::proxy::GatewayState>) {
+    use std::sync::atomic::AtomicI64;
+
+    let ep_id = create_fixture_endpoint(pool, ep_name).await;
+
+    let config = ccag::config::GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 9999,
+        admin_username: "admin".to_string(),
+        admin_password: "admin".to_string(),
+        bedrock_routing_prefix: "us".to_string(),
+        database_url: "postgres://test@localhost/test".to_string(),
+        admin_users: vec![],
+        notification_url: None,
+        rds_iam_auth: false,
+        database_host: None,
+        database_port: 5432,
+        database_name: "test".to_string(),
+        database_user: "test".to_string(),
+        pricing_refresh_interval: 86400,
+        pricing_refresh_enabled: true,
+    };
+
+    let signing_key = "test-signing-key-for-integration-tests";
+    let _ = ccag::db::users::create_user(pool, "admin", None, "admin").await;
+    let identity = ccag::auth::oidc::OidcIdentity {
+        sub: "admin".to_string(),
+        email: None,
+        idp_name: "Local".to_string(),
+    };
+    let admin_token = ccag::auth::session::issue(signing_key, &identity, 24);
+
+    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let bedrock_client = aws_sdk_bedrockruntime::Client::new(&aws_config);
+    let bedrock_control_client = aws_sdk_bedrock::Client::new(&aws_config);
+
+    let (metrics, _provider) = ccag::telemetry::Metrics::new(None).unwrap();
+    let metrics = Arc::new(metrics);
+
+    let endpoint_pool = Arc::new(ccag::endpoint::EndpointPool::new());
+
+    // Load the endpoint into the in-memory pool so the handler can find it
+    let endpoints = db::endpoints::get_enabled_endpoints(pool)
+        .await
+        .expect("get_enabled_endpoints");
+    endpoint_pool.load_endpoints(endpoints, &aws_config).await;
+
+    let db_pool = Arc::new(tokio::sync::RwLock::new(pool.clone()));
+    let state = Arc::new(ccag::proxy::GatewayState {
+        bedrock_client,
+        bedrock_control_client,
+        model_cache: ccag::translate::models::ModelCache::new(),
+        config,
+        key_cache: ccag::auth::KeyCache::new(),
+        rate_limiter: ccag::ratelimit::RateLimiter::new(),
+        idp_validator: Arc::new(ccag::auth::oidc::MultiIdpValidator::new()),
+        db_pool: db_pool.clone(),
+        spend_tracker: Arc::new(ccag::spend::SpendTracker::new(db_pool, metrics.clone())),
+        metrics,
+        virtual_keys_enabled: AtomicBool::new(true),
+        admin_login_enabled: AtomicBool::new(true),
+        cache_version: AtomicI64::new(1),
+        session_token_ttl_hours: AtomicI64::new(24),
+        session_signing_key: signing_key.to_string(),
+        cli_sessions: ccag::api::cli_auth::new_session_store(),
+        setup_tokens: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+        http_client: reqwest::Client::new(),
+        budget_cache: Arc::new(ccag::budget::BudgetSpendCache::new(30)),
+        sns_client: None,
+        eb_client: None,
+        quota_cache: None,
+        aws_config: aws_config.clone(),
+        bedrock_health: tokio::sync::RwLock::new(None),
+        endpoint_pool: endpoint_pool.clone(),
+        endpoint_stats: Arc::new(ccag::endpoint::stats::EndpointStats::new()),
+        started_at: std::time::Instant::now(),
+        login_attempts: tokio::sync::Mutex::new(Vec::new()),
+        pricing_client: std::sync::Arc::new(aws_sdk_pricing::Client::new(&aws_config)),
+    });
+
+    let router = ccag::api::router(state.clone());
+    (router, admin_token, ep_id, state)
+}
+
+// ===========================================================================
+// Test 9 — list_returns_all_overrides_admin_only
+// ===========================================================================
+
+#[tokio::test]
+async fn list_returns_all_overrides_admin_only() {
+    let pool = helpers::setup_test_db().await;
+    let (app, admin_token) = test_app(&pool).await;
+
+    let ep_id = create_fixture_endpoint(&pool, "ep-list-auth").await;
+
+    // POST one override via the admin API
+    let body = serde_json::json!({
+        "endpoint_id": ep_id,
+        "profile_id": "us.anthropic.claude-opus-4-7",
+        "beta_name": "context-1m-2025-08-07",
+        "supported": true,
+        "reason": "integration test"
+    });
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/beta-overrides")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "POST /admin/beta-overrides should return 200"
+    );
+
+    // GET /admin/beta-overrides — should return the override
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/admin/beta-overrides")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let resp_body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+    let overrides = json["overrides"].as_array().expect("response must have 'overrides' array");
+    assert_eq!(overrides.len(), 1, "should return 1 override");
+    assert_eq!(overrides[0]["profile_id"], "us.anthropic.claude-opus-4-7");
+    assert_eq!(overrides[0]["beta_name"], "context-1m-2025-08-07");
+    assert_eq!(overrides[0]["supported"], true);
+
+    // Unauthenticated GET must return 401
+    let resp_unauth = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/admin/beta-overrides")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_unauth.status(),
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated GET /admin/beta-overrides must be 401"
+    );
+
+    // Unauthenticated POST must return 401
+    let resp_unauth_post = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/beta-overrides")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp_unauth_post.status(),
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated POST /admin/beta-overrides must be 401"
+    );
+}
+
+// ===========================================================================
+// Test 10 — upsert_creates_db_row_and_caches_in_memory
+// ===========================================================================
+
+#[tokio::test]
+async fn upsert_creates_db_row_and_caches_in_memory() {
+    let pool = helpers::setup_test_db().await;
+    let (app, admin_token, ep_id, state) =
+        build_app_with_endpoint(&pool, "ep-upsert-cache-true").await;
+
+    let profile = "us.anthropic.claude-opus-4-7";
+    let beta = "context-1m-2025-08-07";
+
+    let body = serde_json::json!({
+        "endpoint_id": ep_id,
+        "profile_id": profile,
+        "beta_name": beta,
+        "supported": true,
+        "reason": "force-enable for test"
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/beta-overrides")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK, "upsert should return 200");
+
+    // (a) DB row must exist
+    let db_rows = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .expect("list_for_endpoint");
+    assert_eq!(db_rows.len(), 1, "DB should have exactly one override row");
+    assert!(db_rows[0].supported, "DB row must have supported=true");
+
+    // (b) In-memory cache must reflect the override
+    let client = state
+        .endpoint_pool
+        .get_client(ep_id)
+        .await
+        .expect("endpoint must be in pool");
+
+    let cached = client.is_beta_supported(profile, beta).await;
+    assert_eq!(
+        cached,
+        Some(true),
+        "is_beta_supported must return Some(true) immediately after upsert API call"
+    );
+
+    // (c) The cache entry source must be AdminOverride
+    // We verify via the public interface: AdminOverride entries must ignore TTL.
+    // We can inspect source by reading beta_capabilities directly.
+    {
+        let map = client.beta_capabilities.read().await;
+        let key = (profile.to_string(), beta.to_string());
+        let entry = map
+            .get(&key)
+            .expect("cache entry must exist after admin upsert");
+        assert_eq!(
+            entry.source,
+            ProbeSource::AdminOverride,
+            "cache source must be AdminOverride"
+        );
+        assert!(entry.supported, "cache entry must be supported=true");
+    }
+}
+
+// ===========================================================================
+// Test 11 — upsert_with_supported_false_caches_in_memory_as_false
+// ===========================================================================
+
+#[tokio::test]
+async fn upsert_with_supported_false_caches_in_memory_as_false() {
+    let pool = helpers::setup_test_db().await;
+    let (app, admin_token, ep_id, state) =
+        build_app_with_endpoint(&pool, "ep-upsert-cache-false").await;
+
+    let profile = "us.anthropic.claude-haiku-4-5";
+    let beta = "context-1m-2025-08-07";
+
+    let body = serde_json::json!({
+        "endpoint_id": ep_id,
+        "profile_id": profile,
+        "beta_name": beta,
+        "supported": false,
+        "reason": "force-disable for test"
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/beta-overrides")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK, "upsert supported=false should return 200");
+
+    // DB must have supported=false
+    let db_rows = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .expect("list_for_endpoint");
+    assert_eq!(db_rows.len(), 1);
+    assert!(!db_rows[0].supported, "DB row must have supported=false");
+
+    // In-memory cache must return Some(false)
+    let client = state
+        .endpoint_pool
+        .get_client(ep_id)
+        .await
+        .expect("endpoint must be in pool");
+
+    let cached = client.is_beta_supported(profile, beta).await;
+    assert_eq!(
+        cached,
+        Some(false),
+        "is_beta_supported must return Some(false) for admin-forced unsupported"
+    );
+}
+
+// ===========================================================================
+// Test 12 — upsert_admin_override_wins_over_existing_seedprobe
+// ===========================================================================
+
+#[tokio::test]
+async fn upsert_admin_override_wins_over_existing_seedprobe() {
+    let pool = helpers::setup_test_db().await;
+    let (app, admin_token, ep_id, state) =
+        build_app_with_endpoint(&pool, "ep-override-wins").await;
+
+    let profile = "us.anthropic.claude-opus-4-7";
+    let beta = "context-1m-2025-08-07";
+
+    // Pre-populate the in-memory cache with a SeedProbe entry saying supported=true
+    let client = state
+        .endpoint_pool
+        .get_client(ep_id)
+        .await
+        .expect("endpoint must be in pool");
+    client.mark_supported(profile, beta, ProbeSource::SeedProbe).await;
+
+    // Verify the seed-probe entry is there
+    assert_eq!(
+        client.is_beta_supported(profile, beta).await,
+        Some(true),
+        "sanity: SeedProbe entry should be Some(true)"
+    );
+
+    // Now POST an admin override with supported=false — override must win
+    let body = serde_json::json!({
+        "endpoint_id": ep_id,
+        "profile_id": profile,
+        "beta_name": beta,
+        "supported": false,
+        "reason": "override beats seed probe"
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/beta-overrides")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Admin override (supported=false) must win over the earlier SeedProbe (supported=true)
+    let cached = client.is_beta_supported(profile, beta).await;
+    assert_eq!(
+        cached,
+        Some(false),
+        "AdminOverride(false) must supersede earlier SeedProbe(true)"
+    );
+
+    // Verify source is AdminOverride
+    {
+        let map = client.beta_capabilities.read().await;
+        let key = (profile.to_string(), beta.to_string());
+        let entry = map.get(&key).expect("cache entry must exist");
+        assert_eq!(
+            entry.source,
+            ProbeSource::AdminOverride,
+            "source must be AdminOverride after admin write"
+        );
+    }
+}
+
+// ===========================================================================
+// Test 13 — delete_removes_db_row_and_in_memory_cache
+// ===========================================================================
+
+#[tokio::test]
+async fn delete_removes_db_row_and_in_memory_cache() {
+    let pool = helpers::setup_test_db().await;
+    let (app, admin_token, ep_id, state) =
+        build_app_with_endpoint(&pool, "ep-delete-cache").await;
+
+    let profile = "us.anthropic.claude-opus-4-7";
+    let beta = "context-1m-2025-08-07";
+
+    // First: upsert via POST
+    let upsert_body = serde_json::json!({
+        "endpoint_id": ep_id,
+        "profile_id": profile,
+        "beta_name": beta,
+        "supported": true,
+        "reason": "to be deleted"
+    });
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/beta-overrides")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&upsert_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "upsert before delete should succeed");
+
+    // Verify it's in DB and cache
+    let rows = db::beta_overrides::list_for_endpoint(&pool, ep_id).await.unwrap();
+    assert_eq!(rows.len(), 1, "sanity: DB row exists before delete");
+
+    let client = state
+        .endpoint_pool
+        .get_client(ep_id)
+        .await
+        .expect("endpoint must be in pool");
+    assert_eq!(
+        client.is_beta_supported(profile, beta).await,
+        Some(true),
+        "sanity: cache says Some(true) before delete"
+    );
+
+    // Now: DELETE via admin API
+    // URL encoding: profile_id and beta_name are path segments; they may contain dots
+    // (which are valid in URL paths) but the router must handle them as-is.
+    let delete_uri = format!(
+        "/admin/beta-overrides/{}/{}/{}",
+        ep_id, profile, beta
+    );
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&delete_uri)
+                .header("authorization", format!("Bearer {admin_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "DELETE of existing override should return 200"
+    );
+
+    // DB row must be gone
+    let rows_after = db::beta_overrides::list_for_endpoint(&pool, ep_id).await.unwrap();
+    assert_eq!(rows_after.len(), 0, "DB row must be deleted");
+
+    // In-memory cache must return None (forget_capability removes the entry)
+    let cached_after = client.is_beta_supported(profile, beta).await;
+    assert_eq!(
+        cached_after,
+        None,
+        "is_beta_supported must return None after the override is deleted"
+    );
+}
+
+// ===========================================================================
+// Test 14 — delete_404_for_nonexistent
+// ===========================================================================
+//
+// Design decision: DELETE a nonexistent override → 404.
+// See module-level doc comment for rationale.
+
+#[tokio::test]
+async fn delete_404_for_nonexistent() {
+    let pool = helpers::setup_test_db().await;
+    let (app, admin_token) = test_app(&pool).await;
+
+    let ep_id = create_fixture_endpoint(&pool, "ep-delete-404").await;
+
+    // Attempt to delete an override that was never created
+    let delete_uri = format!(
+        "/admin/beta-overrides/{}/us.anthropic.nonexistent/context-1m-2025-08-07",
+        ep_id
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&delete_uri)
+                .header("authorization", format!("Bearer {admin_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "DELETE of nonexistent override must return 404"
+    );
+
+    // Response body must be structured error JSON, not a plain string
+    let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body)
+        .expect("DELETE 404 response must be valid JSON");
+    assert!(
+        json["error"].is_object(),
+        "DELETE 404 response must have 'error' object, got: {json}"
+    );
+}
+
+// ===========================================================================
+// Test 15 — upsert_validates_endpoint_exists
+// ===========================================================================
+//
+// Design decision: POST with nonexistent endpoint_id → 404.
+// The handler must catch the FK constraint violation from sqlx and convert it
+// to a structured 404 response (not let a 500 bubble up).
+
+#[tokio::test]
+async fn upsert_validates_endpoint_exists() {
+    let pool = helpers::setup_test_db().await;
+    let (app, admin_token) = test_app(&pool).await;
+
+    // Use a random UUID that has no corresponding endpoint row
+    let nonexistent_ep_id = Uuid::new_v4();
+
+    let body = serde_json::json!({
+        "endpoint_id": nonexistent_ep_id,
+        "profile_id": "us.anthropic.claude-opus-4-7",
+        "beta_name": "context-1m-2025-08-07",
+        "supported": true,
+        "reason": "should fail"
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/beta-overrides")
+                .header("authorization", format!("Bearer {admin_token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Must NOT be 500 — FK violations must be surfaced as client errors
+    assert_ne!(
+        resp.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "FK violation on nonexistent endpoint_id must not produce a 500"
+    );
+
+    // Must be 404 (documented design decision above)
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "POST with nonexistent endpoint_id must return 404"
+    );
+
+    // Response body must be structured error JSON
+    let body_bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes)
+        .expect("404 response body must be valid JSON");
+    assert!(
+        json["error"].is_object(),
+        "404 response must contain 'error' object, got: {json}"
+    );
+}
+
+// ===========================================================================
+// Test: forget_capability — EndpointClient method removes cache entry
+//
+// The Builder must add `forget_capability(&self, profile, beta)` to
+// `EndpointClient`. This test validates that method directly (pure in-memory,
+// no HTTP, no DB). It is kept in this file because it is a contract the admin
+// DELETE handler depends on.
+// ===========================================================================
+
+#[tokio::test]
+async fn forget_capability_removes_entry_from_cache() {
+    use ccag::endpoint::EndpointPool;
+
+    // Build a minimal EndpointPool with one client (no DB, no AWS calls)
+    let pool = EndpointPool::new();
+    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+
+    // We need a real Endpoint record to call create_client; use a DB-backed fixture.
+    let db_pool = helpers::setup_test_db().await;
+    let ep = db::endpoints::create_endpoint(
+        &db_pool,
+        "ep-forget",
+        None,
+        None,
+        None,
+        "us-east-1",
+        "us",
+        0,
+    )
+    .await
+    .expect("create endpoint for forget_capability test");
+
+    let endpoints = vec![ep.clone()];
+    pool.load_endpoints(endpoints, &aws_config).await;
+
+    let client = pool
+        .get_client(ep.id)
+        .await
+        .expect("client must be loaded");
+
+    let profile = "us.anthropic.claude-opus-4-7";
+    let beta = "context-1m-2025-08-07";
+
+    // Pre-populate cache
+    client.mark_supported(profile, beta, ProbeSource::AdminOverride).await;
+    assert_eq!(
+        client.is_beta_supported(profile, beta).await,
+        Some(true),
+        "sanity: entry exists before forget_capability"
+    );
+
+    // forget_capability must remove the entry
+    client.forget_capability(profile, beta).await;
+
+    assert_eq!(
+        client.is_beta_supported(profile, beta).await,
+        None,
+        "is_beta_supported must return None after forget_capability"
+    );
+}

--- a/tests/integration/beta_overrides_db_tests.rs
+++ b/tests/integration/beta_overrides_db_tests.rs
@@ -1,0 +1,377 @@
+/// Integration tests for `db::beta_overrides` — CRUD against a real Postgres DB.
+///
+/// The Builder must create:
+///   - `migrations/011_beta_overrides.sql` — the `beta_overrides` table
+///   - `src/db/beta_overrides.rs` — `BetaOverride`, `list_all`, `list_for_endpoint`, `upsert`, `delete`
+///   - `src/db/mod.rs` — `pub mod beta_overrides;`
+///
+/// Test isolation: each test calls `helpers::setup_test_db()`, which creates a
+/// fresh `test_{uuid}` database, runs all migrations (including 011), and returns
+/// a pool. No shared state between tests.
+use chrono::Utc;
+use uuid::Uuid;
+
+use ccag::db;
+use ccag::db::beta_overrides::BetaOverride;
+
+use crate::helpers;
+
+// ---------------------------------------------------------------------------
+// Helper: create a fixture endpoint in the DB
+// ---------------------------------------------------------------------------
+
+async fn create_fixture_endpoint(pool: &sqlx::PgPool, name: &str) -> Uuid {
+    let ep = db::endpoints::create_endpoint(pool, name, None, None, None, "us-east-1", "us", 0)
+        .await
+        .unwrap_or_else(|e| panic!("create_fixture_endpoint({name}): {e}"));
+    ep.id
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build a BetaOverride value for a given endpoint
+// ---------------------------------------------------------------------------
+
+fn make_override(endpoint_id: Uuid, profile_id: &str, beta_name: &str, supported: bool) -> BetaOverride {
+    BetaOverride {
+        endpoint_id,
+        profile_id: profile_id.to_string(),
+        beta_name: beta_name.to_string(),
+        supported,
+        set_at: Utc::now(),
+        set_by: "test-admin".to_string(),
+        reason: Some("test reason".to_string()),
+    }
+}
+
+// ===========================================================================
+// Test 1 — migration_creates_table_with_expected_columns
+// ===========================================================================
+
+#[tokio::test]
+async fn migration_creates_table_with_expected_columns() {
+    let pool = helpers::setup_test_db().await;
+
+    // Query information_schema.columns for the beta_overrides table
+    let columns: Vec<(String, String)> = sqlx::query_as(
+        r#"SELECT column_name, data_type
+           FROM information_schema.columns
+           WHERE table_name = 'beta_overrides'
+           ORDER BY ordinal_position"#,
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("failed to query information_schema.columns");
+
+    // Collect just names for easy assertion
+    let col_names: Vec<&str> = columns.iter().map(|(n, _)| n.as_str()).collect();
+
+    assert!(
+        col_names.contains(&"endpoint_id"),
+        "expected column 'endpoint_id', found: {col_names:?}"
+    );
+    assert!(
+        col_names.contains(&"profile_id"),
+        "expected column 'profile_id', found: {col_names:?}"
+    );
+    assert!(
+        col_names.contains(&"beta_name"),
+        "expected column 'beta_name', found: {col_names:?}"
+    );
+    assert!(
+        col_names.contains(&"supported"),
+        "expected column 'supported', found: {col_names:?}"
+    );
+    assert!(
+        col_names.contains(&"set_at"),
+        "expected column 'set_at', found: {col_names:?}"
+    );
+    assert!(
+        col_names.contains(&"set_by"),
+        "expected column 'set_by', found: {col_names:?}"
+    );
+    assert!(
+        col_names.contains(&"reason"),
+        "expected column 'reason', found: {col_names:?}"
+    );
+
+    // Verify specific types
+    let type_map: std::collections::HashMap<&str, &str> = columns
+        .iter()
+        .map(|(n, t)| (n.as_str(), t.as_str()))
+        .collect();
+
+    assert_eq!(
+        type_map.get("supported"),
+        Some(&"boolean"),
+        "supported must be boolean"
+    );
+    // set_at: Postgres reports TIMESTAMPTZ as "timestamp with time zone"
+    assert_eq!(
+        type_map.get("set_at"),
+        Some(&"timestamp with time zone"),
+        "set_at must be timestamp with time zone"
+    );
+    // endpoint_id: Postgres reports UUID as "uuid"
+    assert_eq!(
+        type_map.get("endpoint_id"),
+        Some(&"uuid"),
+        "endpoint_id must be uuid"
+    );
+}
+
+// ===========================================================================
+// Test 2 — upsert_inserts_new_row
+// ===========================================================================
+
+#[tokio::test]
+async fn upsert_inserts_new_row() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_fixture_endpoint(&pool, "ep-upsert-new").await;
+
+    let ovr = make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true);
+    db::beta_overrides::upsert(&pool, &ovr)
+        .await
+        .expect("upsert should succeed");
+
+    let rows = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .expect("list_for_endpoint should succeed");
+
+    assert_eq!(rows.len(), 1, "expected exactly one row after upsert");
+    assert_eq!(rows[0].endpoint_id, ep_id);
+    assert_eq!(rows[0].profile_id, "us.anthropic.claude-opus-4-7");
+    assert_eq!(rows[0].beta_name, "context-1m-2025-08-07");
+    assert!(rows[0].supported, "supported flag should be true");
+    assert_eq!(rows[0].set_by, "test-admin");
+    assert_eq!(rows[0].reason.as_deref(), Some("test reason"));
+}
+
+// ===========================================================================
+// Test 3 — upsert_overwrites_existing
+// ===========================================================================
+
+#[tokio::test]
+async fn upsert_overwrites_existing() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_fixture_endpoint(&pool, "ep-upsert-overwrite").await;
+
+    // First upsert: supported = true
+    let ovr1 = make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true);
+    db::beta_overrides::upsert(&pool, &ovr1)
+        .await
+        .expect("first upsert should succeed");
+
+    // Second upsert: same PK, supported = false
+    let ovr2 = BetaOverride {
+        supported: false,
+        set_by: "admin-2".to_string(),
+        reason: None,
+        ..make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", false)
+    };
+    db::beta_overrides::upsert(&pool, &ovr2)
+        .await
+        .expect("second upsert should succeed");
+
+    let rows = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .expect("list_for_endpoint should succeed");
+
+    assert_eq!(rows.len(), 1, "upsert should produce exactly one row, not two");
+    assert!(!rows[0].supported, "second upsert (supported=false) must win");
+    assert_eq!(rows[0].set_by, "admin-2", "set_by should be from the second upsert");
+    assert!(rows[0].reason.is_none(), "reason should be None from second upsert");
+}
+
+// ===========================================================================
+// Test 4 — list_all_aggregates_across_endpoints
+// ===========================================================================
+
+#[tokio::test]
+async fn list_all_aggregates_across_endpoints() {
+    let pool = helpers::setup_test_db().await;
+    let ep1 = create_fixture_endpoint(&pool, "ep-list-all-1").await;
+    let ep2 = create_fixture_endpoint(&pool, "ep-list-all-2").await;
+
+    db::beta_overrides::upsert(
+        &pool,
+        &make_override(ep1, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true),
+    )
+    .await
+    .expect("upsert ep1 override");
+
+    db::beta_overrides::upsert(
+        &pool,
+        &make_override(ep2, "eu.anthropic.claude-sonnet-4-7", "interleaved-thinking-2025-05-14", false),
+    )
+    .await
+    .expect("upsert ep2 override");
+
+    let all = db::beta_overrides::list_all(&pool)
+        .await
+        .expect("list_all should succeed");
+
+    assert_eq!(all.len(), 2, "list_all should return overrides for both endpoints");
+
+    let ep1_row = all.iter().find(|r| r.endpoint_id == ep1);
+    let ep2_row = all.iter().find(|r| r.endpoint_id == ep2);
+
+    assert!(ep1_row.is_some(), "list_all should include ep1's override");
+    assert!(ep2_row.is_some(), "list_all should include ep2's override");
+    assert!(ep1_row.unwrap().supported);
+    assert!(!ep2_row.unwrap().supported);
+}
+
+// ===========================================================================
+// Test 5 — delete_removes_specific_row_only
+// ===========================================================================
+
+#[tokio::test]
+async fn delete_removes_specific_row_only() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_fixture_endpoint(&pool, "ep-delete-specific").await;
+
+    // Insert three overrides on the same endpoint, different (profile, beta) tuples
+    let pairs: &[(&str, &str)] = &[
+        ("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07"),
+        ("us.anthropic.claude-sonnet-4-7", "context-1m-2025-08-07"),
+        ("us.anthropic.claude-haiku-4-5", "context-1m-2025-08-07"),
+    ];
+    for (profile, beta) in pairs {
+        db::beta_overrides::upsert(&pool, &make_override(ep_id, profile, beta, true))
+            .await
+            .expect("upsert should succeed");
+    }
+
+    // Delete the middle one
+    let deleted = db::beta_overrides::delete(
+        &pool,
+        ep_id,
+        "us.anthropic.claude-sonnet-4-7",
+        "context-1m-2025-08-07",
+    )
+    .await
+    .expect("delete should succeed");
+
+    assert_eq!(deleted, 1, "delete should report 1 row affected");
+
+    let remaining = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .expect("list_for_endpoint should succeed");
+
+    assert_eq!(remaining.len(), 2, "two overrides should remain after deleting one");
+    let remaining_profiles: Vec<&str> = remaining.iter().map(|r| r.profile_id.as_str()).collect();
+    assert!(
+        remaining_profiles.contains(&"us.anthropic.claude-opus-4-7"),
+        "opus override should remain"
+    );
+    assert!(
+        remaining_profiles.contains(&"us.anthropic.claude-haiku-4-5"),
+        "haiku override should remain"
+    );
+    assert!(
+        !remaining_profiles.contains(&"us.anthropic.claude-sonnet-4-7"),
+        "sonnet override should be deleted"
+    );
+}
+
+// ===========================================================================
+// Test 6 — delete_returns_zero_for_missing_row
+// ===========================================================================
+
+#[tokio::test]
+async fn delete_returns_zero_for_missing_row() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_fixture_endpoint(&pool, "ep-delete-missing").await;
+
+    // Attempt to delete a row that was never inserted
+    let deleted = db::beta_overrides::delete(
+        &pool,
+        ep_id,
+        "us.anthropic.nonexistent-profile",
+        "context-1m-2025-08-07",
+    )
+    .await
+    .expect("delete of missing row should not error");
+
+    assert_eq!(
+        deleted, 0,
+        "delete of a nonexistent override must return 0 rows affected"
+    );
+}
+
+// ===========================================================================
+// Test 7 — cascade_on_endpoint_delete
+// ===========================================================================
+
+#[tokio::test]
+async fn cascade_on_endpoint_delete() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_fixture_endpoint(&pool, "ep-cascade-delete").await;
+
+    // Insert an override for the endpoint
+    db::beta_overrides::upsert(
+        &pool,
+        &make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true),
+    )
+    .await
+    .expect("upsert should succeed before endpoint deletion");
+
+    // Verify it exists
+    let before = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .expect("list before delete");
+    assert_eq!(before.len(), 1, "sanity: override exists before endpoint deletion");
+
+    // Delete the endpoint — should cascade to beta_overrides
+    db::endpoints::delete_endpoint(&pool, ep_id)
+        .await
+        .expect("delete endpoint should succeed");
+
+    // The override row must also be gone (FK ON DELETE CASCADE)
+    let after = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .expect("list after endpoint delete");
+    assert_eq!(
+        after.len(),
+        0,
+        "FK CASCADE must delete the override when the endpoint is deleted"
+    );
+}
+
+// ===========================================================================
+// Test 8 — set_at_defaults_to_now
+// ===========================================================================
+
+#[tokio::test]
+async fn set_at_defaults_to_now() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_fixture_endpoint(&pool, "ep-set-at-default").await;
+
+    let before_insert = Utc::now();
+
+    // The `upsert` implementation may use DEFAULT now() for set_at when the
+    // caller's set_at is close to the current time. We simply pass Utc::now()
+    // and verify the stored value is within ±5 seconds of now.
+    let ovr = make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true);
+    db::beta_overrides::upsert(&pool, &ovr)
+        .await
+        .expect("upsert should succeed");
+
+    let after_insert = Utc::now();
+
+    let rows = db::beta_overrides::list_for_endpoint(&pool, ep_id)
+        .await
+        .expect("list_for_endpoint should succeed");
+
+    assert_eq!(rows.len(), 1);
+    let stored_set_at = rows[0].set_at;
+
+    assert!(
+        stored_set_at >= before_insert - chrono::Duration::seconds(5),
+        "set_at ({stored_set_at}) should be at or after test start ({before_insert})"
+    );
+    assert!(
+        stored_set_at <= after_insert + chrono::Duration::seconds(5),
+        "set_at ({stored_set_at}) should be at or before test end ({after_insert})"
+    );
+}

--- a/tests/integration/beta_overrides_db_tests.rs
+++ b/tests/integration/beta_overrides_db_tests.rs
@@ -31,7 +31,12 @@ async fn create_fixture_endpoint(pool: &sqlx::PgPool, name: &str) -> Uuid {
 // Helper: build a BetaOverride value for a given endpoint
 // ---------------------------------------------------------------------------
 
-fn make_override(endpoint_id: Uuid, profile_id: &str, beta_name: &str, supported: bool) -> BetaOverride {
+fn make_override(
+    endpoint_id: Uuid,
+    profile_id: &str,
+    beta_name: &str,
+    supported: bool,
+) -> BetaOverride {
     BetaOverride {
         endpoint_id,
         profile_id: profile_id.to_string(),
@@ -128,7 +133,12 @@ async fn upsert_inserts_new_row() {
     let pool = helpers::setup_test_db().await;
     let ep_id = create_fixture_endpoint(&pool, "ep-upsert-new").await;
 
-    let ovr = make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true);
+    let ovr = make_override(
+        ep_id,
+        "us.anthropic.claude-opus-4-7",
+        "context-1m-2025-08-07",
+        true,
+    );
     db::beta_overrides::upsert(&pool, &ovr)
         .await
         .expect("upsert should succeed");
@@ -156,7 +166,12 @@ async fn upsert_overwrites_existing() {
     let ep_id = create_fixture_endpoint(&pool, "ep-upsert-overwrite").await;
 
     // First upsert: supported = true
-    let ovr1 = make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true);
+    let ovr1 = make_override(
+        ep_id,
+        "us.anthropic.claude-opus-4-7",
+        "context-1m-2025-08-07",
+        true,
+    );
     db::beta_overrides::upsert(&pool, &ovr1)
         .await
         .expect("first upsert should succeed");
@@ -166,7 +181,12 @@ async fn upsert_overwrites_existing() {
         supported: false,
         set_by: "admin-2".to_string(),
         reason: None,
-        ..make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", false)
+        ..make_override(
+            ep_id,
+            "us.anthropic.claude-opus-4-7",
+            "context-1m-2025-08-07",
+            false,
+        )
     };
     db::beta_overrides::upsert(&pool, &ovr2)
         .await
@@ -176,10 +196,23 @@ async fn upsert_overwrites_existing() {
         .await
         .expect("list_for_endpoint should succeed");
 
-    assert_eq!(rows.len(), 1, "upsert should produce exactly one row, not two");
-    assert!(!rows[0].supported, "second upsert (supported=false) must win");
-    assert_eq!(rows[0].set_by, "admin-2", "set_by should be from the second upsert");
-    assert!(rows[0].reason.is_none(), "reason should be None from second upsert");
+    assert_eq!(
+        rows.len(),
+        1,
+        "upsert should produce exactly one row, not two"
+    );
+    assert!(
+        !rows[0].supported,
+        "second upsert (supported=false) must win"
+    );
+    assert_eq!(
+        rows[0].set_by, "admin-2",
+        "set_by should be from the second upsert"
+    );
+    assert!(
+        rows[0].reason.is_none(),
+        "reason should be None from second upsert"
+    );
 }
 
 // ===========================================================================
@@ -194,14 +227,24 @@ async fn list_all_aggregates_across_endpoints() {
 
     db::beta_overrides::upsert(
         &pool,
-        &make_override(ep1, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true),
+        &make_override(
+            ep1,
+            "us.anthropic.claude-opus-4-7",
+            "context-1m-2025-08-07",
+            true,
+        ),
     )
     .await
     .expect("upsert ep1 override");
 
     db::beta_overrides::upsert(
         &pool,
-        &make_override(ep2, "eu.anthropic.claude-sonnet-4-7", "interleaved-thinking-2025-05-14", false),
+        &make_override(
+            ep2,
+            "eu.anthropic.claude-sonnet-4-7",
+            "interleaved-thinking-2025-05-14",
+            false,
+        ),
     )
     .await
     .expect("upsert ep2 override");
@@ -210,7 +253,11 @@ async fn list_all_aggregates_across_endpoints() {
         .await
         .expect("list_all should succeed");
 
-    assert_eq!(all.len(), 2, "list_all should return overrides for both endpoints");
+    assert_eq!(
+        all.len(),
+        2,
+        "list_all should return overrides for both endpoints"
+    );
 
     let ep1_row = all.iter().find(|r| r.endpoint_id == ep1);
     let ep2_row = all.iter().find(|r| r.endpoint_id == ep2);
@@ -258,7 +305,11 @@ async fn delete_removes_specific_row_only() {
         .await
         .expect("list_for_endpoint should succeed");
 
-    assert_eq!(remaining.len(), 2, "two overrides should remain after deleting one");
+    assert_eq!(
+        remaining.len(),
+        2,
+        "two overrides should remain after deleting one"
+    );
     let remaining_profiles: Vec<&str> = remaining.iter().map(|r| r.profile_id.as_str()).collect();
     assert!(
         remaining_profiles.contains(&"us.anthropic.claude-opus-4-7"),
@@ -311,7 +362,12 @@ async fn cascade_on_endpoint_delete() {
     // Insert an override for the endpoint
     db::beta_overrides::upsert(
         &pool,
-        &make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true),
+        &make_override(
+            ep_id,
+            "us.anthropic.claude-opus-4-7",
+            "context-1m-2025-08-07",
+            true,
+        ),
     )
     .await
     .expect("upsert should succeed before endpoint deletion");
@@ -320,7 +376,11 @@ async fn cascade_on_endpoint_delete() {
     let before = db::beta_overrides::list_for_endpoint(&pool, ep_id)
         .await
         .expect("list before delete");
-    assert_eq!(before.len(), 1, "sanity: override exists before endpoint deletion");
+    assert_eq!(
+        before.len(),
+        1,
+        "sanity: override exists before endpoint deletion"
+    );
 
     // Delete the endpoint — should cascade to beta_overrides
     db::endpoints::delete_endpoint(&pool, ep_id)
@@ -352,7 +412,12 @@ async fn set_at_defaults_to_now() {
     // The `upsert` implementation may use DEFAULT now() for set_at when the
     // caller's set_at is close to the current time. We simply pass Utc::now()
     // and verify the stored value is within ±5 seconds of now.
-    let ovr = make_override(ep_id, "us.anthropic.claude-opus-4-7", "context-1m-2025-08-07", true);
+    let ovr = make_override(
+        ep_id,
+        "us.anthropic.claude-opus-4-7",
+        "context-1m-2025-08-07",
+        true,
+    );
     db::beta_overrides::upsert(&pool, &ovr)
         .await
         .expect("upsert should succeed");

--- a/tests/integration/beta_overrides_replay_tests.rs
+++ b/tests/integration/beta_overrides_replay_tests.rs
@@ -1,0 +1,473 @@
+/// Integration tests for boot-time beta-override replay (Task 8, Layer B).
+///
+/// # Contract for Builder
+///
+/// Implement a public async function:
+///
+/// ```rust
+/// // Location: src/main.rs (or a new module such as src/boot.rs or src/admin_override_replay.rs)
+/// pub async fn apply_overrides_to_pool(
+///     pool: &sqlx::PgPool,
+///     endpoint_pool: &ccag::endpoint::EndpointPool,
+/// ) -> Result<usize, sqlx::Error>;
+/// ```
+///
+/// Semantics:
+/// 1. Load all rows from `beta_overrides` via `db::beta_overrides::list_all(pool)`.
+/// 2. For each row: call `endpoint_pool.get_client(row.endpoint_id)`.
+///    - `Some(client)` → apply the row using `client.mark_supported` or `client.mark_unsupported`
+///      with `ProbeSource::AdminOverride`.
+///    - `None` → skip with `tracing::debug!` (orphan — endpoint not in pool).
+/// 3. Return the count of overrides successfully applied (i.e. where `get_client` returned `Some`).
+///
+/// The function must be `pub` (or `pub(crate)`) and re-exported so this test can call it as
+/// `ccag::apply_overrides_to_pool` or `ccag::boot::apply_overrides_to_pool`, etc.
+/// The exact re-export path is Builder's choice; document it in the PR.
+///
+/// Usage at boot time (Builder wires this into `src/main.rs`):
+/// ```rust
+/// // After load_endpoints completes, before start_cache_poll_loop:
+/// match ccag::apply_overrides_to_pool(&pool, &state.endpoint_pool).await {
+///     Ok(n) => tracing::info!(n, "Replayed beta overrides into pool"),
+///     Err(e) => tracing::warn!(%e, "Failed to replay beta overrides"),
+/// }
+/// ```
+///
+/// Usage in cache-version poll loop (on every bump, full replay; cheap because table is small):
+/// ```rust
+/// match ccag::apply_overrides_to_pool(pool, &state.endpoint_pool).await {
+///     Ok(n) => tracing::debug!(n, "Re-replayed beta overrides after cache version bump"),
+///     Err(e) => tracing::warn!(%e, "Failed to re-replay beta overrides"),
+/// }
+/// ```
+///
+/// Test isolation: each test calls `helpers::setup_test_db()`, which creates a fresh
+/// `test_{uuid}` database and runs all migrations (including `011_beta_overrides.sql`).
+use std::sync::Arc;
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use ccag::db;
+use ccag::db::beta_overrides::BetaOverride;
+use ccag::endpoint::{EndpointPool, ProbeSource};
+
+use crate::helpers;
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+/// Insert a fixture endpoint into the DB and return its UUID.
+async fn create_endpoint(pool: &sqlx::PgPool, name: &str) -> Uuid {
+    db::endpoints::create_endpoint(pool, name, None, None, None, "us-east-1", "us", 0)
+        .await
+        .unwrap_or_else(|e| panic!("create_endpoint({name}): {e}"))
+        .id
+}
+
+/// Insert a `BetaOverride` row directly into the DB.
+async fn insert_override(
+    pool: &sqlx::PgPool,
+    endpoint_id: Uuid,
+    profile_id: &str,
+    beta_name: &str,
+    supported: bool,
+) {
+    let ovr = BetaOverride {
+        endpoint_id,
+        profile_id: profile_id.to_string(),
+        beta_name: beta_name.to_string(),
+        supported,
+        set_at: Utc::now(),
+        set_by: "test-admin".to_string(),
+        reason: Some("replay test".to_string()),
+    };
+    db::beta_overrides::upsert(pool, &ovr)
+        .await
+        .unwrap_or_else(|e| panic!("insert_override: {e}"));
+}
+
+/// Build an `EndpointPool` loaded with the endpoints currently in the DB.
+///
+/// Uses the same helper pattern as `beta_overrides_admin_tests.rs`.
+async fn load_pool(pool: &sqlx::PgPool) -> Arc<EndpointPool> {
+    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let endpoint_pool = Arc::new(EndpointPool::new());
+    let endpoints = db::endpoints::get_enabled_endpoints(pool)
+        .await
+        .expect("get_enabled_endpoints");
+    endpoint_pool.load_endpoints(endpoints, &aws_config).await;
+    endpoint_pool
+}
+
+// ===========================================================================
+// Test 1 — replay_loads_overrides_into_pool
+//
+// DB has 2 endpoints and 3 override rows (2 for endpoint A, 1 for endpoint B).
+// After calling apply_overrides_to_pool:
+// - Returns count == 3 (all 3 rows matched a loaded endpoint).
+// - EndpointClient A has correct values for its 2 overrides.
+// - EndpointClient B has correct value for its 1 override.
+// ===========================================================================
+
+#[tokio::test]
+async fn replay_loads_overrides_into_pool() {
+    let pool = helpers::setup_test_db().await;
+
+    let ep_a = create_endpoint(&pool, "replay-ep-a").await;
+    let ep_b = create_endpoint(&pool, "replay-ep-b").await;
+
+    // 2 overrides for endpoint A
+    insert_override(
+        &pool,
+        ep_a,
+        "us.anthropic.claude-opus-4-7",
+        "context-1m-2025-08-07",
+        true,
+    )
+    .await;
+    insert_override(
+        &pool,
+        ep_a,
+        "us.anthropic.claude-haiku-4-5",
+        "context-1m-2025-08-07",
+        false,
+    )
+    .await;
+    // 1 override for endpoint B
+    insert_override(
+        &pool,
+        ep_b,
+        "us.anthropic.claude-sonnet-4-5",
+        "context-1m-2025-08-07",
+        true,
+    )
+    .await;
+
+    let endpoint_pool = load_pool(&pool).await;
+
+    let count = ccag::apply_overrides_to_pool(&pool, &endpoint_pool)
+        .await
+        .expect("apply_overrides_to_pool must not return an error");
+
+    assert_eq!(
+        count, 3,
+        "all 3 override rows matched a pool endpoint; count must be 3"
+    );
+
+    // Verify endpoint A — opus-4-7 is supported
+    let client_a = endpoint_pool
+        .get_client(ep_a)
+        .await
+        .expect("endpoint A must be in pool");
+    let opus_supported = client_a
+        .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+        .await;
+    assert_eq!(
+        opus_supported,
+        Some(true),
+        "endpoint A / opus-4-7 must have supported=true after replay"
+    );
+
+    // Verify endpoint A — haiku-4-5 is NOT supported
+    let haiku_supported = client_a
+        .is_beta_supported("us.anthropic.claude-haiku-4-5", "context-1m-2025-08-07")
+        .await;
+    assert_eq!(
+        haiku_supported,
+        Some(false),
+        "endpoint A / haiku-4-5 must have supported=false after replay"
+    );
+
+    // Verify endpoint B — sonnet-4-5 is supported
+    let client_b = endpoint_pool
+        .get_client(ep_b)
+        .await
+        .expect("endpoint B must be in pool");
+    let sonnet_supported = client_b
+        .is_beta_supported("us.anthropic.claude-sonnet-4-5", "context-1m-2025-08-07")
+        .await;
+    assert_eq!(
+        sonnet_supported,
+        Some(true),
+        "endpoint B / sonnet-4-5 must have supported=true after replay"
+    );
+}
+
+// ===========================================================================
+// Test 2 — replay_skips_orphan_overrides
+//
+// The pool is loaded with only ONE endpoint (endpoint A).
+// The DB has an override row for a *different* UUID that was NOT loaded into
+// the pool (simulating an incomplete pool-load, e.g. the endpoint was disabled
+// between the DB insert and the pool load).
+//
+// After replay:
+// - count == 1 (only the row for the loaded endpoint was applied).
+// - The orphan row is silently skipped (no panic, no error).
+// ===========================================================================
+
+#[tokio::test]
+async fn replay_skips_orphan_overrides() {
+    let pool = helpers::setup_test_db().await;
+
+    // Create one endpoint that IS in the DB (and will be loaded into the pool)
+    let ep_loaded = create_endpoint(&pool, "replay-loaded").await;
+    // A UUID for an endpoint NOT in the pool (not inserted into the DB as an
+    // endpoint row, so get_client returns None for it)
+    let ep_orphan_not_in_pool = Uuid::new_v4();
+
+    insert_override(
+        &pool,
+        ep_loaded,
+        "us.anthropic.claude-opus-4-7",
+        "context-1m-2025-08-07",
+        true,
+    )
+    .await;
+
+    // Insert an override row with a UUID that has NO corresponding endpoint in the DB.
+    // This bypasses the FK constraint by inserting directly (simulating the scenario
+    // where the endpoint was deleted but the override row was somehow not CASCADE'd, or
+    // the pool was loaded before the FK row was created).
+    //
+    // We use a raw sqlx query here to bypass the FK check (the FK is `ON DELETE CASCADE`,
+    // so normally this can't happen via the application layer — this test verifies the
+    // defensive code path in apply_overrides_to_pool).
+    //
+    // NOTE: If the DB enforces FK strictly (no INSERT possible for nonexistent endpoint_id),
+    // the Builder should mark this test as `#[ignore]` and document why. The behavior
+    // being tested (skip when get_client returns None) is still exercised via the
+    // "pool not yet loaded" scenario: insert the endpoint into DB but do NOT load it
+    // into the pool.
+    let ep_in_db_not_in_pool = create_endpoint(&pool, "replay-not-loaded").await;
+    insert_override(
+        &pool,
+        ep_in_db_not_in_pool,
+        "us.anthropic.claude-sonnet-4-5",
+        "context-1m-2025-08-07",
+        false,
+    )
+    .await;
+
+    // Load only ep_loaded into the pool (NOT ep_in_db_not_in_pool)
+    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let endpoint_pool = Arc::new(EndpointPool::new());
+    let endpoints = db::endpoints::get_enabled_endpoints(&pool)
+        .await
+        .expect("get_enabled_endpoints");
+    // Filter: only load the first endpoint (ep_loaded)
+    let only_loaded: Vec<_> = endpoints
+        .into_iter()
+        .filter(|e| e.id == ep_loaded)
+        .collect();
+    endpoint_pool.load_endpoints(only_loaded, &aws_config).await;
+
+    let count = ccag::apply_overrides_to_pool(&pool, &endpoint_pool)
+        .await
+        .expect("apply_overrides_to_pool must not return an error on orphan rows");
+
+    assert_eq!(
+        count, 1,
+        "only the 1 row for the loaded endpoint should be applied; the orphan row is skipped"
+    );
+
+    // The loaded endpoint's override IS applied
+    let client = endpoint_pool
+        .get_client(ep_loaded)
+        .await
+        .expect("ep_loaded must be in pool");
+    assert_eq!(
+        client
+            .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+            .await,
+        Some(true),
+        "the loaded endpoint's override must be applied"
+    );
+
+    // The not-loaded endpoint is NOT in the pool — verify there's no panic
+    let missing = endpoint_pool.get_client(ep_in_db_not_in_pool).await;
+    assert!(
+        missing.is_none(),
+        "ep_in_db_not_in_pool must not be in the pool"
+    );
+
+    // ep_orphan_not_in_pool was never in DB, so no override row for it either
+    let _ = ep_orphan_not_in_pool; // suppress unused warning
+}
+
+// ===========================================================================
+// Test 3 — replay_admin_override_beats_existing_seedprobe
+//
+// Pre-populate the EndpointClient cache with a SeedProbe entry:
+//   (profile, beta) → supported=true, source=SeedProbe
+//
+// DB has an override row for the same (endpoint, profile, beta) with supported=false.
+//
+// After replay:
+// - is_beta_supported returns Some(false) (AdminOverride wins).
+// - The entry's source is AdminOverride (confirmed indirectly: it must NOT expire
+//   after CAPABILITY_TTL, which SeedProbe entries would — but we verify by checking
+//   that a second call to is_beta_supported still returns Some(false)).
+// ===========================================================================
+
+#[tokio::test]
+async fn replay_admin_override_beats_existing_seedprobe() {
+    let pool = helpers::setup_test_db().await;
+
+    let ep_id = create_endpoint(&pool, "replay-override-beats-seed").await;
+
+    // Pre-populate pool client with a SeedProbe entry saying "supported=true"
+    let endpoint_pool = load_pool(&pool).await;
+    let client = endpoint_pool
+        .get_client(ep_id)
+        .await
+        .expect("endpoint must be in pool");
+    client
+        .mark_supported(
+            "us.anthropic.claude-opus-4-7",
+            "context-1m-2025-08-07",
+            ProbeSource::SeedProbe,
+        )
+        .await;
+
+    // Confirm the seed probe is currently saying supported=true
+    let before = client
+        .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+        .await;
+    assert_eq!(
+        before,
+        Some(true),
+        "seed probe should say Some(true) before replay"
+    );
+
+    // DB has an AdminOverride that says supported=false for the same key
+    insert_override(
+        &pool,
+        ep_id,
+        "us.anthropic.claude-opus-4-7",
+        "context-1m-2025-08-07",
+        false,
+    )
+    .await;
+
+    // Run replay
+    let count = ccag::apply_overrides_to_pool(&pool, &endpoint_pool)
+        .await
+        .expect("apply_overrides_to_pool must not error");
+    assert_eq!(count, 1, "one override row must be applied");
+
+    // AdminOverride must now win: supported=false
+    let after = client
+        .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+        .await;
+    assert_eq!(
+        after,
+        Some(false),
+        "AdminOverride (supported=false) must override the pre-existing SeedProbe (supported=true)"
+    );
+}
+
+// ===========================================================================
+// Test 4 — replay_idempotent_when_called_twice
+//
+// Call apply_overrides_to_pool twice.  Each call must:
+// - Return count == N (same count both times; no accumulation).
+// - Leave the cache in the same state as after one call.
+// ===========================================================================
+
+#[tokio::test]
+async fn replay_idempotent_when_called_twice() {
+    let pool = helpers::setup_test_db().await;
+
+    let ep_id = create_endpoint(&pool, "replay-idempotent").await;
+    insert_override(
+        &pool,
+        ep_id,
+        "us.anthropic.claude-opus-4-7",
+        "context-1m-2025-08-07",
+        true,
+    )
+    .await;
+    insert_override(
+        &pool,
+        ep_id,
+        "us.anthropic.claude-haiku-4-5",
+        "context-1m-2025-08-07",
+        false,
+    )
+    .await;
+
+    let endpoint_pool = load_pool(&pool).await;
+
+    let count1 = ccag::apply_overrides_to_pool(&pool, &endpoint_pool)
+        .await
+        .expect("first apply must not error");
+    assert_eq!(count1, 2, "first replay: count must be 2");
+
+    let count2 = ccag::apply_overrides_to_pool(&pool, &endpoint_pool)
+        .await
+        .expect("second apply must not error");
+    assert_eq!(
+        count2, 2,
+        "second replay: count must still be 2 (idempotent)"
+    );
+
+    // Cache state must be consistent after both calls
+    let client = endpoint_pool
+        .get_client(ep_id)
+        .await
+        .expect("endpoint must be in pool");
+
+    assert_eq!(
+        client
+            .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+            .await,
+        Some(true),
+        "opus-4-7 must be supported=true after two replays"
+    );
+    assert_eq!(
+        client
+            .is_beta_supported("us.anthropic.claude-haiku-4-5", "context-1m-2025-08-07")
+            .await,
+        Some(false),
+        "haiku-4-5 must be supported=false after two replays"
+    );
+}
+
+// ===========================================================================
+// Test 5 — replay_handles_empty_db
+//
+// Fresh DB with no override rows.  apply_overrides_to_pool must:
+// - Return Ok(0) (no rows, no overrides applied).
+// - Not panic or error.
+// ===========================================================================
+
+#[tokio::test]
+async fn replay_handles_empty_db() {
+    let pool = helpers::setup_test_db().await;
+
+    // Create one endpoint so the pool is non-empty (the function must still return 0)
+    let ep_id = create_endpoint(&pool, "replay-empty-db").await;
+    let endpoint_pool = load_pool(&pool).await;
+
+    let count = ccag::apply_overrides_to_pool(&pool, &endpoint_pool)
+        .await
+        .expect("apply_overrides_to_pool must not error on an empty beta_overrides table");
+
+    assert_eq!(count, 0, "no override rows in DB means count must be 0");
+
+    // The endpoint client cache must remain empty
+    let client = endpoint_pool
+        .get_client(ep_id)
+        .await
+        .expect("endpoint must be in pool");
+    let result = client
+        .is_beta_supported("us.anthropic.claude-opus-4-7", "context-1m-2025-08-07")
+        .await;
+    assert!(
+        result.is_none(),
+        "cache must be empty (None) when no overrides were applied; got: {result:?}"
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin_tests;
 pub mod beta_overrides_admin_tests;
 pub mod beta_overrides_db_tests;
+pub mod beta_overrides_replay_tests;
 pub mod budget_tests;
 pub mod db_tests;
 pub mod endpoint_tests;

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,4 +1,6 @@
 pub mod admin_tests;
+pub mod beta_overrides_admin_tests;
+pub mod beta_overrides_db_tests;
 pub mod budget_tests;
 pub mod db_tests;
 pub mod endpoint_tests;


### PR DESCRIPTION
## Summary

Adds end-to-end 1M context window support for Claude Code's `[1m]` model variants, built on a **self-learning per-`(profile, beta)` capability cache** that requires zero CCAG release when Anthropic ships new betas or AWS adds new 1M-capable models.

Spec: `.claude/specs/1m-context-support.md` (gitignored). Resolves the gap where requests opting into 1M via the picker silently got 200K because `src/translate/request.rs` stripped all betas. Bumps to **v1.8.0** (minor — feature).

## Architectural pivot — why this isn't an allowlist

The original design candidate was an "allowlist of one" (`context-1m-2025-08-07`). Rejected because it has the same fragility commit `2c148f2` removed: every Anthropic beta release would require a CCAG binary upgrade, and self-deployers don't update in lockstep. Instead:

- **Per-`(profile, beta)` cache** on each `EndpointClient` — populated by health-loop seed probes (24h TTL), opportunistic learning on successful requests, and **rejection-parsing on Bedrock `ValidationException` with a single retry-without-rejected-beta**.
- The cache learns. New Anthropic beta → first user request, forwarded optimistically, cached. New 1M-capable Bedrock model → seed probe finds it on next health-loop tick, `/v1/models` advertises `[1m]` variant. Bedrock GA-flips a beta → rejection-parse caches `false`, retry once, future requests pre-emptively strip. **No binary release needed for any of these.**
- The only hardcoded artifact is `SUFFIX_BETA_MAP` (one entry today: `[1m] → context-1m-2025-08-07`) — data-shaped, used only for `/v1/models` advertising and seed-probe targeting.

## What's in the PR

| Slice | Commit | What |
|---|---|---|
| T1 | `9505ad6` | `EndpointClient.beta_capabilities` cache + `CapabilityEntry` + `ProbeSource` (SeedProbe / RequestSuccess / RequestRejection / AdminOverride) + accessors |
| T2 | `9505ad6` | Health-loop seed probe (synthetic 1-token InvokeModel + classification) |
| T3 | `a23df87` | Request-path: pass through `req.betas`, cache-aware filter, opportunistic learning on 200, parse-mark-retry on ValidationException |
| T4 | `df546c4` | Generic `[\w+]` suffix stripping in `anthropic_to_bedrock` |
| T5 | `e4197f0` | `/v1/models` emits paired `[1m]` entries from cached capability |
| T6 | `54bc0e7` | `proxy_login.sh` exports `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`; docs updated; stale `CLAUDE.md` "ALLOWLIST approach" line corrected |
| T7 | `a751bb3` | Admin override: `migrations/011_beta_overrides.sql`, `src/db/beta_overrides.rs`, `GET/POST/DELETE /admin/beta-overrides` |
| T8 | `f7c6a47` | `ccag betas list-overrides | override | clear-override` CLI; boot replay before serving traffic; `cache_version` invalidation |
| R1 | `a898e4c` | Review fixups: AdminOverride source guard, web-search retry orchestration, default-client docs gap, public-doc cleanup, cache-Arc preservation across endpoint reloads |
| - | `62bf7a1` | Version bump 1.7.3 → 1.8.0 |

## Test posture

- **449 lib + 242 integration tests green.** Clippy clean.
- **One pre-existing flaky test** (`budget::notifications::tests::deliver_routes_to_webhook`) — confirmed flaky on baseline before this branch (`mock_server` `duration > 0` race when test runs sub-millisecond). Not introduced here.
- **`[env]` fixture for Bedrock `ValidationException` format** is documented in T2/T3 acceptance criteria but pinned with realistic guesses; should be validated against live Bedrock during staging deploy. The `parse_rejected_betas` `candidates` parameter is the safety net — even if the format drifts, only known-incoming betas can be classified as rejected.

## Reviewer findings — addressed

5 reviewers (security, performance, quality, design, docs) ran against the branch. **All blocking findings fixed in `a898e4c`:**

1. `mark_supported`/`mark_unsupported` no longer overwrite `AdminOverride` entries from automatic learning paths (per spec contract).
2. `handle_with_web_search` now receives `BetaRetryContext` and runs the same parse-mark-retry on ValidationException as the non-web-search paths.
3. `docs/configuration.md` now states the multi-endpoint requirement (default Bedrock client doesn't get probed; `[1m]` variants only appear when at least one named endpoint is configured).
4. Removed `"see Tasks 7-8"` (internal spec language) from public docs.
5. `EndpointPool::load_endpoints` now preserves the `Arc<RwLock<...>>` for `beta_capabilities` and `available_models` across endpoint reloads — admin actions no longer wipe learned state.

## Deferred (advisory only — tracked, not blocking)

- Probe-storm jitter at 24h TTL boundary (sequential probes across all profiles can take ~45s; advisable to add ±2h jitter at write time and `MissedTickBehavior::Skip` on the health-loop interval).
- Default Bedrock client probing (`src/main.rs:386` TODO — multi-endpoint deployments work fine; default-only deployments don't probe).
- `/v1/models` capability-topology leakage to unauthenticated callers (pre-existing pattern; flag for operator awareness).
- Test-helper duplication in `endpoint/mod.rs` (~400 lines of `make_test_client` repeated across 8 modules; pre-existing).
- Probe body uses `format!()` rather than `serde_json::json!` (low risk today; betas are well-formed).

## What this PR does NOT do

- No Anthropic-direct fallback (Bedrock-only).
- No persistence of the learned cache to Postgres (only admin overrides persist; learned cache rebuilds within minutes on restart).
- No `count_tokens` changes (verify whether the field flow there inherits from `translate()` — same code path).
- No portal UI for capability overrides (CLI + admin API only for now).
- No 1M-specific cost/budget treatment (1M tokens cost more — spend logs already record actual input tokens; per-request budget enforcement unchanged).

## Test plan

- [ ] CI green (lib + integration + clippy)
- [ ] `/deploy --staging` and verify:
  - [ ] After ~60s, `GET /v1/models` returns `[1m]` variants for capable models on the staging endpoint
  - [ ] CC's `/model` picker shows `Claude Opus 4 7 (1M context)` (or equivalent for whichever model is configured) — confirms `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` wiring works end-to-end
  - [ ] Real Bedrock 1M request through CC succeeds with the beta forwarded (verify via spend log + Bedrock API console)
  - [ ] Capture the actual `ValidationException` string format Bedrock returns when the beta is unsupported on a model — pin as a comment in `src/translate/betas.rs` for the parser fixture
  - [ ] Admin override CLI round-trip: `ccag betas override <ep> <profile> <beta> false` then verify `/v1/models` doesn't advertise that variant; `ccag betas clear-override` restores
- [ ] After staging verification: `/deploy --prod --release` to tag v1.8.0 and ship.