### PR TITLE
feat: per-endpoint per-model AIP overrides (1.8.0)

### DIFF
--- a/cli/src/commands/aip_overrides.rs
+++ b/cli/src/commands/aip_overrides.rs
@@ -1,0 +1,137 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::config::AdminClient;
+
+#[derive(Subcommand)]
+pub enum AipOverridesCommands {
+    /// List all AIP overrides for an endpoint
+    List {
+        /// Endpoint ID
+        endpoint: String,
+    },
+
+    /// Add an AIP override for a specific model on an endpoint
+    Add {
+        /// Endpoint ID
+        endpoint: String,
+
+        /// Model ID (e.g. claude-sonnet-4-5)
+        #[arg(long)]
+        model: String,
+
+        /// Application Inference Profile ARN
+        #[arg(long)]
+        arn: String,
+
+        /// Optional reason for the override
+        #[arg(long)]
+        reason: Option<String>,
+    },
+
+    /// Remove an AIP override for a specific model on an endpoint
+    Remove {
+        /// Endpoint ID
+        endpoint: String,
+
+        /// Model ID
+        #[arg(long)]
+        model: String,
+    },
+}
+
+pub async fn run(
+    cmd: AipOverridesCommands,
+    url: Option<String>,
+    token: Option<String>,
+) -> Result<()> {
+    match cmd {
+        AipOverridesCommands::List { endpoint } => list(endpoint, url, token).await,
+        AipOverridesCommands::Add {
+            endpoint,
+            model,
+            arn,
+            reason,
+        } => add(endpoint, model, arn, reason, url, token).await,
+        AipOverridesCommands::Remove { endpoint, model } => {
+            remove(endpoint, model, url, token).await
+        }
+    }
+}
+
+async fn list(endpoint: String, url: Option<String>, token: Option<String>) -> Result<()> {
+    let client = AdminClient::from_options(url, token).await?;
+    let path = format!("/admin/endpoints/{endpoint}/aip-overrides");
+    let resp = client.get(&path).await?;
+
+    if let Some(overrides) = resp["overrides"].as_array() {
+        if overrides.is_empty() {
+            eprintln!("No AIP overrides found for endpoint {endpoint}.");
+            return Ok(());
+        }
+        eprintln!(
+            "{:<30}  {:<80}  {:<24}  SET-BY",
+            "MODEL", "AIP ARN", "SET AT"
+        );
+        eprintln!("{}", "-".repeat(150));
+        for o in overrides {
+            println!(
+                "{:<30}  {:<80}  {:<24}  {}",
+                o["model_id"].as_str().unwrap_or("-"),
+                o["aip_arn"].as_str().unwrap_or("-"),
+                o["set_at"].as_str().unwrap_or("-"),
+                o["set_by"].as_str().unwrap_or("-"),
+            );
+            if let Some(reason) = o["reason"].as_str() {
+                println!("  reason: {reason}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn add(
+    endpoint: String,
+    model: String,
+    arn: String,
+    reason: Option<String>,
+    url: Option<String>,
+    token: Option<String>,
+) -> Result<()> {
+    let client = AdminClient::from_options(url, token).await?;
+    let path = format!("/admin/endpoints/{endpoint}/aip-overrides");
+
+    let mut body = serde_json::json!({
+        "model_id": model,
+        "aip_arn": arn,
+    });
+    if let Some(r) = reason {
+        body["reason"] = serde_json::Value::String(r);
+    }
+
+    let resp = client.post(&path, &body).await?;
+    let model_id = resp["model_id"].as_str().unwrap_or(&model);
+    crate::util::success(&format!(
+        "AIP override added: {model_id} on endpoint {endpoint}"
+    ));
+
+    Ok(())
+}
+
+async fn remove(
+    endpoint: String,
+    model: String,
+    url: Option<String>,
+    token: Option<String>,
+) -> Result<()> {
+    let client = AdminClient::from_options(url, token).await?;
+    let path = format!("/admin/endpoints/{endpoint}/aip-overrides/{model}");
+
+    client.delete(&path).await?;
+    crate::util::success(&format!(
+        "AIP override removed: {model} from endpoint {endpoint}"
+    ));
+
+    Ok(())
+}

--- a/cli/src/commands/endpoints.rs
+++ b/cli/src/commands/endpoints.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::Subcommand;
 
+use crate::commands::aip_overrides::{AipOverridesCommands, run as aip_overrides_run};
 use crate::config::AdminClient;
 use crate::util;
 
@@ -101,9 +102,18 @@ pub enum EndpointsCommands {
         /// Endpoint ID
         id: String,
     },
+
+    /// Manage per-model Application Inference Profile overrides
+    #[command(subcommand)]
+    AipOverrides(AipOverridesCommands),
 }
 
 pub async fn run(cmd: EndpointsCommands, url: Option<String>, token: Option<String>) -> Result<()> {
+    // AipOverrides is delegated to its own module before building AdminClient.
+    if let EndpointsCommands::AipOverrides(sub) = cmd {
+        return aip_overrides_run(sub, url, token).await;
+    }
+
     let client = AdminClient::from_options(url, token).await?;
 
     match cmd {
@@ -154,6 +164,11 @@ pub async fn run(cmd: EndpointsCommands, url: Option<String>, token: Option<Stri
             inference_profile_arn,
             priority,
         } => {
+            if inference_profile_arn.is_some() {
+                crate::util::warn(
+                    "--inference-profile-arn is deprecated. Use: ccag endpoints aip-overrides add <endpoint> --model <model> --arn <arn>",
+                );
+            }
             let mut body = serde_json::json!({
                 "name": name,
                 "region": region,
@@ -263,6 +278,615 @@ pub async fn run(cmd: EndpointsCommands, url: Option<String>, token: Option<Stri
                 }
             }
         }
+
+        EndpointsCommands::AipOverrides(_) => unreachable!("handled above"),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Contract tests for Task 8: `ccag endpoints aip-overrides` subcommands.
+    //!
+    //! Tests are expected RED until the builder implements
+    //! `cli/src/commands/aip_overrides.rs`.
+    //!
+    //! Mocking strategy: a minimal single-use HTTP server running in a
+    //! background thread using only `std::net::TcpListener`.  No extra
+    //! dependencies required — `tokio` and `reqwest` are already in
+    //! `cli/Cargo.toml`.
+    //!
+    //! Contracts covered:
+    //!  1  – aip-overrides list happy path
+    //!  2  – aip-overrides list empty
+    //!  3  – aip-overrides add happy path (without reason)
+    //!  3b – aip-overrides add with --reason
+    //!  4  – aip-overrides add 409 conflict
+    //!  5  – aip-overrides add 400 bad request
+    //!  6  – aip-overrides remove happy path
+    //!  7  – aip-overrides remove 404
+    //!  8  – legacy --inference-profile-arn exits Ok
+    //!  8b – deprecation message format snapshot
+    //!  9  – legacy flag: stdout clean (deprecation note goes to stderr only)
+
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    // Contracts 1-7 import from the future aip_overrides module.
+    // These will fail to compile until the builder creates the module — that
+    // is the intended red state.
+    use super::super::aip_overrides::{AipOverridesCommands, run as aip_run};
+
+    const ENDPOINT_ID: &str = "11111111-1111-1111-1111-111111111111";
+    const TOKEN: &str = "test-token";
+
+    // ─── Minimal mock HTTP server ─────────────────────────────────────────────
+    //
+    // `MockServer::start(response_body, status_code)` binds to a random
+    // ephemeral port, serves exactly one request with the given response, and
+    // returns the base URL.  The server runs in a background thread so async
+    // tests can proceed.
+    //
+    // `CapturedRequest` holds the method, path, and body of the request that
+    // was received, so tests can assert on what the CLI sent.
+
+    #[derive(Debug, Default)]
+    struct CapturedRequest {
+        method: String,
+        path: String,
+        body: String,
+        auth_header: String,
+    }
+
+    /// Spawn a single-shot HTTP server.  Returns `(base_url, captured)`.
+    /// The server serves the given response once, then exits.
+    fn spawn_mock_server(
+        status: u16,
+        response_body: &str,
+    ) -> (String, Arc<Mutex<Option<CapturedRequest>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        let url = format!("http://127.0.0.1:{port}");
+
+        let body = response_body.to_string();
+        let captured: Arc<Mutex<Option<CapturedRequest>>> = Arc::new(Mutex::new(None));
+        let captured_clone = Arc::clone(&captured);
+
+        std::thread::spawn(move || {
+            // Accept one connection
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut raw = Vec::new();
+                let mut buf = [0u8; 4096];
+                // Read until we have the full HTTP request (crude but sufficient
+                // for testing — we always send JSON bodies < 4096 bytes).
+                if let Ok(n) = stream.read(&mut buf) {
+                    raw.extend_from_slice(&buf[..n]);
+                }
+
+                let req_str = String::from_utf8_lossy(&raw).into_owned();
+                let mut lines = req_str.lines();
+                let request_line = lines.next().unwrap_or("").to_string();
+                let mut parts = request_line.splitn(3, ' ');
+                let method = parts.next().unwrap_or("").to_string();
+                let path = parts.next().unwrap_or("").to_string();
+
+                let mut auth_header = String::new();
+                let mut content_length: usize = 0;
+                for line in &mut lines {
+                    if line.is_empty() {
+                        break;
+                    }
+                    let lower = line.to_lowercase();
+                    if lower.starts_with("authorization:") {
+                        auth_header = line[14..].trim().to_string();
+                    }
+                    if lower.starts_with("content-length:") {
+                        content_length = line[15..].trim().parse().unwrap_or(0);
+                    }
+                }
+
+                // Body follows the blank line
+                let body_start = req_str
+                    .find("\r\n\r\n")
+                    .map(|i| i + 4)
+                    .or_else(|| req_str.find("\n\n").map(|i| i + 2))
+                    .unwrap_or(req_str.len());
+                let req_body = if content_length > 0 && body_start < req_str.len() {
+                    req_str[body_start..].to_string()
+                } else {
+                    String::new()
+                };
+
+                *captured_clone.lock().unwrap() = Some(CapturedRequest {
+                    method,
+                    path,
+                    body: req_body,
+                    auth_header,
+                });
+
+                let reason = match status {
+                    200 => "OK",
+                    201 => "Created",
+                    400 => "Bad Request",
+                    404 => "Not Found",
+                    409 => "Conflict",
+                    _ => "Unknown",
+                };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                    body.len(),
+                    body,
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        (url, captured)
+    }
+
+    fn url(base: &str) -> Option<String> {
+        Some(base.to_string())
+    }
+    fn token() -> Option<String> {
+        Some(TOKEN.to_string())
+    }
+
+    // ─── Contract 1: aip-overrides list happy path ───────────────────────────
+
+    #[tokio::test]
+    async fn test_aip_overrides_list_happy_path() {
+        let body = serde_json::json!({
+            "overrides": [
+                {
+                    "model_id": "claude-sonnet-4-5",
+                    "aip_arn": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged",
+                    "set_at": "2026-06-06T12:00:00Z",
+                    "set_by": "admin",
+                    "reason": "cost tagging"
+                },
+                {
+                    "model_id": "claude-opus-4-7",
+                    "aip_arn": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-tagged",
+                    "set_at": "2026-06-06T12:01:00Z",
+                    "set_by": "admin",
+                    "reason": null
+                }
+            ]
+        })
+        .to_string();
+
+        let (base_url, captured) = spawn_mock_server(200, &body);
+
+        let cmd = AipOverridesCommands::List {
+            endpoint: ENDPOINT_ID.to_string(),
+        };
+
+        let result = aip_run(cmd, url(&base_url), token()).await;
+        assert!(result.is_ok(), "list happy path must succeed: {result:?}");
+
+        let req = captured.lock().unwrap();
+        let req = req.as_ref().expect("server must have received a request");
+        assert_eq!(req.method, "GET", "must use GET");
+        assert!(
+            req.path.contains(ENDPOINT_ID),
+            "path must contain endpoint id, got: {}",
+            req.path
+        );
+        assert!(
+            req.path.ends_with("/aip-overrides"),
+            "path must end with /aip-overrides, got: {}",
+            req.path
+        );
+        assert!(
+            req.auth_header.contains(TOKEN),
+            "must send Bearer token, got: {}",
+            req.auth_header
+        );
+    }
+
+    // ─── Contract 2: aip-overrides list empty ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_aip_overrides_list_empty() {
+        let body = serde_json::json!({ "overrides": [] }).to_string();
+        let (base_url, _captured) = spawn_mock_server(200, &body);
+
+        let cmd = AipOverridesCommands::List {
+            endpoint: ENDPOINT_ID.to_string(),
+        };
+
+        let result = aip_run(cmd, url(&base_url), token()).await;
+        assert!(
+            result.is_ok(),
+            "empty list must still exit Ok (no error): {result:?}"
+        );
+    }
+
+    // ─── Contract 3: aip-overrides add happy path ────────────────────────────
+
+    #[tokio::test]
+    async fn test_aip_overrides_add_happy_path() {
+        let model_id = "claude-sonnet-4-5";
+        let aip_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged";
+
+        let response_body = serde_json::json!({
+            "model_id": model_id,
+            "aip_arn": aip_arn,
+            "set_at": "2026-06-06T12:00:00Z",
+            "set_by": "admin"
+        })
+        .to_string();
+
+        let (base_url, captured) = spawn_mock_server(201, &response_body);
+
+        let cmd = AipOverridesCommands::Add {
+            endpoint: ENDPOINT_ID.to_string(),
+            model: model_id.to_string(),
+            arn: aip_arn.to_string(),
+            reason: None,
+        };
+
+        let result = aip_run(cmd, url(&base_url), token()).await;
+        assert!(result.is_ok(), "add happy path must succeed: {result:?}");
+
+        let req = captured.lock().unwrap();
+        let req = req.as_ref().expect("server must have received a request");
+        assert_eq!(req.method, "POST", "must use POST");
+        assert!(
+            req.path.contains(ENDPOINT_ID),
+            "path must contain endpoint id"
+        );
+        assert!(
+            req.path.ends_with("/aip-overrides"),
+            "path must end with /aip-overrides"
+        );
+
+        // Request body must contain model_id and aip_arn
+        let sent: serde_json::Value =
+            serde_json::from_str(&req.body).expect("request body must be valid JSON");
+        assert_eq!(
+            sent["model_id"].as_str(),
+            Some(model_id),
+            "model_id must be in request body"
+        );
+        assert_eq!(
+            sent["aip_arn"].as_str(),
+            Some(aip_arn),
+            "aip_arn must be in request body"
+        );
+        // reason must NOT be present when not supplied
+        assert!(
+            sent.get("reason").map(|v| v.is_null()).unwrap_or(true),
+            "reason must be absent or null when not provided"
+        );
+    }
+
+    // ─── Contract 3b: aip-overrides add with reason ──────────────────────────
+
+    #[tokio::test]
+    async fn test_aip_overrides_add_with_reason() {
+        let model_id = "claude-opus-4-7";
+        let aip_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-tagged";
+        let reason = "ops team cost allocation";
+
+        let response_body = serde_json::json!({
+            "model_id": model_id,
+            "aip_arn": aip_arn,
+            "set_at": "2026-06-06T12:02:00Z",
+            "set_by": "admin",
+            "reason": reason
+        })
+        .to_string();
+
+        let (base_url, captured) = spawn_mock_server(201, &response_body);
+
+        let cmd = AipOverridesCommands::Add {
+            endpoint: ENDPOINT_ID.to_string(),
+            model: model_id.to_string(),
+            arn: aip_arn.to_string(),
+            reason: Some(reason.to_string()),
+        };
+
+        let result = aip_run(cmd, url(&base_url), token()).await;
+        assert!(result.is_ok(), "add with reason must succeed: {result:?}");
+
+        let req = captured.lock().unwrap();
+        let req = req.as_ref().expect("server must have received a request");
+        let sent: serde_json::Value =
+            serde_json::from_str(&req.body).expect("request body must be valid JSON");
+        assert_eq!(
+            sent["reason"].as_str(),
+            Some(reason),
+            "reason must be included in request body"
+        );
+    }
+
+    // ─── Contract 4: aip-overrides add 409 conflict ──────────────────────────
+
+    #[tokio::test]
+    async fn test_aip_overrides_add_conflict_409() {
+        let response_body = serde_json::json!({
+            "error": {
+                "type": "conflict",
+                "message": "override already exists for model claude-sonnet-4-5"
+            }
+        })
+        .to_string();
+
+        let (base_url, _captured) = spawn_mock_server(409, &response_body);
+
+        let cmd = AipOverridesCommands::Add {
+            endpoint: ENDPOINT_ID.to_string(),
+            model: "claude-sonnet-4-5".to_string(),
+            arn: "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/x"
+                .to_string(),
+            reason: None,
+        };
+
+        let result = aip_run(cmd, url(&base_url), token()).await;
+        assert!(
+            result.is_err(),
+            "409 must cause non-zero exit (Err), got Ok"
+        );
+
+        let err_msg = format!("{:?}", result.unwrap_err());
+        let conflict_indicated = err_msg.contains("409")
+            || err_msg.to_lowercase().contains("conflict")
+            || err_msg.to_lowercase().contains("already exists");
+        assert!(
+            conflict_indicated,
+            "error must indicate a conflict (got: {err_msg})"
+        );
+    }
+
+    // ─── Contract 5: aip-overrides add 400 bad request ───────────────────────
+
+    #[tokio::test]
+    async fn test_aip_overrides_add_bad_request_400() {
+        let response_body = serde_json::json!({
+            "error": {
+                "type": "validation_error",
+                "message": "aip_arn does not match expected ARN format"
+            }
+        })
+        .to_string();
+
+        let (base_url, _captured) = spawn_mock_server(400, &response_body);
+
+        let cmd = AipOverridesCommands::Add {
+            endpoint: ENDPOINT_ID.to_string(),
+            model: "claude-sonnet-4-5".to_string(),
+            arn: "not-a-valid-arn".to_string(),
+            reason: None,
+        };
+
+        let result = aip_run(cmd, url(&base_url), token()).await;
+        assert!(
+            result.is_err(),
+            "400 must cause non-zero exit (Err), got Ok"
+        );
+
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("400"),
+            "error must mention 400 status (got: {err_msg})"
+        );
+    }
+
+    // ─── Contract 6: aip-overrides remove happy path ─────────────────────────
+
+    #[tokio::test]
+    async fn test_aip_overrides_remove_happy_path() {
+        let model_id = "claude-sonnet-4-5";
+
+        let response_body = serde_json::json!({ "deleted": true }).to_string();
+        let (base_url, captured) = spawn_mock_server(200, &response_body);
+
+        let cmd = AipOverridesCommands::Remove {
+            endpoint: ENDPOINT_ID.to_string(),
+            model: model_id.to_string(),
+        };
+
+        let result = aip_run(cmd, url(&base_url), token()).await;
+        assert!(result.is_ok(), "remove happy path must succeed: {result:?}");
+
+        let req = captured.lock().unwrap();
+        let req = req.as_ref().expect("server must have received a request");
+        assert_eq!(req.method, "DELETE", "must use DELETE");
+        assert!(
+            req.path.ends_with(model_id),
+            "DELETE path must end with model_id, got: {}",
+            req.path
+        );
+        assert!(
+            req.path.contains(ENDPOINT_ID),
+            "DELETE path must contain endpoint id"
+        );
+    }
+
+    // ─── Contract 7: aip-overrides remove 404 ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_aip_overrides_remove_not_found_404() {
+        let response_body = serde_json::json!({
+            "error": {
+                "type": "not_found",
+                "message": "no override found for model claude-opus-4-7 on this endpoint"
+            }
+        })
+        .to_string();
+
+        let (base_url, _captured) = spawn_mock_server(404, &response_body);
+
+        let cmd = AipOverridesCommands::Remove {
+            endpoint: ENDPOINT_ID.to_string(),
+            model: "claude-opus-4-7".to_string(),
+        };
+
+        let result = aip_run(cmd, url(&base_url), token()).await;
+        assert!(
+            result.is_err(),
+            "404 must cause non-zero exit (Err), got Ok"
+        );
+
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("404"),
+            "error must mention 404 status (got: {err_msg})"
+        );
+    }
+
+    // ─── Contract 8: legacy --inference-profile-arn exits Ok ─────────────────
+    //
+    // `ccag endpoints create --inference-profile-arn <arn>` must:
+    //   (a) call POST /admin/endpoints as today
+    //   (b) exit Ok (zero exit code)
+    //   (c) emit a deprecation note to stderr (validated by contracts 8b + 9)
+
+    #[tokio::test]
+    async fn test_legacy_inference_profile_arn_exits_ok() {
+        let endpoint_name = "test-endpoint";
+        let inference_profile_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged";
+
+        let response_body = serde_json::json!({
+            "id": ENDPOINT_ID,
+            "name": endpoint_name,
+            "region": "us-east-1",
+            "routing_prefix": "us",
+            "inference_profile_arn": inference_profile_arn,
+            "enabled": true
+        })
+        .to_string();
+
+        let (base_url, captured) = spawn_mock_server(201, &response_body);
+
+        let cmd = EndpointsCommands::Create {
+            name: endpoint_name.to_string(),
+            region: "us-east-1".to_string(),
+            routing_prefix: "us".to_string(),
+            role_arn: None,
+            external_id: None,
+            inference_profile_arn: Some(inference_profile_arn.to_string()),
+            priority: None,
+        };
+
+        let result = run(cmd, url(&base_url), token()).await;
+        assert!(
+            result.is_ok(),
+            "legacy --inference-profile-arn must exit Ok: {result:?}"
+        );
+
+        let req = captured.lock().unwrap();
+        let req = req.as_ref().expect("server must have received a request");
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.path, "/admin/endpoints");
+
+        // Verify the ARN was forwarded in the request body
+        let sent: serde_json::Value =
+            serde_json::from_str(&req.body).expect("request body must be valid JSON");
+        assert_eq!(
+            sent["inference_profile_arn"].as_str(),
+            Some(inference_profile_arn),
+            "inference_profile_arn must be forwarded to the API"
+        );
+    }
+
+    // ─── Contract 8b: deprecation message format snapshot ────────────────────
+    //
+    // The builder must emit EXACTLY this format to stderr when
+    // --inference-profile-arn is supplied:
+    //
+    //   "[!!] --inference-profile-arn is deprecated. Use: ccag endpoints aip-overrides add <endpoint> --model <model> --arn <arn>"
+    //
+    // This constant is the canonical snapshot.  If the format is changed,
+    // this test must be updated first.
+
+    #[test]
+    fn test_legacy_deprecation_message_format_snapshot() {
+        // The exact string the builder must emit (via `crate::util::warn` or
+        // equivalent) to stderr when `--inference-profile-arn` is provided.
+        //
+        // `crate::util::warn` formats as:
+        //   "\x1b[33m[!!]\x1b[0m {msg}"
+        //
+        // So the full stderr line (with ANSI stripped) must match:
+        //   "[!!] --inference-profile-arn is deprecated. Use: ccag endpoints aip-overrides add <endpoint> --model <model> --arn <arn>"
+        //
+        // We validate the semantic content here; the builder owns the exact
+        // ANSI formatting.
+        let expected_msg = "--inference-profile-arn is deprecated. Use: ccag endpoints aip-overrides add <endpoint> --model <model> --arn <arn>";
+
+        // Snapshot checks
+        assert!(
+            expected_msg.contains("--inference-profile-arn is deprecated"),
+            "must name the deprecated flag"
+        );
+        assert!(
+            expected_msg.contains("ccag endpoints aip-overrides add"),
+            "must point at the replacement subcommand"
+        );
+        assert!(
+            expected_msg.contains("--model"),
+            "replacement hint must include --model flag"
+        );
+        assert!(
+            expected_msg.contains("--arn"),
+            "replacement hint must include --arn flag"
+        );
+    }
+
+    // ─── Contract 9: stdout clean when legacy flag used ───────────────────────
+    //
+    // The deprecation note must NOT appear on stdout — only stderr.
+    // `util::warn` already uses `eprintln!`, so using it satisfies this.
+    //
+    // We verify indirectly: the request body sent to the server must not
+    // contain the deprecation string (guards against accidental stdout
+    // pollution in the request payload).
+
+    #[tokio::test]
+    async fn test_legacy_flag_request_body_clean() {
+        let endpoint_name = "another-endpoint";
+        let inference_profile_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/haiku-tagged";
+
+        let response_body = serde_json::json!({
+            "id": "22222222-2222-2222-2222-222222222222",
+            "name": endpoint_name,
+            "region": "us-east-1",
+            "routing_prefix": "us",
+            "inference_profile_arn": inference_profile_arn,
+            "enabled": true
+        })
+        .to_string();
+
+        let (base_url, captured) = spawn_mock_server(201, &response_body);
+
+        let cmd = EndpointsCommands::Create {
+            name: endpoint_name.to_string(),
+            region: "us-east-1".to_string(),
+            routing_prefix: "us".to_string(),
+            role_arn: None,
+            external_id: None,
+            inference_profile_arn: Some(inference_profile_arn.to_string()),
+            priority: None,
+        };
+
+        let result = run(cmd, url(&base_url), token()).await;
+        assert!(result.is_ok(), "must exit Ok: {result:?}");
+
+        let req = captured.lock().unwrap();
+        let req = req.as_ref().expect("server must have received a request");
+        // The HTTP request body to the admin API must not contain the
+        // deprecation text (it belongs on stderr only).
+        assert!(
+            !req.body.contains("deprecated"),
+            "request body must not contain 'deprecated' — deprecation note belongs on stderr only"
+        );
+    }
 }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod aip_overrides;
 pub mod betas;
 pub mod config;
 pub mod endpoints;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,7 @@ CCAG supports Claude Code's 1M-context model variants via the `[1m]` suffix conv
 |---|---|---|
 | `PRICING_REFRESH_INTERVAL` | `86400` | Seconds between automatic refreshes of model pricing from the AWS Price List API (default 86400 = 24 hours). |
 | `PRICING_REFRESH_ENABLED` | `true` | Set to `false` or `0` to disable the automatic pricing refresh background loop. Useful when AWS credentials lack Pricing API access or for air-gapped environments. |
+| `CAPABILITY_PROBE_AIP` | `true` | Set to `false` to skip seed-probe invocations against AIP-mapped profiles (saves AIP throttle quota); CRI-backed profiles are still probed. Can also be toggled at runtime via the `capability_probe_aip` key in `proxy_settings`. |
 
 ### Infrastructure Alarms
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,7 +131,18 @@ CCAG supports Claude Code's 1M-context model variants via the `[1m]` suffix conv
 
 **No operator maintenance.** Self-deployers do not need a new CCAG binary release when Anthropic ships a new beta header that Bedrock accepts, or when AWS launches a new 1M-capable Claude model. The health-loop probe and rejection-learning paths handle both cases automatically.
 
+### Capability probes on AIP-mapped models
 
+When an endpoint has [AIP overrides](endpoints.md#aip-overrides) configured, the health loop's seed probes extend to AIP-mapped model entries by default (`CAPABILITY_PROBE_AIP=true`). Each AIP-mapped `(endpoint, profile, beta)` pair receives the same synthetic probe as a CRI-backed profile: approximately 50 input tokens, ≤5 output tokens, once per `CAPABILITY_TTL` (24 hours). Probes from the health-loop are separate from `GetInferenceProfile` calls (which are control-plane and always run regardless of this setting).
+
+**When to disable (`CAPABILITY_PROBE_AIP=false`):** operators using AIPs for strict cost attribution who do not want synthetic-probe spend appearing against tagged AIP profiles. Set the env var at deploy time or toggle `capability_probe_aip` in `proxy_settings` at runtime (no restart needed).
+
+**Consequences of disabling:** the capability cache for AIP-mapped entries stays empty until rejection-learning populates it from real traffic. As a result:
+
+- `/v1/models` does not emit beta-suffixed variants (e.g., `claude-sonnet-4-5[1m]`) for AIP-only models on this endpoint until the first real request triggers learning.
+- The first user request for an unsupported beta absorbs one round-trip penalty (Bedrock rejects, the gateway strips the beta and retries). Subsequent requests for that `(profile, beta)` pair use the cached result.
+
+**Pre-populating the cache manually:** operators who disable probing can force capability flags via `ccag betas override <endpoint-id> <profile-id> <beta-name> true|false [--reason "..."]`. Admin overrides ignore TTL and survive restarts.
 
 ### Pricing
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -24,26 +24,17 @@ curl -X POST https://ccag.example.com/admin/endpoints \
   }'
 ```
 
-### Routing Target
+### Cross-Region Inference (default)
 
-Each endpoint uses one of two routing modes:
+An endpoint is a **deployment target**: an AWS account, region, credential set, and routing scope. By default, all model requests route via Bedrock's cross-region inference (CRI) — Bedrock selects the nearest healthy region within the chosen geographic scope and invokes the appropriate system inference profile (e.g., `us.anthropic.claude-sonnet-4-5-20250929-v1:0`). No additional configuration is needed.
 
-**Cross-region inference** (default): Bedrock routes the request to the nearest healthy region within the chosen geographic scope (US, EU, APAC, etc.) using system-defined inference profiles. Set the `region` (API connection region) and `routing_prefix`.
+### AIP Overrides
 
-**Application inference profile**: Invokes a specific profile ARN directly. Use this for custom profiles with cost-tracking tags, custom throttle limits, or cross-account access granted via a resource policy on the inference profile.
+Application Inference Profiles (AIPs) let you attach cost-allocation tags, custom throttle limits, or cross-account resource policies to specific model invocations. In CCAG, AIPs are configured **per-model** on each endpoint via the `endpoint_aip_overrides` table. Each override row maps a logical model (e.g., `claude-sonnet-4-5`) to a specific AIP ARN. Models without an override fall through to the CRI path automatically.
 
-```bash
-curl -X POST https://ccag.example.com/admin/endpoints \
-  -H "authorization: Bearer $TOKEN" \
-  -H "content-type: application/json" \
-  -d '{
-    "name": "Tagged Profile",
-    "region": "us-west-2",
-    "routing_prefix": "us",
-    "inference_profile_arn": "arn:aws:bedrock:us-west-2:123456789012:inference-profile/my-profile",
-    "priority": 0
-  }'
-```
+This means one endpoint can cover many models: some tagged via AIP, others served by CRI, all from the same AWS credentials.
+
+See [AIP Overrides](#aip-overrides-1) below for the management API and a worked example.
 
 ### Geographic Scope
 
@@ -56,8 +47,7 @@ The `routing_prefix` determines which cross-region inference scope Bedrock uses:
 | `apac` | Asia Pacific | Tokyo, Mumbai, Singapore, Seoul, Osaka |
 | `au` | Australia | Sydney, Melbourne |
 | `us-gov` | GovCloud | GovCloud West, GovCloud East |
-
-Global scope (all participating regions) is available through application inference profiles.
+| `global` | All participating regions | Managed by Bedrock; use with CRI only |
 
 ### Credentials
 
@@ -90,6 +80,7 @@ The endpoint's credentials (gateway role or assumed role) need:
 | `bedrock:InvokeModel` | Yes | Inference |
 | `bedrock:InvokeModelWithResponseStream` | Yes | Streaming inference |
 | `bedrock:ListInferenceProfiles` | Yes | Model discovery and health checks |
+| `bedrock:GetInferenceProfile` | Yes (AIP endpoints) | AIP health checks and auto-migration |
 | `servicequotas:ListServiceQuotas` | No | Quota visibility in the admin portal |
 
 Example policy:
@@ -103,7 +94,8 @@ Example policy:
       "Action": [
         "bedrock:InvokeModel",
         "bedrock:InvokeModelWithResponseStream",
-        "bedrock:ListInferenceProfiles"
+        "bedrock:ListInferenceProfiles",
+        "bedrock:GetInferenceProfile"
       ],
       "Resource": "*"
     },
@@ -133,6 +125,127 @@ For cross-account access, the target account's role trust policy must trust the 
   ]
 }
 ```
+
+## AIP Overrides
+
+### Worked Example: Tagging Sonnet and Opus on One Endpoint
+
+Create the endpoint (no `inference_profile_arn` needed):
+
+```bash
+curl -X POST https://ccag.example.com/admin/endpoints \
+  -H "authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "US Production",
+    "region": "us-east-1",
+    "routing_prefix": "us",
+    "priority": 0,
+    "enabled": true
+  }'
+# {"id": "11111111-1111-1111-1111-111111111111", "name": "US Production", ...}
+```
+
+Add a Sonnet AIP override:
+
+```bash
+curl -X POST https://ccag.example.com/admin/endpoints/11111111-1111-1111-1111-111111111111/aip-overrides \
+  -H "authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{
+    "model_id": "claude-sonnet-4-5",
+    "aip_arn": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123sonnet",
+    "reason": "cost allocation tag: team=platform"
+  }'
+# {"endpoint_id": "11111111-...", "model_id": "claude-sonnet-4-5", "aip_arn": "arn:aws:bedrock:...", "set_by": "admin", ...}
+```
+
+Add an Opus AIP override:
+
+```bash
+curl -X POST https://ccag.example.com/admin/endpoints/11111111-1111-1111-1111-111111111111/aip-overrides \
+  -H "authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{
+    "model_id": "claude-opus-4-5",
+    "aip_arn": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/def456opus",
+    "reason": "cost allocation tag: team=platform"
+  }'
+```
+
+After both are configured, `GET /admin/endpoints/{id}` returns:
+
+```json
+{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "name": "US Production",
+  "region": "us-east-1",
+  "routing_prefix": "us",
+  "inference_profile_arn": null,
+  "aip_overrides": [
+    {
+      "model_id": "claude-sonnet-4-5",
+      "aip_arn": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123sonnet",
+      "set_by": "admin",
+      "reason": "cost allocation tag: team=platform"
+    },
+    {
+      "model_id": "claude-opus-4-5",
+      "aip_arn": "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/def456opus",
+      "set_by": "admin",
+      "reason": "cost allocation tag: team=platform"
+    }
+  ],
+  "health_status": "healthy"
+}
+```
+
+**Request routing for this endpoint:**
+
+| Requested model | Invocation target | Reason |
+|---|---|---|
+| `claude-sonnet-4-5` | `arn:aws:bedrock:...:application-inference-profile/abc123sonnet` | AIP override match |
+| `claude-opus-4-5` | `arn:aws:bedrock:...:application-inference-profile/def456opus` | AIP override match |
+| `claude-haiku-4-5` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | No override → CRI |
+
+Haiku has no override configured, so the gateway falls through to the system CRI profile for the endpoint's `routing_prefix`. No configuration needed for Haiku — it just works.
+
+### Managing AIP Overrides
+
+**List overrides for an endpoint:**
+
+```bash
+curl https://ccag.example.com/admin/endpoints/{id}/aip-overrides \
+  -H "authorization: Bearer $TOKEN"
+```
+
+**Add or update an override (`model_id` is the upsert key):**
+
+```bash
+curl -X POST https://ccag.example.com/admin/endpoints/{id}/aip-overrides \
+  -H "authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"model_id": "claude-sonnet-4-5", "aip_arn": "arn:aws:bedrock:...:application-inference-profile/abc123", "reason": "..."}'
+```
+
+**Remove an override:**
+
+```bash
+curl -X DELETE https://ccag.example.com/admin/endpoints/{id}/aip-overrides/claude-sonnet-4-5 \
+  -H "authorization: Bearer $TOKEN"
+```
+
+CLI equivalents:
+
+```bash
+ccag endpoints aip-overrides list <endpoint-name-or-id>
+ccag endpoints aip-overrides add <endpoint-name-or-id> --model claude-sonnet-4-5 --arn arn:aws:bedrock:... [--reason "..."]
+ccag endpoints aip-overrides remove <endpoint-name-or-id> claude-sonnet-4-5
+```
+
+### Backwards Compatibility
+
+The `inference_profile_arn` field on `POST /admin/endpoints` continues to work for one release cycle. When set, CCAG automatically creates a single `aip_overrides` row (using `GetInferenceProfile` to identify the underlying model) and returns the response with both `aip_overrides: [...]` and `inference_profile_arn` populated, plus `Deprecation: true` and `Sunset` response headers (RFC 8594). Migrate to the `aip-overrides` endpoints for new tooling.
 
 ## Assigning Endpoints to Teams
 
@@ -188,10 +301,12 @@ On first startup with no endpoints configured, CCAG auto-creates one from the ga
 
 CCAG health-checks every enabled endpoint every 60 seconds:
 
-- Endpoints with an `inference_profile_arn`: calls `GetInferenceProfile` with that ARN
-- Other endpoints: calls `ListInferenceProfiles` (validates credentials and region reachability)
+1. **CRI check:** calls `ListInferenceProfiles` to validate credentials and discover available models. Profiles matching the endpoint's `routing_prefix` are added to `available_models`.
+2. **AIP override check:** for each row in `endpoint_aip_overrides`, calls `GetInferenceProfile` to verify the AIP is reachable and reads its underlying foundation model. The resolved model ID is added to `available_models`.
 
-Unhealthy endpoints are excluded from routing. When an endpoint recovers, CCAG pre-warms its quota cache.
+The endpoint is marked **healthy** only if both steps succeed. A single unresolvable AIP ARN marks the entire endpoint unhealthy until the override is corrected or removed.
+
+`available_models` is the deduplicated union from both steps. This union feeds the model-availability check on each request (`filter_by_model`) and the 1M-context capability-probe loop.
 
 Health status is visible in the portal and the list endpoints API:
 
@@ -231,6 +346,34 @@ CCAG tracks per-endpoint statistics over a 1-hour rolling window:
 
 These are visible in the admin portal's endpoint list. Stats are observational and do not affect routing decisions.
 
+## Migration from a Pre-1.8.0 Release
+
+**Zero operator action required.** On first startup after upgrading to 1.8.0, CCAG runs an auto-migration for every endpoint that has a legacy `inference_profile_arn` populated and no rows yet in `endpoint_aip_overrides`:
+
+1. Calls `GetInferenceProfile` on the legacy ARN.
+2. Parses the underlying foundation model from the ARN tail.
+3. Inserts an `endpoint_aip_overrides` row with `set_by = "auto-migration"`.
+4. Leaves the legacy `inference_profile_arn` column intact for one release.
+
+If `GetInferenceProfile` fails (transient credential issue, AIP deleted), startup still completes and the endpoint continues to serve traffic via the legacy code path. The migration retries on the next restart.
+
+**Verifying the migration:**
+
+```bash
+# CLI
+ccag endpoints aip-overrides list <endpoint-name>
+
+# API
+curl https://ccag.example.com/admin/endpoints/{id} \
+  -H "authorization: Bearer $TOKEN"
+# Look for "aip_overrides": [...] and "inference_profile_arn": "<legacy-arn>"
+# Both will be populated immediately after the migration.
+```
+
+**Behaviour change to be aware of:** before 1.8.0, an endpoint with `inference_profile_arn` set would route **every** request through that ARN regardless of which model the client requested (silent substitution). After the auto-migration, only the specific model the AIP is tagged with routes through the AIP; other models route via CRI.
+
+If you relied on the old "force every request through one AIP regardless of model" behaviour, replicate it by adding an AIP override row for each model you want to tag. To keep the exact old behaviour for a single-model AIP, no action is needed — the auto-migrated row handles it.
+
 ## API Reference
 
 | Method | Path | Description |
@@ -242,6 +385,9 @@ These are visible in the admin portal's endpoint list. Stats are observational a
 | `PUT` | `/admin/endpoints/{id}/default` | Set as default endpoint |
 | `GET` | `/admin/endpoints/{id}/quotas` | Get Bedrock service quotas |
 | `GET` | `/admin/endpoints/{id}/models` | List available inference profiles |
+| `GET` | `/admin/endpoints/{id}/aip-overrides` | List AIP overrides for an endpoint |
+| `POST` | `/admin/endpoints/{id}/aip-overrides` | Add or update an AIP override |
+| `DELETE` | `/admin/endpoints/{id}/aip-overrides/{model_id}` | Remove an AIP override |
 | `GET` | `/admin/teams/{team_id}/endpoints` | Get team endpoint assignments and routing strategy |
 | `PUT` | `/admin/teams/{team_id}/endpoints` | Set team endpoint assignments and routing strategy |
 

--- a/migrations/012_endpoint_aip_overrides.sql
+++ b/migrations/012_endpoint_aip_overrides.sql
@@ -1,0 +1,14 @@
+-- Per-endpoint AIP override map.
+-- Each row says "on this endpoint, when a user requests this model, invoke it
+-- via this Application Inference Profile ARN."  Models without a row fall
+-- through to the existing CRI path.
+
+CREATE TABLE IF NOT EXISTS endpoint_aip_overrides (
+    endpoint_id UUID        NOT NULL REFERENCES endpoints(id) ON DELETE CASCADE,
+    model_id    TEXT        NOT NULL,
+    aip_arn     TEXT        NOT NULL,
+    set_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    set_by      TEXT        NOT NULL,
+    reason      TEXT,
+    PRIMARY KEY (endpoint_id, model_id)
+);

--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -14,6 +14,21 @@ use crate::auth::CachedKey;
 use crate::db;
 use crate::proxy::GatewayState;
 
+// ── Deprecation header constants (Slice 3 backwards-compat shim) ─────────────
+
+/// Value of the `Deprecation` response header per RFC 8594.
+const DEPRECATION_HEADER_VALUE: &str = "true";
+
+/// Value of the `Sunset` response header — one minor release ahead (2027-01-01).
+const SUNSET_HEADER_VALUE: &str = "Wed, 01 Jan 2027 00:00:00 GMT";
+
+/// Value written to `set_by` for override rows auto-inserted by the compat shim.
+const COMPAT_SHIM_SET_BY: &str = "compat-shim-on-create";
+
+/// Reason string stored in override rows written by the compat shim.
+const COMPAT_SHIM_REASON: &str =
+    "compat shim from POST /admin/endpoints inference_profile_arn field";
+
 /// Format an AWS SDK error into a clean, user-facing message.
 /// Extracts the service error code + message when available; falls back to
 /// a human-readable description for dispatch/credentials failures.
@@ -2172,6 +2187,45 @@ pub async fn list_endpoints(
     }
 }
 
+/// Injectable helper for the compat shim: calls `get_foundation_model(legacy_arn)`
+/// and inserts one row into `endpoint_aip_overrides` with
+/// `set_by = "compat-shim-on-create"`.
+///
+/// Returns `Ok(model_id)` on success, `Err(reason)` on any failure.  The caller
+/// (`create_endpoint`) should log the error as a warning and continue — the
+/// endpoint creation itself is never rolled back.
+///
+/// The closure-based seam mirrors `migrate_legacy_aip_endpoints` in
+/// `src/migrations/aip_legacy.rs` and allows the integration test suite to
+/// inject a mock without real Bedrock credentials.
+pub async fn try_create_compat_override<F, Fut>(
+    endpoint_id: uuid::Uuid,
+    legacy_arn: &str,
+    pool: &sqlx::PgPool,
+    get_foundation_model: F,
+) -> Result<String, String>
+where
+    F: Fn(&str) -> Fut + Send + Sync,
+    Fut: std::future::Future<Output = Result<String, String>> + Send,
+{
+    // Resolve the Anthropic logical model ID via the injected closure.
+    let model_id = get_foundation_model(legacy_arn).await?;
+
+    // Insert the override row.
+    crate::db::endpoint_aip_overrides::insert(
+        pool,
+        endpoint_id,
+        &model_id,
+        legacy_arn,
+        COMPAT_SHIM_SET_BY,
+        Some(COMPAT_SHIM_REASON),
+    )
+    .await
+    .map_err(|e| format!("DB insert failed: {e}"))?;
+
+    Ok(model_id)
+}
+
 #[derive(Deserialize)]
 pub struct CreateEndpointRequest {
     pub name: String,
@@ -2195,7 +2249,7 @@ pub async fn create_endpoint(
     let pool = state.db().await;
     let pool = &pool;
 
-    match db::endpoints::create_endpoint(
+    let endpoint = match db::endpoints::create_endpoint(
         pool,
         &body.name,
         body.role_arn.as_deref(),
@@ -2207,19 +2261,190 @@ pub async fn create_endpoint(
     )
     .await
     {
-        Ok(endpoint) => {
-            tracing::info!(id = %endpoint.id, name = %endpoint.name, "Created endpoint");
-            // Reload endpoints into pool
-            if let Ok(endpoints) = db::endpoints::get_enabled_endpoints(pool).await {
-                state
-                    .endpoint_pool
-                    .load_endpoints(endpoints, &state.aws_config)
-                    .await;
+        Ok(ep) => ep,
+        Err(e) => return admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    tracing::info!(id = %endpoint.id, name = %endpoint.name, "Created endpoint");
+
+    // ── Compat shim: if inference_profile_arn was supplied, try to auto-insert
+    // an aip_overrides row so new API clients get the richer shape immediately.
+    let mut aip_overrides: Vec<crate::db::endpoint_aip_overrides::AipOverride> = Vec::new();
+    let has_legacy_arn = body.inference_profile_arn.is_some();
+
+    if let Some(ref legacy_arn) = body.inference_profile_arn {
+        let control_client = state.bedrock_control_client.clone();
+        let model_cache = state.model_cache.clone();
+        let arn_owned = legacy_arn.clone();
+
+        let get_foundation_model = move |_arn: &str| {
+            let control = control_client.clone();
+            let mc = model_cache.clone();
+            let arn2 = arn_owned.clone();
+            async move {
+                let resp = control
+                    .get_inference_profile()
+                    .inference_profile_identifier(&arn2)
+                    .send()
+                    .await
+                    .map_err(|e| format!("GetInferenceProfile failed for {arn2}: {e:?}"))?;
+
+                let fm_arn = resp
+                    .models()
+                    .iter()
+                    .next()
+                    .and_then(|m| m.model_arn())
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| {
+                        format!("GetInferenceProfile returned no model ARN for {arn2}")
+                    })?;
+
+                let tail = crate::translate::models::parse_foundation_model_from_arn(&fm_arn)?;
+                let anthropic_id = crate::translate::models::bedrock_to_anthropic(tail, Some(&mc));
+                Ok(anthropic_id)
             }
-            (StatusCode::CREATED, Json(json!(endpoint))).into_response()
+        };
+
+        match try_create_compat_override(endpoint.id, legacy_arn, pool, get_foundation_model).await
+        {
+            Ok(model_id) => {
+                tracing::info!(
+                    endpoint_id = %endpoint.id,
+                    model_id = %model_id,
+                    "Compat shim auto-inserted AIP override row"
+                );
+                let _ = db::settings::bump_cache_version(pool).await;
+                // Reload overrides for response body
+                if let Ok(rows) =
+                    db::endpoint_aip_overrides::list_by_endpoint(pool, endpoint.id).await
+                {
+                    aip_overrides = rows;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    endpoint_id = %endpoint.id,
+                    error = %e,
+                    "Compat shim failed to insert AIP override row — auto-migration retries at next startup"
+                );
+                // Endpoint creation is not rolled back; aip_overrides stays empty.
+            }
         }
-        Err(e) => admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
     }
+
+    // Reload endpoints into pool
+    if let Ok(endpoints) = db::endpoints::get_enabled_endpoints(pool).await {
+        state
+            .endpoint_pool
+            .load_endpoints_with_db(endpoints, &state.aws_config, pool)
+            .await;
+    }
+
+    // Build response: always include aip_overrides array and inference_profile_arn.
+    let mut resp_headers = axum::http::HeaderMap::new();
+    if has_legacy_arn {
+        resp_headers.insert(
+            "deprecation",
+            axum::http::HeaderValue::from_static(DEPRECATION_HEADER_VALUE),
+        );
+        resp_headers.insert(
+            "sunset",
+            axum::http::HeaderValue::from_static(SUNSET_HEADER_VALUE),
+        );
+    }
+
+    let body_json = json!({
+        "id": endpoint.id,
+        "name": endpoint.name,
+        "role_arn": endpoint.role_arn,
+        "external_id": endpoint.external_id,
+        "inference_profile_arn": endpoint.inference_profile_arn,
+        "region": endpoint.region,
+        "routing_prefix": endpoint.routing_prefix,
+        "priority": endpoint.priority,
+        "is_default": endpoint.is_default,
+        "enabled": endpoint.enabled,
+        "created_at": endpoint.created_at,
+        "aip_overrides": aip_overrides,
+    });
+
+    (StatusCode::CREATED, resp_headers, Json(body_json)).into_response()
+}
+
+/// GET /admin/endpoints/{id}
+///
+/// Returns the endpoint row enriched with:
+/// - `aip_overrides: [...]` — always present, possibly empty.
+/// - `inference_profile_arn` — derived as follows:
+///   - exactly one override row → that row's `aip_arn`
+///   - zero rows + legacy column non-null → legacy column value
+///   - otherwise → null
+///
+/// Adds `Deprecation` and `Sunset` headers when `inference_profile_arn` is
+/// non-null in the response.
+pub async fn get_endpoint_by_id(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Path(endpoint_id): Path<Uuid>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+    let pool = &pool;
+
+    let endpoint = match db::endpoints::get_endpoint(pool, endpoint_id).await {
+        Ok(Some(ep)) => ep,
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "Endpoint not found"),
+        Err(e) => return admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    let aip_overrides = match db::endpoint_aip_overrides::list_by_endpoint(pool, endpoint_id).await
+    {
+        Ok(rows) => rows,
+        Err(e) => return admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+
+    // Determine the legacy-compat `inference_profile_arn` field value:
+    //   - exactly 1 override row → that row's aip_arn
+    //   - 0 rows + legacy column non-null → legacy column
+    //   - otherwise → null
+    let legacy_ipa: Option<String> = if aip_overrides.len() == 1 {
+        Some(aip_overrides[0].aip_arn.clone())
+    } else if aip_overrides.is_empty() {
+        endpoint.inference_profile_arn.clone()
+    } else {
+        None
+    };
+
+    let mut resp_headers = axum::http::HeaderMap::new();
+    if legacy_ipa.is_some() {
+        resp_headers.insert(
+            "deprecation",
+            axum::http::HeaderValue::from_static(DEPRECATION_HEADER_VALUE),
+        );
+        resp_headers.insert(
+            "sunset",
+            axum::http::HeaderValue::from_static(SUNSET_HEADER_VALUE),
+        );
+    }
+
+    let body_json = json!({
+        "id": endpoint.id,
+        "name": endpoint.name,
+        "role_arn": endpoint.role_arn,
+        "external_id": endpoint.external_id,
+        "inference_profile_arn": legacy_ipa,
+        "region": endpoint.region,
+        "routing_prefix": endpoint.routing_prefix,
+        "priority": endpoint.priority,
+        "is_default": endpoint.is_default,
+        "enabled": endpoint.enabled,
+        "created_at": endpoint.created_at,
+        "aip_overrides": aip_overrides,
+    });
+
+    (StatusCode::OK, resp_headers, Json(body_json)).into_response()
 }
 
 #[derive(Deserialize)]
@@ -2268,7 +2493,7 @@ pub async fn update_endpoint(
             if let Ok(endpoints) = db::endpoints::get_enabled_endpoints(pool).await {
                 state
                     .endpoint_pool
-                    .load_endpoints(endpoints, &state.aws_config)
+                    .load_endpoints_with_db(endpoints, &state.aws_config, pool)
                     .await;
             }
             Json(json!({ "updated": true })).into_response()
@@ -2296,7 +2521,7 @@ pub async fn delete_endpoint(
             if let Ok(endpoints) = db::endpoints::get_enabled_endpoints(pool).await {
                 state
                     .endpoint_pool
-                    .load_endpoints(endpoints, &state.aws_config)
+                    .load_endpoints_with_db(endpoints, &state.aws_config, pool)
                     .await;
             }
             Json(json!({ "deleted": true })).into_response()
@@ -2384,7 +2609,7 @@ pub async fn set_team_endpoints(
             if let Ok(all_endpoints) = db::endpoints::list_endpoints(pool).await {
                 state
                     .endpoint_pool
-                    .load_endpoints(all_endpoints, &state.aws_config)
+                    .load_endpoints_with_db(all_endpoints, &state.aws_config, pool)
                     .await;
             }
             Json(json!({ "updated": true })).into_response()
@@ -2410,7 +2635,7 @@ pub async fn set_default_endpoint(
             if let Ok(all_endpoints) = db::endpoints::list_endpoints(pool).await {
                 state
                     .endpoint_pool
-                    .load_endpoints(all_endpoints, &state.aws_config)
+                    .load_endpoints_with_db(all_endpoints, &state.aws_config, pool)
                     .await;
             }
             Json(json!({ "updated": true })).into_response()
@@ -4186,6 +4411,174 @@ pub async fn delete_beta_override(
                 client.forget_capability(&profile_id, &beta_name).await;
             }
             // Bump cache_version so other gateway replicas evict the override within 5s.
+            let _ = db::settings::bump_cache_version(pool).await;
+            Json(json!({ "deleted": true })).into_response()
+        }
+        Err(e) => admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
+// ============================================================
+// AIP Overrides Admin API
+// ============================================================
+
+#[derive(Deserialize)]
+pub struct CreateAipOverrideRequest {
+    /// The Anthropic model ID (e.g. `claude-sonnet-4-5`). Required.
+    pub model_id: Option<String>,
+    /// An ARN starting with `arn:aws:bedrock:`. Required.
+    pub aip_arn: Option<String>,
+    /// Optional human-readable note.
+    pub reason: Option<String>,
+}
+
+/// GET /admin/endpoints/{id}/aip-overrides
+pub async fn list_aip_overrides(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Path(endpoint_id): Path<Uuid>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+    let pool = &pool;
+
+    // 404 if endpoint doesn't exist
+    match db::endpoints::get_endpoint(pool, endpoint_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "Endpoint not found"),
+        Err(e) => return admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+
+    match db::endpoint_aip_overrides::list_by_endpoint(pool, endpoint_id).await {
+        Ok(rows) => Json(json!({ "overrides": rows })).into_response(),
+        Err(e) => admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
+/// POST /admin/endpoints/{id}/aip-overrides
+pub async fn create_aip_override(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Path(endpoint_id): Path<Uuid>,
+    Json(body): Json<CreateAipOverrideRequest>,
+) -> Response {
+    let admin_sub = match check_admin_auth_identity(&headers, &state).await {
+        Ok(sub) => sub,
+        Err(resp) => return resp,
+    };
+    let pool = state.db().await;
+    let pool = &pool;
+
+    // Validate model_id is present
+    let model_id = match body.model_id.as_deref().filter(|s| !s.is_empty()) {
+        Some(m) => m.to_string(),
+        None => return error_response(StatusCode::BAD_REQUEST, "model_id is required"),
+    };
+
+    // Validate AIP ARN
+    let aip_arn = match body.aip_arn.as_deref() {
+        Some(arn) if arn.starts_with("arn:aws:bedrock:") => arn.to_string(),
+        Some(_) | None => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "aip_arn must start with arn:aws:bedrock:",
+            );
+        }
+    };
+
+    // 404 if endpoint doesn't exist
+    match db::endpoints::get_endpoint(pool, endpoint_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "Endpoint not found"),
+        Err(e) => return admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+
+    match db::endpoint_aip_overrides::insert(
+        pool,
+        endpoint_id,
+        &model_id,
+        &aip_arn,
+        &admin_sub,
+        body.reason.as_deref(),
+    )
+    .await
+    {
+        Ok(()) => {
+            let _ = db::settings::bump_cache_version(pool).await;
+            // Echo back the inserted row by fetching it
+            match db::endpoint_aip_overrides::list_by_endpoint(pool, endpoint_id).await {
+                Ok(rows) => {
+                    if let Some(row) = rows.into_iter().find(|r| r.model_id == model_id) {
+                        (StatusCode::CREATED, Json(json!(row))).into_response()
+                    } else {
+                        (
+                            StatusCode::CREATED,
+                            Json(json!({ "model_id": model_id, "aip_arn": aip_arn })),
+                        )
+                            .into_response()
+                    }
+                }
+                Err(_) => (
+                    StatusCode::CREATED,
+                    Json(json!({ "model_id": model_id, "aip_arn": aip_arn })),
+                )
+                    .into_response(),
+            }
+        }
+        Err(e) => {
+            // Detect Postgres PK violation (SQLSTATE 23505) → 409 Conflict
+            if let Some(db_err) = e.downcast_ref::<sqlx::Error>()
+                && let sqlx::Error::Database(dbe) = db_err
+                && dbe.code().as_deref() == Some("23505")
+            {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(json!({
+                        "type": "error",
+                        "error": {
+                            "type": "conflict",
+                            "message": "An AIP override for this (endpoint_id, model_id) pair already exists"
+                        }
+                    })),
+                )
+                    .into_response();
+            }
+            admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string())
+        }
+    }
+}
+
+/// DELETE /admin/endpoints/{id}/aip-overrides/{model_id}
+pub async fn delete_aip_override(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Path((endpoint_id, model_id)): Path<(Uuid, String)>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+    let pool = &pool;
+
+    // 404 if endpoint doesn't exist
+    match db::endpoints::get_endpoint(pool, endpoint_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return error_response(StatusCode::NOT_FOUND, "Endpoint not found"),
+        Err(e) => return admin_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+
+    match db::endpoint_aip_overrides::delete_by_model(pool, endpoint_id, &model_id).await {
+        Ok(1) => {
+            let _ = db::settings::bump_cache_version(pool).await;
+            Json(json!({ "deleted": true })).into_response()
+        }
+        Ok(0) => error_response(
+            StatusCode::NOT_FOUND,
+            "AIP override not found for this model",
+        ),
+        Ok(_) => {
             let _ = db::settings::bump_cache_version(pool).await;
             Json(json!({ "deleted": true })).into_response()
         }

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -677,14 +677,32 @@ pub async fn messages(
         &websearch_mode,
     );
 
-    // If the endpoint has an application inference profile ARN configured, use it directly
-    // as the model ID — overrides the prefix-based cross-region inference profile.
-    if let Some(profile_arn) = selected_endpoint
-        .as_ref()
-        .and_then(|ep| ep.config.inference_profile_arn.as_deref())
-    {
-        bedrock_model = profile_arn.to_string();
-    } else {
+    // Resolve the dispatch target using the four-case AIP precedence chain:
+    //   1. New AIP override table has a row for this model → use that ARN.
+    //   2. New table has rows for other models but not this one → CRI unchanged (no substitution).
+    //   3. New table empty + legacy column set → force-substitute legacy ARN (compat).
+    //   4. New table empty + legacy column null → pure CRI unchanged.
+    let resolved = resolve_dispatch_target(
+        &bedrock_model,
+        &original_model,
+        selected_endpoint
+            .as_ref()
+            .and_then(|ep| ep.aip_override_for(&original_model)),
+        selected_endpoint
+            .as_ref()
+            .is_some_and(|ep| ep.has_any_aip_overrides()),
+        selected_endpoint
+            .as_ref()
+            .and_then(|ep| ep.config.inference_profile_arn.as_deref()),
+    );
+
+    // If we substituted (AIP override or legacy ARN), bedrock_model is now an ARN — skip discovery.
+    // If we didn't substitute (cases 2 and 4), bedrock_model is the CRI form — discovery-on-miss
+    // may still need to run.
+    let substituted = resolved != bedrock_model;
+    bedrock_model = resolved;
+
+    if !substituted {
         // Discovery-on-miss: if the model wasn't resolved (no dot = no prefix match),
         // try discovering it via ListInferenceProfiles.
         let control_client = selected_endpoint
@@ -4497,5 +4515,314 @@ mod tests_t5_suffix_variants {
             "last_id must be null for empty response; got: {:?}",
             json["last_id"]
         );
+    }
+}
+
+/// Resolve the final Bedrock model ID / ARN to use for dispatching a request.
+///
+/// Implements the four-case precedence chain from §Slice 2:
+/// 1. New AIP override table has a row for this model → use that ARN (per-model routing).
+/// 2. New table has rows for other models but not this one → fall through to CRI unchanged
+///    (no silent substitution — let discovery-on-miss handle unknown models).
+/// 3. New table empty + legacy column set → force-substitute the legacy ARN (compat net).
+/// 4. New table empty + legacy column null → pure CRI, return unchanged.
+pub fn resolve_dispatch_target(
+    cri_bedrock_model: &str,
+    _original_model: &str,
+    aip_override: Option<&str>,
+    has_any_aip_overrides: bool,
+    legacy_inference_profile_arn: Option<&str>,
+) -> String {
+    if let Some(arn) = aip_override {
+        // Case 1: new table has a row for this model.
+        return arn.to_string();
+    }
+    if has_any_aip_overrides {
+        // Case 2: new table has rows but not for this model — use CRI unchanged.
+        return cri_bedrock_model.to_string();
+    }
+    if let Some(legacy_arn) = legacy_inference_profile_arn {
+        // Case 3: new table empty, legacy column set — safety-net compat.
+        return legacy_arn.to_string();
+    }
+    // Case 4: pure CRI, no overrides at all.
+    cri_bedrock_model.to_string()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 4 (Slice 2B) — Contract tests for the request-path dispatch-precedence chain
+//
+// These tests call `resolve_dispatch_target`, a pure helper that DOES NOT EXIST
+// yet. They are intentionally written to fail to compile until the builder adds
+// the function.  DO NOT add the function here — that is the builder's job.
+//
+// Spec reference: §Slice 2 "Request path changes", lines 154-193
+// Tasks file:     Task 4, lines 98-122
+//
+// Precedence table being tested:
+//   1. New table has a row for the requested model → dispatch AIP ARN (per-model).
+//   2. New table has rows for other models, but not this one → fall through to CRI
+//      (no silent substitution).
+//   3. New table empty + legacy column set → force-substitute legacy ARN (compat).
+//   4. New table empty + legacy column null → pure CRI, unchanged.
+//
+// The four arguments map exactly onto the information the caller gathers from
+// `EndpointClient` before calling the helper:
+//   - `cri_bedrock_model`              — what request::translate produced
+//   - `original_model`                 — the user-supplied model name (e.g. "claude-sonnet-4-5")
+//   - `aip_override`                   — ep.aip_override_for(original_model)
+//   - `has_any_aip_overrides`          — ep.has_any_aip_overrides()
+//   - `legacy_inference_profile_arn`   — ep.config.inference_profile_arn.as_deref()
+// ─────────────────────────────────────────────────────────────────────────────
+#[rustfmt::skip]
+#[cfg(test)]
+mod tests_dispatch_precedence {
+    // Import the function that the builder must provide.
+    // This import is what causes the intentional compile failure.
+    use super::resolve_dispatch_target;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// Sonnet CRI model ID as produced by request::translate with prefix "us".
+    const SONNET_CRI: &str = "us.anthropic.claude-sonnet-4-5-20250929-v1:0";
+    /// Opus CRI model ID.
+    const OPUS_CRI: &str = "us.anthropic.claude-opus-4-7-20251101-v1:0";
+    /// Haiku CRI model ID.
+    const HAIKU_CRI: &str = "us.anthropic.claude-haiku-4-5-20251001-v1:0";
+
+    /// AIP ARN for a tagged Sonnet application inference profile.
+    const SONNET_AIP_ARN: &str =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged";
+    /// AIP ARN for a tagged Opus application inference profile.
+    const OPUS_AIP_ARN: &str =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-tagged";
+    /// Legacy ARN — was set in the `inference_profile_arn` column before migration.
+    const LEGACY_ARN: &str =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-legacy";
+
+    // ── Test 1: new table has the requested model → dispatch AIP ARN ──────────
+    //
+    // Endpoint has one override row: claude-sonnet-4-5 → SONNET_AIP_ARN.
+    // Request is for claude-sonnet-4-5.
+    // Expected: dispatch target == SONNET_AIP_ARN.
+    #[test]
+    fn test_dispatch_aip_override_for_model_uses_override_arn() {
+        let result = resolve_dispatch_target(
+            SONNET_CRI,                // cri_bedrock_model
+            "claude-sonnet-4-5",       // original_model
+            Some(SONNET_AIP_ARN),      // aip_override  — ep.aip_override_for("claude-sonnet-4-5")
+            true,                      // has_any_aip_overrides
+            None,                      // legacy_inference_profile_arn
+        );
+
+        assert_eq!(
+            result, SONNET_AIP_ARN,
+            "When new table has a row for the requested model, dispatch target must \
+             be the AIP ARN from the override row, not the CRI form"
+        );
+    }
+
+    // ── Test 2: new table has Sonnet+Opus; request for Opus → Opus ARN ────────
+    //
+    // Endpoint has two override rows. Request is for claude-opus-4-7.
+    // aip_override_for("claude-opus-4-7") returns OPUS_AIP_ARN.
+    // Expected: dispatch target == OPUS_AIP_ARN (not SONNET_AIP_ARN, not CRI).
+    #[test]
+    fn test_dispatch_aip_override_for_different_model_dispatches_correct_arn() {
+        let result = resolve_dispatch_target(
+            OPUS_CRI,                  // cri_bedrock_model
+            "claude-opus-4-7",         // original_model
+            Some(OPUS_AIP_ARN),        // aip_override  — ep.aip_override_for("claude-opus-4-7")
+            true,                      // has_any_aip_overrides
+            None,                      // legacy_inference_profile_arn
+        );
+
+        assert_eq!(
+            result, OPUS_AIP_ARN,
+            "When new table has rows for multiple models, each model must dispatch its \
+             own AIP ARN; an Opus request must not use the Sonnet ARN or fall to CRI"
+        );
+    }
+
+    // ── Test 3: new table has rows but not for this model → CRI, no sub ───────
+    //
+    // Endpoint has Sonnet+Opus overrides.  Request is for claude-haiku-4-5.
+    // aip_override_for("claude-haiku-4-5") returns None; has_any_aip_overrides → true.
+    // Expected: dispatch target == HAIKU_CRI (fall through to CRI, no substitution).
+    #[test]
+    fn test_dispatch_no_override_with_other_overrides_falls_through_to_cri() {
+        let result = resolve_dispatch_target(
+            HAIKU_CRI,                 // cri_bedrock_model
+            "claude-haiku-4-5",        // original_model
+            None,                      // aip_override  — no row for haiku
+            true,                      // has_any_aip_overrides  — other models ARE configured
+            None,                      // legacy_inference_profile_arn
+        );
+
+        assert_eq!(
+            result, HAIKU_CRI,
+            "When new table has rows for other models but not for the requested model, \
+             the dispatch target must be the CRI form unchanged — no silent substitution"
+        );
+    }
+
+    // ── Test 4: new table empty + legacy column set → force-substitute ────────
+    //
+    // Endpoint has NO new-table rows (auto-migration hasn't run or failed).
+    // Legacy column = LEGACY_ARN.  Request is for claude-sonnet-4-5.
+    // Expected: dispatch target == LEGACY_ARN (safety net — today's behaviour).
+    #[test]
+    fn test_dispatch_legacy_arn_compat_when_new_table_empty() {
+        let result = resolve_dispatch_target(
+            SONNET_CRI,                // cri_bedrock_model
+            "claude-sonnet-4-5",       // original_model
+            None,                      // aip_override  — no new-table row
+            false,                     // has_any_aip_overrides — new table is empty
+            Some(LEGACY_ARN),          // legacy_inference_profile_arn
+        );
+
+        assert_eq!(
+            result, LEGACY_ARN,
+            "When new table is empty and legacy column is set, dispatch target must be \
+             the legacy ARN (safety-net compat path)"
+        );
+    }
+
+    // ── Test 5: legacy force-substitution applies regardless of model ─────────
+    //
+    // Same endpoint as Test 4 (new table empty, legacy column = LEGACY_ARN).
+    // Request is for claude-opus-4-7 — a DIFFERENT model than the ARN represents.
+    // Expected: dispatch target STILL == LEGACY_ARN.
+    //
+    // This documents today's semantics: when only the legacy column is set, ALL
+    // traffic on the endpoint is force-substituted through that single ARN,
+    // regardless of the requested model.  This behaviour is intentionally preserved
+    // until the auto-migration runs and populates the new table.
+    #[test]
+    fn test_dispatch_legacy_arn_compat_dispatches_for_any_model() {
+        let result = resolve_dispatch_target(
+            OPUS_CRI,                  // cri_bedrock_model
+            "claude-opus-4-7",         // original_model — NOT what the legacy ARN targets
+            None,                      // aip_override  — no new-table row
+            false,                     // has_any_aip_overrides — new table is empty
+            Some(LEGACY_ARN),          // legacy_inference_profile_arn  (a Sonnet AIP)
+        );
+
+        assert_eq!(
+            result, LEGACY_ARN,
+            "Legacy force-substitution must apply to ALL models when the new table is \
+             empty — the legacy ARN is used even for Opus, because migration has not run"
+        );
+    }
+
+    // ── Test 6: new table empty + legacy column null → pure CRI ───────────────
+    //
+    // Endpoint has no new-table rows AND no legacy column.
+    // Request for claude-sonnet-4-5; CRI form = SONNET_CRI.
+    // Expected: dispatch target == SONNET_CRI (pure CRI path, no override).
+    #[test]
+    fn test_dispatch_pure_cri_no_overrides_no_legacy() {
+        let result = resolve_dispatch_target(
+            SONNET_CRI,                // cri_bedrock_model
+            "claude-sonnet-4-5",       // original_model
+            None,                      // aip_override  — no new-table row
+            false,                     // has_any_aip_overrides — new table is empty
+            None,                      // legacy_inference_profile_arn — column is NULL
+        );
+
+        assert_eq!(
+            result, SONNET_CRI,
+            "When both new table and legacy column are absent, dispatch target must \
+             be the CRI form unchanged — pure CRI path"
+        );
+    }
+
+    // ── Test 7: new table row beats legacy column (precedence) ────────────────
+    //
+    // Endpoint has BOTH a new-table row for Sonnet AND the legacy column set.
+    // Request for claude-sonnet-4-5.
+    // Expected: dispatch target == SONNET_AIP_ARN (new table wins; legacy ignored).
+    #[test]
+    fn test_dispatch_aip_override_takes_precedence_over_legacy_column() {
+        let result = resolve_dispatch_target(
+            SONNET_CRI,                // cri_bedrock_model
+            "claude-sonnet-4-5",       // original_model
+            Some(SONNET_AIP_ARN),      // aip_override  — new-table row present
+            true,                      // has_any_aip_overrides
+            Some(LEGACY_ARN),          // legacy_inference_profile_arn — also set
+        );
+
+        assert_eq!(
+            result, SONNET_AIP_ARN,
+            "New-table AIP override must take precedence over the legacy column when \
+             both are present for the same model"
+        );
+    }
+
+    // ── Snapshot: lock all four precedence cases at once ─────────────────────
+    //
+    // Encodes the full matrix as a single assertion-set so any future refactor
+    // that alters precedence semantics will fail this test loudly.
+    #[test]
+    fn test_dispatch_precedence_snapshot() {
+        struct Case {
+            label: &'static str,
+            cri: &'static str,
+            model: &'static str,
+            aip_override: Option<&'static str>,
+            has_any: bool,
+            legacy: Option<&'static str>,
+            expected: &'static str,
+        }
+
+        let cases = [
+            Case {
+                label: "1. new-table match → AIP ARN",
+                cri: SONNET_CRI,
+                model: "claude-sonnet-4-5",
+                aip_override: Some(SONNET_AIP_ARN),
+                has_any: true,
+                legacy: None,
+                expected: SONNET_AIP_ARN,
+            },
+            Case {
+                label: "2. new-table rows exist, no row for model → CRI (no substitution)",
+                cri: HAIKU_CRI,
+                model: "claude-haiku-4-5",
+                aip_override: None,
+                has_any: true,
+                legacy: None,
+                expected: HAIKU_CRI,
+            },
+            Case {
+                label: "3. new table empty + legacy set → legacy force-substitute",
+                cri: SONNET_CRI,
+                model: "claude-sonnet-4-5",
+                aip_override: None,
+                has_any: false,
+                legacy: Some(LEGACY_ARN),
+                expected: LEGACY_ARN,
+            },
+            Case {
+                label: "4. new table empty + legacy null → pure CRI",
+                cri: SONNET_CRI,
+                model: "claude-sonnet-4-5",
+                aip_override: None,
+                has_any: false,
+                legacy: None,
+                expected: SONNET_CRI,
+            },
+        ];
+
+        for c in &cases {
+            let result = resolve_dispatch_target(
+                c.cri, c.model, c.aip_override, c.has_any, c.legacy,
+            );
+            assert_eq!(
+                result, c.expected,
+                "Precedence snapshot failed for case: {}",
+                c.label
+            );
+        }
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -123,11 +123,9 @@ pub fn router(state: Arc<GatewayState>) -> Router {
         .route("/admin/endpoints", post(admin::create_endpoint))
         .route(
             "/admin/endpoints/{endpoint_id}",
-            put(admin::update_endpoint),
-        )
-        .route(
-            "/admin/endpoints/{endpoint_id}",
-            delete(admin::delete_endpoint),
+            get(admin::get_endpoint_by_id)
+                .put(admin::update_endpoint)
+                .delete(admin::delete_endpoint),
         )
         .route(
             "/admin/endpoints/{endpoint_id}/quotas",
@@ -136,6 +134,14 @@ pub fn router(state: Arc<GatewayState>) -> Router {
         .route(
             "/admin/endpoints/{endpoint_id}/models",
             get(admin::get_endpoint_models),
+        )
+        .route(
+            "/admin/endpoints/{endpoint_id}/aip-overrides",
+            get(admin::list_aip_overrides).post(admin::create_aip_override),
+        )
+        .route(
+            "/admin/endpoints/{endpoint_id}/aip-overrides/{model_id}",
+            delete(admin::delete_aip_override),
         )
         .route("/admin/bedrock/models", get(admin::get_all_models))
         .route(

--- a/src/db/endpoint_aip_overrides.rs
+++ b/src/db/endpoint_aip_overrides.rs
@@ -1,0 +1,83 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// A single per-endpoint AIP override row.
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct AipOverride {
+    pub endpoint_id: Uuid,
+    pub model_id: String,
+    pub aip_arn: String,
+    pub set_at: DateTime<Utc>,
+    pub set_by: String,
+    pub reason: Option<String>,
+}
+
+/// Insert a new AIP override row.
+///
+/// Returns an error on PK violation (duplicate `(endpoint_id, model_id)`).
+/// The raw `sqlx::Error::Database` with Postgres code `23505` is propagated so
+/// admin handlers can downcast it and return HTTP 409.
+pub async fn insert(
+    pool: &PgPool,
+    endpoint_id: Uuid,
+    model_id: &str,
+    aip_arn: &str,
+    set_by: &str,
+    reason: Option<&str>,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"INSERT INTO endpoint_aip_overrides (endpoint_id, model_id, aip_arn, set_by, reason)
+           VALUES ($1, $2, $3, $4, $5)"#,
+    )
+    .bind(endpoint_id)
+    .bind(model_id)
+    .bind(aip_arn)
+    .bind(set_by)
+    .bind(reason)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// List all AIP override rows for the given endpoint.
+///
+/// Returns an empty vec when no rows exist (not an error).
+pub async fn list_by_endpoint(
+    pool: &PgPool,
+    endpoint_id: Uuid,
+) -> anyhow::Result<Vec<AipOverride>> {
+    let rows = sqlx::query_as::<_, AipOverride>(
+        r#"SELECT endpoint_id, model_id, aip_arn, set_at, set_by, reason
+           FROM endpoint_aip_overrides
+           WHERE endpoint_id = $1
+           ORDER BY model_id"#,
+    )
+    .bind(endpoint_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows)
+}
+
+/// Delete the override row for a specific `(endpoint_id, model_id)`.
+///
+/// Idempotent: if no row exists the operation succeeds silently (0 rows
+/// affected is not treated as an error at the DB layer).  Admin handlers
+/// inspect the rows-affected count and may return 404 if appropriate.
+pub async fn delete_by_model(
+    pool: &PgPool,
+    endpoint_id: Uuid,
+    model_id: &str,
+) -> anyhow::Result<u64> {
+    let result =
+        sqlx::query("DELETE FROM endpoint_aip_overrides WHERE endpoint_id = $1 AND model_id = $2")
+            .bind(endpoint_id)
+            .bind(model_id)
+            .execute(pool)
+            .await?;
+
+    Ok(result.rows_affected())
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,6 @@
 pub mod beta_overrides;
 pub mod budget;
+pub mod endpoint_aip_overrides;
 pub mod endpoints;
 pub mod idp;
 pub mod keys;

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -70,6 +70,10 @@ pub struct EndpointClient {
     /// `AdminOverride` entries ignore TTL and are never overwritten by automatic probing.
     /// Non-override entries expire after `CAPABILITY_TTL` (24 h).
     pub beta_capabilities: Arc<RwLock<HashMap<(String, String), CapabilityEntry>>>,
+    /// Per-model AIP override map: Anthropic logical model ID → AIP ARN.
+    /// Populated at endpoint load time from `endpoint_aip_overrides` DB rows.
+    /// Empty for endpoints that have not been configured with any AIP overrides.
+    pub aip_overrides: HashMap<String, String>,
 }
 
 impl EndpointClient {
@@ -202,6 +206,26 @@ impl EndpointClient {
         }
         pairs
     }
+
+    /// Returns the AIP ARN for `model_id` from the new `aip_overrides` map, or
+    /// `None` if no override exists for this model.
+    ///
+    /// This helper reads **only** the `aip_overrides` HashMap (populated from the
+    /// `endpoint_aip_overrides` table). It does NOT fall back to
+    /// `config.inference_profile_arn` (the legacy column). The legacy fallback is
+    /// the responsibility of the request dispatcher — this strict boundary makes
+    /// each code path testable in isolation.
+    pub fn aip_override_for(&self, model_id: &str) -> Option<&str> {
+        self.aip_overrides.get(model_id).map(|s| s.as_str())
+    }
+
+    /// Returns `true` iff the `aip_overrides` map has at least one entry.
+    ///
+    /// Like `aip_override_for`, this ignores `config.inference_profile_arn`.
+    /// An endpoint with only the legacy column set returns `false` here.
+    pub fn has_any_aip_overrides(&self) -> bool {
+        !self.aip_overrides.is_empty()
+    }
 }
 
 // ── Seed-probe helpers ────────────────────────────────────────────────────────
@@ -323,10 +347,40 @@ impl EndpointPool {
     /// endpoints that are already in the pool (matched by UUID), so that learned
     /// capability data survives routine config reloads triggered by cache_version bumps.
     /// Only genuinely new endpoints get a fresh empty cache.
+    ///
+    /// `aip_overrides` are NOT loaded (empty maps on every client). Use
+    /// [`load_endpoints_with_db`] when a DB pool is available to also populate
+    /// per-endpoint AIP override maps.
     pub async fn load_endpoints(
         &self,
         endpoints: Vec<Endpoint>,
         base_aws_config: &aws_config::SdkConfig,
+    ) {
+        self.load_endpoints_inner(endpoints, base_aws_config, None)
+            .await
+    }
+
+    /// Load/reload endpoint clients from database endpoint configs and populate
+    /// each client's `aip_overrides` map from the `endpoint_aip_overrides` table.
+    ///
+    /// Equivalent to [`load_endpoints`] but fetches per-endpoint AIP override rows
+    /// so that `EndpointClient::aip_override_for` and `has_any_aip_overrides` work
+    /// correctly at runtime.
+    pub async fn load_endpoints_with_db(
+        &self,
+        endpoints: Vec<Endpoint>,
+        base_aws_config: &aws_config::SdkConfig,
+        pool: &sqlx::PgPool,
+    ) {
+        self.load_endpoints_inner(endpoints, base_aws_config, Some(pool))
+            .await
+    }
+
+    async fn load_endpoints_inner(
+        &self,
+        endpoints: Vec<Endpoint>,
+        base_aws_config: &aws_config::SdkConfig,
+        pool: Option<&sqlx::PgPool>,
     ) {
         let mut new_clients = HashMap::new();
         let mut new_default: Option<Uuid> = None;
@@ -352,9 +406,28 @@ impl EndpointPool {
             if ep.is_default {
                 new_default = Some(ep.id);
             }
+
+            // Load AIP overrides from DB when a pool is available.
+            let aip_overrides: HashMap<String, String> = if let Some(p) = pool {
+                match crate::db::endpoint_aip_overrides::list_by_endpoint(p, ep.id).await {
+                    Ok(rows) => rows.into_iter().map(|r| (r.model_id, r.aip_arn)).collect(),
+                    Err(e) => {
+                        tracing::warn!(endpoint_id = %ep.id, %e, "Failed to load AIP overrides for endpoint — using empty map");
+                        HashMap::new()
+                    }
+                }
+            } else {
+                HashMap::new()
+            };
+
             let preserved_caches = preserved.get(&ep.id).cloned();
-            let client =
-                Self::create_client_with_caches(&ep, base_aws_config, preserved_caches).await;
+            let client = Self::create_client_with_caches(
+                &ep,
+                base_aws_config,
+                preserved_caches,
+                aip_overrides,
+            )
+            .await;
             if let Some(c) = client {
                 new_clients.insert(ep.id, Arc::new(c));
             }
@@ -372,6 +445,7 @@ impl EndpointPool {
         endpoint: &Endpoint,
         _base_config: &aws_config::SdkConfig,
         preserved_caches: Option<PreservedCaches>,
+        aip_overrides: HashMap<String, String>,
     ) -> Option<EndpointClient> {
         let region = aws_config::Region::new(endpoint.region.clone());
 
@@ -423,6 +497,7 @@ impl EndpointPool {
             last_health_check: AtomicI64::new(0),
             available_models,
             beta_capabilities,
+            aip_overrides,
         })
     }
 
@@ -675,6 +750,7 @@ mod tests {
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
+            aip_overrides: HashMap::new(),
         }
     }
 
@@ -1385,6 +1461,7 @@ mod tests_slice2 {
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
+            aip_overrides: HashMap::new(),
         }
     }
 
@@ -1691,6 +1768,7 @@ mod tests_slice3 {
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
+            aip_overrides: HashMap::new(),
         }
     }
 
@@ -2132,6 +2210,7 @@ mod tests_dynamic_model_slice1 {
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(tokio::sync::RwLock::new(models)),
             beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            aip_overrides: HashMap::new(),
         }
     }
 
@@ -2316,6 +2395,7 @@ mod tests_model_filtering_slice3 {
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(models)),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
+            aip_overrides: HashMap::new(),
         }
     }
 
@@ -2626,6 +2706,7 @@ mod tests_slice5 {
             last_health_check: AtomicI64::new(0),
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
+            aip_overrides: HashMap::new(),
         }
     }
 
@@ -2802,6 +2883,7 @@ mod tests_1m_capability_cache {
             available_models: Arc::new(tokio::sync::RwLock::new(vec![])),
             // Builder must add this field:
             beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            aip_overrides: HashMap::new(),
         }
     }
 
@@ -3167,6 +3249,7 @@ mod tests_seed_probe {
             last_health_check: std::sync::atomic::AtomicI64::new(0),
             available_models: Arc::new(tokio::sync::RwLock::new(vec![])),
             beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            aip_overrides: HashMap::new(),
         }
     }
 
@@ -3417,6 +3500,279 @@ mod tests_seed_probe {
             result,
             Some(true),
             "ProbeOutcome::Inconclusive must not overwrite an existing Some(true) cache entry"
+        );
+    }
+}
+// ── AIP override helpers — Task 1 (Slice 1) tests ──
+//
+// These tests cover the two new methods that the builder will add to
+// `EndpointClient`:
+//
+//   - `aip_override_for(model_id: &str) -> Option<&str>`
+//     Returns the AIP ARN from the in-memory `aip_overrides` HashMap when a
+//     matching entry exists, `None` otherwise.
+//
+//   - `has_any_aip_overrides() -> bool`
+//     Returns `true` iff `aip_overrides` is non-empty.
+//
+// The `aip_overrides: HashMap<String, String>` field is populated at load time
+// by reading `endpoint_aip_overrides` rows from the DB — the builder wires that
+// in `load_endpoints` / `create_client`. Here we test the helper methods
+// directly by constructing an `EndpointClient` with a known map.
+//
+// None of these tests require a database connection.
+
+#[cfg(test)]
+mod tests_aip_override_helpers {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build a minimal `EndpointClient` with the provided `aip_overrides` map
+    /// and an optional `inference_profile_arn` on the config (legacy column).
+    ///
+    /// The AWS SDK clients are constructed with dummy configs — they are never
+    /// invoked in these unit tests.
+    fn make_client_with_overrides(
+        aip_overrides: HashMap<String, String>,
+        legacy_inference_profile_arn: Option<String>,
+    ) -> EndpointClient {
+        use std::sync::atomic::AtomicBool;
+        use std::sync::atomic::AtomicI64;
+
+        let id = Uuid::new_v4();
+        let config = crate::db::schema::Endpoint {
+            id,
+            name: "test-ep".to_string(),
+            role_arn: None,
+            external_id: None,
+            inference_profile_arn: legacy_inference_profile_arn,
+            region: "us-east-1".to_string(),
+            routing_prefix: "us".to_string(),
+            priority: 0,
+            is_default: false,
+            enabled: true,
+            created_at: chrono::Utc::now(),
+        };
+
+        let runtime_client = aws_sdk_bedrockruntime::Client::from_conf(
+            aws_sdk_bedrockruntime::Config::builder()
+                .behavior_version(aws_sdk_bedrockruntime::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+        let control_client = aws_sdk_bedrock::Client::from_conf(
+            aws_sdk_bedrock::Config::builder()
+                .behavior_version(aws_sdk_bedrock::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+        let quota_client = aws_sdk_servicequotas::Client::from_conf(
+            aws_sdk_servicequotas::Config::builder()
+                .behavior_version(aws_sdk_servicequotas::config::BehaviorVersion::latest())
+                .region(aws_config::Region::new("us-east-1"))
+                .build(),
+        );
+
+        EndpointClient {
+            config,
+            runtime_client,
+            control_client,
+            quota_cache: crate::quota::QuotaCache::new(quota_client),
+            healthy: AtomicBool::new(true),
+            last_health_check: AtomicI64::new(0),
+            available_models: Arc::new(RwLock::new(vec![])),
+            beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
+            aip_overrides,
+        }
+    }
+
+    // ── aip_override_for ──────────────────────────────────────────────────────
+
+    /// `aip_override_for` returns `Some(arn)` when an exact model_id entry
+    /// exists in the `aip_overrides` map.
+    #[test]
+    fn test_aip_override_for_returns_arn_when_present() {
+        let mut map = HashMap::new();
+        let expected_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged";
+        map.insert("claude-sonnet-4-5".to_string(), expected_arn.to_string());
+
+        let client = make_client_with_overrides(map, None);
+
+        let result = client.aip_override_for("claude-sonnet-4-5");
+        assert_eq!(
+            result,
+            Some(expected_arn),
+            "aip_override_for must return Some(arn) for a model present in the map"
+        );
+    }
+
+    /// `aip_override_for` returns `None` when the requested model has no entry
+    /// in the `aip_overrides` map, even when other models are present.
+    #[test]
+    fn test_aip_override_for_returns_none_for_absent_model() {
+        let mut map = HashMap::new();
+        map.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged"
+                .to_string(),
+        );
+        map.insert(
+            "claude-opus-4-7".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-tagged"
+                .to_string(),
+        );
+
+        let client = make_client_with_overrides(map, None);
+
+        let result = client.aip_override_for("claude-haiku-4-5");
+        assert!(
+            result.is_none(),
+            "aip_override_for must return None for a model not in the override map"
+        );
+    }
+
+    /// `aip_override_for` returns `None` when the map is empty.
+    #[test]
+    fn test_aip_override_for_returns_none_when_map_empty() {
+        let client = make_client_with_overrides(HashMap::new(), None);
+
+        let result = client.aip_override_for("claude-sonnet-4-5");
+        assert!(
+            result.is_none(),
+            "aip_override_for must return None when aip_overrides map is empty"
+        );
+    }
+
+    /// Boundary test: when no row exists in the new table (`aip_overrides` is
+    /// empty) but `inference_profile_arn` is set on the legacy column,
+    /// `aip_override_for` STILL returns `None`.
+    ///
+    /// The helper reads only the new `aip_overrides` map. The legacy fallback
+    /// (force-substitution from `config.inference_profile_arn`) is the
+    /// responsibility of the request dispatcher (Task 4), not this helper.
+    /// This test codifies the boundary between the two code paths.
+    #[test]
+    fn test_aip_override_for_ignores_legacy_inference_profile_arn() {
+        let legacy_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/legacy-sonnet";
+
+        // Empty new-table map, but legacy column is set
+        let client = make_client_with_overrides(HashMap::new(), Some(legacy_arn.to_string()));
+
+        // The helper must return None — it does NOT fall through to the legacy column.
+        // The dispatcher will check config.inference_profile_arn separately.
+        let result = client.aip_override_for("claude-sonnet-4-5");
+        assert!(
+            result.is_none(),
+            "aip_override_for must return None when aip_overrides is empty, even if \
+             config.inference_profile_arn is set (legacy fallback is the dispatcher's job)"
+        );
+    }
+
+    /// `aip_override_for` performs exact-key matching only. A partial model name
+    /// (e.g. `"claude-sonnet"`) must NOT match the full key `"claude-sonnet-4-5"`.
+    #[test]
+    fn test_aip_override_for_exact_key_match_only() {
+        let mut map = HashMap::new();
+        map.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged"
+                .to_string(),
+        );
+
+        let client = make_client_with_overrides(map, None);
+
+        // Partial key must not match
+        assert!(
+            client.aip_override_for("claude-sonnet").is_none(),
+            "aip_override_for must not match on a partial model name"
+        );
+        // Different version must not match
+        assert!(
+            client.aip_override_for("claude-sonnet-4-6").is_none(),
+            "aip_override_for must not match a different version of the same model family"
+        );
+    }
+
+    // ── has_any_aip_overrides ─────────────────────────────────────────────────
+
+    /// `has_any_aip_overrides` returns `true` when at least one entry exists.
+    #[test]
+    fn test_has_any_aip_overrides_true_when_non_empty() {
+        let mut map = HashMap::new();
+        map.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet"
+                .to_string(),
+        );
+
+        let client = make_client_with_overrides(map, None);
+        assert!(
+            client.has_any_aip_overrides(),
+            "has_any_aip_overrides must return true when the map has entries"
+        );
+    }
+
+    /// `has_any_aip_overrides` returns `false` when the map is empty.
+    #[test]
+    fn test_has_any_aip_overrides_false_when_empty() {
+        let client = make_client_with_overrides(HashMap::new(), None);
+        assert!(
+            !client.has_any_aip_overrides(),
+            "has_any_aip_overrides must return false when aip_overrides is empty"
+        );
+    }
+
+    /// `has_any_aip_overrides` returns `false` even when the legacy
+    /// `inference_profile_arn` is set, as long as the new map is empty.
+    ///
+    /// This mirrors the boundary test for `aip_override_for`: the legacy column
+    /// is invisible to the new helpers.
+    #[test]
+    fn test_has_any_aip_overrides_false_with_only_legacy_column() {
+        let legacy_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/legacy";
+        let client = make_client_with_overrides(HashMap::new(), Some(legacy_arn.to_string()));
+
+        assert!(
+            !client.has_any_aip_overrides(),
+            "has_any_aip_overrides must return false when aip_overrides is empty, \
+             even if the legacy inference_profile_arn column is set"
+        );
+    }
+
+    /// Multiple entries: `has_any_aip_overrides` remains `true` after inserting
+    /// multiple models, and `aip_override_for` returns the correct ARN for each.
+    #[test]
+    fn test_multiple_overrides_all_accessible() {
+        let sonnet_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet";
+        let opus_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus";
+
+        let mut map = HashMap::new();
+        map.insert("claude-sonnet-4-5".to_string(), sonnet_arn.to_string());
+        map.insert("claude-opus-4-7".to_string(), opus_arn.to_string());
+
+        let client = make_client_with_overrides(map, None);
+
+        assert!(
+            client.has_any_aip_overrides(),
+            "has_any_aip_overrides must be true for a map with 2 entries"
+        );
+        assert_eq!(
+            client.aip_override_for("claude-sonnet-4-5"),
+            Some(sonnet_arn),
+            "must return correct sonnet ARN"
+        );
+        assert_eq!(
+            client.aip_override_for("claude-opus-4-7"),
+            Some(opus_arn),
+            "must return correct opus ARN"
+        );
+        assert!(
+            client.aip_override_for("claude-haiku-4-5").is_none(),
+            "haiku has no override, must return None"
         );
     }
 }

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -74,6 +74,10 @@ pub struct EndpointClient {
     /// Populated at endpoint load time from `endpoint_aip_overrides` DB rows.
     /// Empty for endpoints that have not been configured with any AIP overrides.
     pub aip_overrides: HashMap<String, String>,
+    /// Subset of `available_models` whose entries were resolved from AIP overrides
+    /// (not already present in the CRI list). Updated each health-loop tick alongside
+    /// `available_models`. Used by `should_probe_profile` to gate capability probes.
+    pub aip_derived_profile_ids: tokio::sync::RwLock<Vec<String>>,
 }
 
 impl EndpointClient {
@@ -498,6 +502,7 @@ impl EndpointPool {
             available_models,
             beta_capabilities,
             aip_overrides,
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         })
     }
 
@@ -700,6 +705,226 @@ impl EndpointPool {
     }
 }
 
+/// Result returned by [`compute_health_state`].
+pub struct HealthState {
+    /// Whether the endpoint is considered healthy.
+    pub healthy: bool,
+    /// Deduplicated union of CRI profiles + AIP-resolved model IDs.
+    pub available_models: Vec<String>,
+    /// Subset of `available_models` whose entries were contributed exclusively
+    /// by AIP overrides (not already present in the CRI list).
+    /// Empty for pure-CRI endpoints and on any failure.
+    pub aip_derived_profile_ids: Vec<String>,
+}
+
+/// Compute the unified health state for a single endpoint.
+///
+/// Encapsulates the spec §Slice 2 Health loop changes logic:
+///
+/// 1. **CRI fails** → `(false, vec![])`. `get_foundation_model` is never called.
+/// 2. **CRI ok + zero `aip_overrides` + no legacy ARN** → `(true, cri_list)`.
+///    `get_foundation_model` is never called.
+/// 3. **CRI ok + zero `aip_overrides` + legacy ARN set** → call
+///    `get_foundation_model(legacy_arn)` once. On success parse and return
+///    `(true, vec!["<prefix>.<bedrock_suffix>"])`. On failure `(false, vec![])`.
+///    (Auto-migration safety net — behaves as today when new table is empty.)
+/// 4. **CRI ok + `aip_overrides` non-empty** → call `get_foundation_model` once
+///    per override. If ANY fails → `(false, vec![])`. If all succeed → deduplicated
+///    union of `cri_list` ∪ AIP-resolved entries, `(true, union)`.
+///
+/// Returns a [`HealthState`] struct with `healthy`, `available_models`, and
+/// `aip_derived_profile_ids` (the subset of `available_models` that came
+/// exclusively from AIP overrides, i.e. not already covered by the CRI list).
+pub async fn compute_health_state<F, Fut>(
+    cri_list_result: Result<Vec<String>, String>,
+    aip_overrides: &HashMap<String, String>,
+    get_foundation_model: F,
+    routing_prefix: &str,
+    legacy_inference_profile_arn: Option<&str>,
+) -> HealthState
+where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = Result<String, String>>,
+{
+    // ── Branch 1: CRI failure → immediately unhealthy ─────────────────────────
+    let cri_list = match cri_list_result {
+        Ok(list) => list,
+        Err(_) => {
+            return HealthState {
+                healthy: false,
+                available_models: vec![],
+                aip_derived_profile_ids: vec![],
+            };
+        }
+    };
+
+    // ── Branch 2: CRI ok, no new overrides, no legacy ARN → pure CRI ──────────
+    if aip_overrides.is_empty() && legacy_inference_profile_arn.is_none() {
+        return HealthState {
+            healthy: true,
+            available_models: cri_list,
+            aip_derived_profile_ids: vec![],
+        };
+    }
+
+    // ── Branch 3: CRI ok, no new overrides, legacy ARN set ────────────────────
+    if aip_overrides.is_empty() {
+        // Safety: guarded by `is_empty()` + `is_none()` check above — if we
+        // reach here, `legacy_inference_profile_arn` is `Some`.
+        let legacy_arn = legacy_inference_profile_arn.expect("guarded above");
+        match get_foundation_model(legacy_arn.to_string()).await {
+            Ok(fm_arn) => {
+                match crate::translate::models::parse_foundation_model_from_arn(&fm_arn) {
+                    Ok(bedrock_suffix) => {
+                        let model_id = format!("{routing_prefix}.{bedrock_suffix}");
+                        // Legacy ARN path: the single resolved entry is AIP-derived
+                        // (there is no CRI list to compare against).
+                        let aip_derived = vec![model_id.clone()];
+                        return HealthState {
+                            healthy: true,
+                            available_models: vec![model_id],
+                            aip_derived_profile_ids: aip_derived,
+                        };
+                    }
+                    Err(_) => {
+                        return HealthState {
+                            healthy: false,
+                            available_models: vec![],
+                            aip_derived_profile_ids: vec![],
+                        };
+                    }
+                }
+            }
+            Err(_) => {
+                return HealthState {
+                    healthy: false,
+                    available_models: vec![],
+                    aip_derived_profile_ids: vec![],
+                };
+            }
+        }
+    }
+
+    // ── Branch 4: CRI ok + aip_overrides non-empty ────────────────────────────
+    // Build union: CRI list first (exact dedup), then AIP-resolved entries.
+    //
+    // Dedup strategy for AIP entries: skip adding an AIP-resolved model if any
+    // already-present entry is a prefix of the new model ID. This handles both:
+    //   - Exact match (same string already in union).
+    //   - Short-form CRI entry covering a long-form AIP entry, e.g.
+    //     CRI "us.anthropic.claude-sonnet-4-5" already covers the AIP-resolved
+    //     "us.anthropic.claude-sonnet-4-5-20250929-v1:0".
+    let mut union: Vec<String> = Vec::new();
+    let mut aip_derived: Vec<String> = Vec::new();
+
+    // Seed with CRI list first (no duplicates expected, but guard anyway).
+    for model in &cri_list {
+        if !union.contains(model) {
+            union.push(model.clone());
+        }
+    }
+
+    // Helper: returns true iff `candidate` is already semantically covered
+    // by an entry in `union` (exact match OR existing is a prefix of candidate).
+    fn is_covered(union: &[String], candidate: &str) -> bool {
+        union
+            .iter()
+            .any(|existing| candidate.starts_with(existing.as_str()))
+    }
+
+    // Resolve each AIP override. Sequential — mirrors existing health-loop style.
+    for aip_arn in aip_overrides.values() {
+        match get_foundation_model(aip_arn.clone()).await {
+            Ok(fm_arn) => {
+                match crate::translate::models::parse_foundation_model_from_arn(&fm_arn) {
+                    Ok(bedrock_suffix) => {
+                        let model_id = format!("{routing_prefix}.{bedrock_suffix}");
+                        if !is_covered(&union, &model_id) {
+                            // This entry is not already in the CRI list → AIP-derived.
+                            aip_derived.push(model_id.clone());
+                            union.push(model_id);
+                        }
+                        // If already covered by CRI, it is NOT added to aip_derived.
+                    }
+                    Err(_) => {
+                        return HealthState {
+                            healthy: false,
+                            available_models: vec![],
+                            aip_derived_profile_ids: vec![],
+                        };
+                    }
+                }
+            }
+            Err(_) => {
+                return HealthState {
+                    healthy: false,
+                    available_models: vec![],
+                    aip_derived_profile_ids: vec![],
+                };
+            }
+        }
+    }
+
+    HealthState {
+        healthy: true,
+        available_models: union,
+        aip_derived_profile_ids: aip_derived,
+    }
+}
+
+/// Returns `true` if a capability probe should be run for `profile_id`.
+///
+/// - If `capability_probe_aip_enabled` is `true`, all profiles are probed.
+/// - If `false`, profiles present in `aip_derived_profile_ids` are skipped;
+///   CRI-only profiles (not in that slice) continue to be probed.
+pub fn should_probe_profile(
+    profile_id: &str,
+    aip_derived_profile_ids: &[String],
+    capability_probe_aip_enabled: bool,
+) -> bool {
+    if capability_probe_aip_enabled {
+        return true;
+    }
+    // Flag is false: skip if this profile is AIP-derived.
+    !aip_derived_profile_ids.iter().any(|id| id == profile_id)
+}
+
+/// Resolves the effective value of the `CAPABILITY_PROBE_AIP` flag from two
+/// optional sources, in priority order:
+///
+/// 1. `db_setting` — value from the `proxy_settings` table (highest priority).
+/// 2. `env_value`  — value of the `CAPABILITY_PROBE_AIP` env var.
+/// 3. Hard-coded default: `true`.
+///
+/// Parsing is case-insensitive: `"true"` / `"True"` / `"TRUE"` → `true`,
+/// `"false"` / `"False"` / `"FALSE"` → `false`. Any other value falls through
+/// to the next source.
+pub fn effective_capability_probe_aip(db_setting: Option<&str>, env_value: Option<&str>) -> bool {
+    fn parse_bool(s: &str) -> Option<bool> {
+        let trimmed = s.trim();
+        if trimmed.eq_ignore_ascii_case("true") {
+            Some(true)
+        } else if trimmed.eq_ignore_ascii_case("false") {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    if let Some(db) = db_setting
+        && let Some(v) = parse_bool(db)
+    {
+        return v;
+    }
+    if let Some(env) = env_value
+        && let Some(v) = parse_bool(env)
+    {
+        return v;
+    }
+    // Default: probe everything.
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -751,6 +976,7 @@ mod tests {
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
             aip_overrides: HashMap::new(),
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -1462,6 +1688,7 @@ mod tests_slice2 {
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
             aip_overrides: HashMap::new(),
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -1769,6 +1996,7 @@ mod tests_slice3 {
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
             aip_overrides: HashMap::new(),
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -2211,6 +2439,7 @@ mod tests_dynamic_model_slice1 {
             available_models: Arc::new(tokio::sync::RwLock::new(models)),
             beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             aip_overrides: HashMap::new(),
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -2396,6 +2625,7 @@ mod tests_model_filtering_slice3 {
             available_models: Arc::new(RwLock::new(models)),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
             aip_overrides: HashMap::new(),
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -2707,6 +2937,7 @@ mod tests_slice5 {
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
             aip_overrides: HashMap::new(),
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -2884,6 +3115,7 @@ mod tests_1m_capability_cache {
             // Builder must add this field:
             beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             aip_overrides: HashMap::new(),
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -3250,6 +3482,7 @@ mod tests_seed_probe {
             available_models: Arc::new(tokio::sync::RwLock::new(vec![])),
             beta_capabilities: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             aip_overrides: HashMap::new(),
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -3583,6 +3816,7 @@ mod tests_aip_override_helpers {
             available_models: Arc::new(RwLock::new(vec![])),
             beta_capabilities: Arc::new(RwLock::new(HashMap::new())),
             aip_overrides,
+            aip_derived_profile_ids: tokio::sync::RwLock::new(vec![]),
         }
     }
 
@@ -3773,6 +4007,889 @@ mod tests_aip_override_helpers {
         assert!(
             client.aip_override_for("claude-haiku-4-5").is_none(),
             "haiku has no override, must return None"
+        );
+    }
+}
+
+// ── Health loop union — Task 3 (Slice 2A) tests ──────────────────────────────
+//
+// These tests exercise `compute_health_state`, a pure-ish async function the
+// builder will add to this module. The function encapsulates the unified
+// health-loop body from spec §Slice 2 Health loop changes:
+//
+//   pub async fn compute_health_state<F, Fut>(
+//       cri_list_result: Result<Vec<String>, String>,
+//       aip_overrides: &HashMap<String, String>,
+//       get_foundation_model: F,
+//       routing_prefix: &str,
+//       legacy_inference_profile_arn: Option<&str>,
+//   ) -> (bool, Vec<String>)
+//   where
+//       F: Fn(String) -> Fut,
+//       Fut: Future<Output = Result<String, String>>,
+//
+// Parameters:
+//   cri_list_result   — The Ok/Err outcome of `ListInferenceProfiles` filtered to
+//                       this endpoint's routing prefix. `Ok(vec)` carries the
+//                       profile IDs already filtered to `<prefix>.` form (e.g.
+//                       `["us.anthropic.claude-haiku-4-5", ...]`).
+//   aip_overrides     — The endpoint's `aip_overrides` HashMap (model_id → AIP ARN).
+//                       From `EndpointClient.aip_overrides`.
+//   get_foundation_model — Async callback that takes an AIP ARN (`String`) and
+//                       returns `Ok(foundation_model_arn)` or `Err(reason)`. In
+//                       production this calls `GetInferenceProfile`; in tests it
+//                       is a simple closure.
+//   routing_prefix    — The endpoint's routing prefix (e.g. `"us"`). Used to
+//                       construct the `<prefix>.<bedrock_suffix>` model ID for
+//                       each resolved AIP foundation model.
+//   legacy_inference_profile_arn — `client.config.inference_profile_arn.as_deref()`.
+//                       Non-None only for endpoints that haven't completed the
+//                       auto-migration to the new table. When non-None AND
+//                       `aip_overrides` is empty, the function falls back to the
+//                       legacy single-ARN path (validate via get_foundation_model,
+//                       populate available_models with the resolved foundation model).
+//
+// Returns:
+//   (healthy: bool, available_models: Vec<String>)
+//
+//   - `healthy` is true iff CRI list succeeded AND every AIP override resolved.
+//   - `available_models` is the deduplicated union of CRI profiles + AIP-resolved
+//     `<routing_prefix>.<bedrock_suffix>` model IDs. On any failure, the function
+//     returns `(false, <empty-or-partial-vec>)` — callers must not rely on
+//     partial content when healthy=false.
+//
+// None of these tests require a database connection or AWS credentials.
+// The `get_foundation_model` callback is a sync-wrapped async closure.
+
+// ── tests_health_loop_union ─────────────────────────────────────────────────
+//
+// These tests exercise `compute_health_state`.  After Task 5 (Slice 2C), the
+// function returns a `HealthState` struct instead of a bare tuple:
+//
+//   pub struct HealthState {
+//       pub healthy: bool,
+//       pub available_models: Vec<String>,
+//       pub aip_derived_profile_ids: Vec<String>,
+//   }
+//
+// All tests in this block destructure `HealthState` using the struct field
+// syntax.  Tests 1-8 are the original Task 3 tests updated to the new return
+// type; tests 9-10 are new Task 5 additions.
+
+#[cfg(test)]
+mod tests_health_loop_union {
+    use super::*;
+    use std::collections::HashMap;
+
+    // ── Test 1: CRI + two AIP overrides → healthy union ───────────────────────
+
+    /// An endpoint with a successful CRI list and two healthy AIP overrides
+    /// must produce healthy=true and available_models = dedup'd union of CRI
+    /// profiles + AIP-resolved foundation models.
+    ///
+    /// CRI list:  ["us.anthropic.claude-haiku-4-5", "us.anthropic.claude-sonnet-4-5"]
+    /// AIP overrides:
+    ///   "claude-sonnet-4-5" → sonnet AIP ARN (foundation model resolves to same
+    ///                          Bedrock suffix as the CRI entry → dedup)
+    ///   "claude-opus-4-7"   → opus   AIP ARN (foundation model resolves to new entry)
+    ///
+    /// Expected available_models (order-insensitive):
+    ///   ["us.anthropic.claude-haiku-4-5",
+    ///    "us.anthropic.claude-sonnet-4-5",
+    ///    "us.anthropic.claude-opus-4-7"]
+    #[tokio::test]
+    async fn test_health_cri_plus_two_aip_overrides_healthy_union() {
+        let cri_result = Ok(vec![
+            "us.anthropic.claude-haiku-4-5".to_string(),
+            "us.anthropic.claude-sonnet-4-5".to_string(),
+        ]);
+
+        let mut aip_overrides = HashMap::new();
+        aip_overrides.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged"
+                .to_string(),
+        );
+        aip_overrides.insert(
+            "claude-opus-4-7".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-tagged"
+                .to_string(),
+        );
+
+        // Mock callback: each AIP ARN resolves to a foundation-model ARN whose
+        // tail is the Bedrock model suffix (without the routing prefix).
+        let get_fm = |arn: String| async move {
+            if arn.contains("sonnet-tagged") {
+                // Resolves to same suffix as the CRI entry — will be deduped.
+                Ok("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0"
+                    .to_string())
+            } else if arn.contains("opus-tagged") {
+                Ok(
+                    "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-7"
+                        .to_string(),
+                )
+            } else {
+                Err(format!("unexpected ARN in test: {arn}"))
+            }
+        };
+
+        let HealthState {
+            healthy,
+            mut available_models,
+            aip_derived_profile_ids: _,
+        } = compute_health_state(
+            cri_result,
+            &aip_overrides,
+            get_fm,
+            "us",
+            None, // no legacy ARN
+        )
+        .await;
+
+        assert!(
+            healthy,
+            "endpoint must be healthy when CRI list succeeded and all AIP overrides resolved"
+        );
+
+        available_models.sort();
+        assert_eq!(
+            available_models.len(),
+            3,
+            "available_models must contain exactly 3 entries (Haiku + Sonnet + Opus, \
+             with Sonnet deduped from CRI and AIP); got: {available_models:?}"
+        );
+        assert!(
+            available_models.contains(&"us.anthropic.claude-haiku-4-5".to_string()),
+            "available_models must include the Haiku CRI entry; got: {available_models:?}"
+        );
+        assert!(
+            available_models
+                .iter()
+                .any(|m| m.contains("claude-sonnet-4-5")),
+            "available_models must include a Sonnet entry; got: {available_models:?}"
+        );
+        assert!(
+            available_models
+                .iter()
+                .any(|m| m.contains("claude-opus-4-7")),
+            "available_models must include an Opus entry resolved from the AIP; \
+             got: {available_models:?}"
+        );
+    }
+
+    // ── Test 2: One failing AIP override → healthy=false ──────────────────────
+
+    /// When one AIP override returns an error from get_foundation_model, the
+    /// endpoint must be marked unhealthy and available_models must NOT be
+    /// advanced (to avoid advertising models that are unreachable).
+    ///
+    /// CRI list succeeds, but the Opus AIP call fails.
+    #[tokio::test]
+    async fn test_health_one_failing_aip_override_marks_unhealthy() {
+        let cri_result = Ok(vec![
+            "us.anthropic.claude-haiku-4-5".to_string(),
+            "us.anthropic.claude-sonnet-4-5".to_string(),
+        ]);
+
+        let mut aip_overrides = HashMap::new();
+        aip_overrides.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-ok"
+                .to_string(),
+        );
+        aip_overrides.insert(
+            "claude-opus-4-7".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-fail"
+                .to_string(),
+        );
+
+        let get_fm = |arn: String| async move {
+            if arn.contains("sonnet-ok") {
+                Ok("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0"
+                    .to_string())
+            } else {
+                // Opus AIP call fails — simulates GetInferenceProfile returning an error.
+                Err("GetInferenceProfile failed: ResourceNotFoundException".to_string())
+            }
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            aip_derived_profile_ids: _,
+        } = compute_health_state(cri_result, &aip_overrides, get_fm, "us", None).await;
+
+        assert!(
+            !healthy,
+            "endpoint must be unhealthy when any AIP override fails to resolve; \
+             got healthy=true with available_models={available_models:?}"
+        );
+        // available_models must NOT be advanced when the endpoint is unhealthy.
+        assert!(
+            available_models.is_empty(),
+            "available_models must be empty when the endpoint is unhealthy \
+             (spec: 'available_models not advanced'); got: {available_models:?}"
+        );
+    }
+
+    // ── Test 3: CRI-only endpoint (zero AIP overrides) → unchanged behavior ───
+
+    /// Regression guard: an endpoint with no AIP overrides must behave exactly
+    /// as today — available_models is the CRI list, healthy iff CRI succeeded.
+    #[tokio::test]
+    async fn test_health_cri_only_no_aip_overrides_regression() {
+        let cri_result = Ok(vec![
+            "us.anthropic.claude-haiku-4-5".to_string(),
+            "us.anthropic.claude-sonnet-4-5".to_string(),
+            "us.anthropic.claude-opus-4-7".to_string(),
+        ]);
+
+        // No AIP overrides — get_foundation_model should never be called.
+        let get_fm = |arn: String| async move {
+            panic!(
+                "get_foundation_model must NOT be called when aip_overrides is empty; \
+                 called with ARN: {arn}"
+            );
+            #[allow(unreachable_code)]
+            Err(String::new())
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            aip_derived_profile_ids: _,
+        } = compute_health_state(
+            cri_result,
+            &HashMap::new(), // empty overrides
+            get_fm,
+            "us",
+            None,
+        )
+        .await;
+
+        assert!(
+            healthy,
+            "CRI-only endpoint must be healthy when CRI list succeeded"
+        );
+        let mut available_models = available_models;
+        available_models.sort();
+        assert_eq!(
+            available_models,
+            vec![
+                "us.anthropic.claude-haiku-4-5",
+                "us.anthropic.claude-opus-4-7",
+                "us.anthropic.claude-sonnet-4-5",
+            ],
+            "available_models must be exactly the CRI list for a CRI-only endpoint"
+        );
+    }
+
+    /// Regression guard: CRI failure on a CRI-only endpoint marks it unhealthy.
+    #[tokio::test]
+    async fn test_health_cri_only_failure_marks_unhealthy() {
+        let cri_result: Result<Vec<String>, String> =
+            Err("ListInferenceProfiles failed: AccessDeniedException".to_string());
+
+        let get_fm = |arn: String| async move {
+            panic!(
+                "get_foundation_model must NOT be called when aip_overrides is empty; \
+                 called with ARN: {arn}"
+            );
+            #[allow(unreachable_code)]
+            Err(String::new())
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            aip_derived_profile_ids: _,
+        } = compute_health_state(cri_result, &HashMap::new(), get_fm, "us", None).await;
+
+        assert!(
+            !healthy,
+            "CRI-only endpoint must be unhealthy when CRI list fails"
+        );
+        assert!(
+            available_models.is_empty(),
+            "available_models must be empty when CRI list fails; got: {available_models:?}"
+        );
+    }
+
+    // ── Test 4: Legacy inference_profile_arn (no new table) → today's behavior ─
+
+    /// Auto-migration safety net: when `aip_overrides` is empty AND the legacy
+    /// `inference_profile_arn` column is set, the function must fall back to the
+    /// legacy single-ARN path:
+    ///   - Call get_foundation_model with the legacy ARN.
+    ///   - If it succeeds, populate available_models with the resolved
+    ///     `<routing_prefix>.<bedrock_suffix>` model ID.
+    ///   - healthy = success of the get_foundation_model call.
+    ///
+    /// This branch fires only when the auto-migration has NOT yet run for this
+    /// endpoint (empty new table + legacy column still set).
+    #[tokio::test]
+    async fn test_health_legacy_arn_no_new_table_preserves_today_behavior() {
+        // CRI list succeeds (it's always called)
+        let cri_result = Ok(vec![]);
+
+        let legacy_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/legacy-sonnet";
+
+        let get_fm = |arn: String| async move {
+            assert_eq!(
+                arn, legacy_arn,
+                "get_foundation_model must be called with the legacy ARN"
+            );
+            // Resolves to a Sonnet foundation model ARN.
+            Ok("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0"
+                .to_string())
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            aip_derived_profile_ids: _,
+        } = compute_health_state(
+            cri_result,
+            &HashMap::new(), // empty new table
+            get_fm,
+            "us",
+            Some(legacy_arn), // legacy column is set
+        )
+        .await;
+
+        assert!(
+            healthy,
+            "endpoint must be healthy when the legacy ARN resolves successfully"
+        );
+        assert_eq!(
+            available_models.len(),
+            1,
+            "available_models must have exactly one entry (the legacy AIP's foundation model); \
+             got: {available_models:?}"
+        );
+        assert!(
+            available_models[0].contains("claude-sonnet-4-5"),
+            "available_models entry must represent the resolved foundation model in \
+             '<routing_prefix>.<bedrock_suffix>' form; got: {}",
+            available_models[0]
+        );
+        assert!(
+            available_models[0].starts_with("us."),
+            "available_models entry must start with the routing prefix 'us.'; \
+             got: {}",
+            available_models[0]
+        );
+    }
+
+    /// Legacy path failure: when the legacy ARN's get_foundation_model call fails,
+    /// the endpoint must be unhealthy and available_models must be empty.
+    #[tokio::test]
+    async fn test_health_legacy_arn_failure_marks_unhealthy() {
+        let cri_result = Ok(vec![]);
+
+        let legacy_arn =
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/legacy-broken";
+
+        let get_fm = |arn: String| async move {
+            assert!(arn.contains("legacy-broken"), "unexpected ARN: {arn}");
+            Err("GetInferenceProfile failed: ResourceNotFoundException".to_string())
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            aip_derived_profile_ids: _,
+        } = compute_health_state(cri_result, &HashMap::new(), get_fm, "us", Some(legacy_arn)).await;
+
+        assert!(
+            !healthy,
+            "endpoint must be unhealthy when the legacy ARN fails to resolve"
+        );
+        assert!(
+            available_models.is_empty(),
+            "available_models must be empty when legacy ARN resolution fails; \
+             got: {available_models:?}"
+        );
+    }
+
+    // ── Test 5: Dedup — AIP foundation model already in CRI list ──────────────
+
+    /// When an AIP override resolves to a foundation model whose
+    /// `<routing_prefix>.<bedrock_suffix>` form is already present in the CRI list,
+    /// the model must appear exactly once in available_models.
+    ///
+    /// This guards against the double-emit scenario where both the CRI branch and
+    /// the AIP branch independently contribute the same Sonnet entry.
+    #[tokio::test]
+    async fn test_health_dedup_aip_foundation_model_coincides_with_cri() {
+        // CRI list already contains the Sonnet entry.
+        let cri_result = Ok(vec![
+            "us.anthropic.claude-haiku-4-5".to_string(),
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string(),
+        ]);
+
+        let mut aip_overrides = HashMap::new();
+        // This AIP resolves to the SAME Bedrock suffix as the CRI Sonnet entry.
+        aip_overrides.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-dup"
+                .to_string(),
+        );
+
+        let get_fm = |_arn: String| async move {
+            // Resolves to the same foundation model as the CRI "sonnet" entry.
+            Ok("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0"
+                .to_string())
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            aip_derived_profile_ids: _,
+        } = compute_health_state(cri_result, &aip_overrides, get_fm, "us", None).await;
+
+        assert!(healthy, "endpoint must be healthy");
+
+        let sonnet_count = available_models
+            .iter()
+            .filter(|m| m.contains("claude-sonnet-4-5"))
+            .count();
+        assert_eq!(
+            sonnet_count, 1,
+            "Sonnet must appear exactly once in available_models after dedup; \
+             got {sonnet_count} occurrences in: {available_models:?}"
+        );
+        assert_eq!(
+            available_models.len(),
+            2,
+            "available_models must have exactly 2 entries (Haiku + Sonnet deduped); \
+             got: {available_models:?}"
+        );
+    }
+
+    // ── Test 6: CRI failure with AIP overrides → unhealthy regardless of AIP ───
+
+    /// If the CRI ListInferenceProfiles call fails, the endpoint is unhealthy
+    /// even if all AIP overrides would have resolved successfully.
+    /// (Health rule: CRI AND every AIP override must succeed.)
+    #[tokio::test]
+    async fn test_health_cri_failure_with_aip_overrides_unhealthy() {
+        let cri_result: Result<Vec<String>, String> =
+            Err("ListInferenceProfiles failed: ThrottlingException".to_string());
+
+        let mut aip_overrides = HashMap::new();
+        aip_overrides.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-ok"
+                .to_string(),
+        );
+
+        let get_fm = |_arn: String| async move {
+            Ok("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0"
+                .to_string())
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            aip_derived_profile_ids: _,
+        } = compute_health_state(cri_result, &aip_overrides, get_fm, "us", None).await;
+
+        assert!(
+            !healthy,
+            "endpoint must be unhealthy when CRI list fails, regardless of AIP resolution"
+        );
+        assert!(
+            available_models.is_empty(),
+            "available_models must be empty when CRI list fails; got: {available_models:?}"
+        );
+    }
+
+    // ── Test 7 (new — Task 5): aip_derived_profile_ids populated correctly ─────
+
+    /// An endpoint with two AIP overrides and a non-overlapping CRI list.
+    /// `aip_derived_profile_ids` must contain exactly the two `<prefix>.<suffix>`
+    /// strings resolved from AIP overrides, NOT the CRI-only entries.
+    ///
+    /// CRI list: ["us.anthropic.claude-haiku-4-5"]  (Haiku — CRI only)
+    /// AIP overrides:
+    ///   "claude-sonnet-4-5" → sonnet-only AIP ARN  (distinct from CRI)
+    ///   "claude-opus-4-7"   → opus AIP ARN          (distinct from CRI)
+    ///
+    /// Expected aip_derived_profile_ids contains the resolved Sonnet and Opus
+    /// model IDs; Haiku must NOT appear in aip_derived_profile_ids.
+    #[tokio::test]
+    async fn test_health_state_aip_derived_profile_ids_populated() {
+        let cri_result = Ok(vec!["us.anthropic.claude-haiku-4-5".to_string()]);
+
+        let mut aip_overrides = HashMap::new();
+        aip_overrides.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-aip"
+                .to_string(),
+        );
+        aip_overrides.insert(
+            "claude-opus-4-7".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-aip"
+                .to_string(),
+        );
+
+        let get_fm = |arn: String| async move {
+            if arn.contains("sonnet-aip") {
+                Ok("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0"
+                    .to_string())
+            } else if arn.contains("opus-aip") {
+                Ok(
+                    "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-7"
+                        .to_string(),
+                )
+            } else {
+                Err(format!("unexpected ARN: {arn}"))
+            }
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            mut aip_derived_profile_ids,
+        } = compute_health_state(cri_result, &aip_overrides, get_fm, "us", None).await;
+
+        assert!(healthy, "endpoint must be healthy");
+        assert_eq!(
+            available_models.len(),
+            3,
+            "available_models must have 3 entries (Haiku + Sonnet + Opus); \
+             got: {available_models:?}"
+        );
+
+        // The AIP-derived set must contain exactly the two AIP-resolved entries.
+        aip_derived_profile_ids.sort();
+        assert_eq!(
+            aip_derived_profile_ids.len(),
+            2,
+            "aip_derived_profile_ids must contain exactly 2 entries (Sonnet + Opus); \
+             got: {aip_derived_profile_ids:?}"
+        );
+        assert!(
+            aip_derived_profile_ids
+                .iter()
+                .any(|id| id.contains("claude-sonnet-4-5")),
+            "aip_derived_profile_ids must include the AIP-resolved Sonnet entry; \
+             got: {aip_derived_profile_ids:?}"
+        );
+        assert!(
+            aip_derived_profile_ids
+                .iter()
+                .any(|id| id.contains("claude-opus-4-7")),
+            "aip_derived_profile_ids must include the AIP-resolved Opus entry; \
+             got: {aip_derived_profile_ids:?}"
+        );
+        // Haiku is CRI-only and must NOT appear in aip_derived_profile_ids.
+        assert!(
+            !aip_derived_profile_ids
+                .iter()
+                .any(|id| id.contains("claude-haiku-4-5")),
+            "aip_derived_profile_ids must NOT include the CRI-only Haiku entry; \
+             got: {aip_derived_profile_ids:?}"
+        );
+    }
+
+    // ── Test 8 (new — Task 5): overlapping AIP + CRI → CRI provenance wins ────
+
+    /// When an AIP override resolves to a `<prefix>.<suffix>` that is already
+    /// in the CRI list, the dedup logic treats it as CRI provenance.  The model
+    /// must appear in `available_models` exactly once, and it must NOT appear
+    /// in `aip_derived_profile_ids`.
+    ///
+    /// CRI list: ["us.anthropic.claude-haiku-4-5",
+    ///            "us.anthropic.claude-sonnet-4-5-20250929-v1:0"]
+    /// AIP override: "claude-sonnet-4-5" → ARN that resolves to the same Sonnet suffix
+    ///
+    /// Expected: aip_derived_profile_ids is EMPTY (overlap treated as CRI).
+    #[tokio::test]
+    async fn test_health_state_aip_derived_excludes_cri_dedup_overlap() {
+        let cri_result = Ok(vec![
+            "us.anthropic.claude-haiku-4-5".to_string(),
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string(),
+        ]);
+
+        let mut aip_overrides = HashMap::new();
+        // AIP resolves to the same suffix that is already in the CRI list.
+        aip_overrides.insert(
+            "claude-sonnet-4-5".to_string(),
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-overlap"
+                .to_string(),
+        );
+
+        let get_fm = |_arn: String| async move {
+            Ok("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0"
+                .to_string())
+        };
+
+        let HealthState {
+            healthy,
+            available_models,
+            aip_derived_profile_ids,
+        } = compute_health_state(cri_result, &aip_overrides, get_fm, "us", None).await;
+
+        assert!(healthy, "endpoint must be healthy");
+        assert_eq!(
+            available_models.len(),
+            2,
+            "available_models must have exactly 2 entries (Haiku + Sonnet deduped); \
+             got: {available_models:?}"
+        );
+
+        // Because the AIP-resolved Sonnet is already covered by a CRI entry,
+        // CRI provenance wins and aip_derived_profile_ids must be empty.
+        assert!(
+            aip_derived_profile_ids.is_empty(),
+            "aip_derived_profile_ids must be empty when all AIP-resolved entries \
+             are already covered by CRI; got: {aip_derived_profile_ids:?}"
+        );
+    }
+}
+
+// ── Capability-probe opt-out — Task 5 (Slice 2C) tests ───────────────────────
+//
+// These tests exercise two pure helpers added to this module:
+//
+//   pub fn should_probe_profile(
+//       profile_id: &str,
+//       aip_derived_profile_ids: &[String],
+//       capability_probe_aip_enabled: bool,
+//   ) -> bool
+//
+// and (in a separate module below):
+//
+//   pub fn effective_capability_probe_aip(
+//       db_setting: Option<&str>,
+//       env_value: Option<&str>,
+//   ) -> bool
+//
+// Behaviour of `should_probe_profile`:
+//   - flag true  → always return true.
+//   - flag false, profile is in aip_derived_profile_ids → return false.
+//   - flag false, profile is NOT in aip_derived_profile_ids → return true.
+//
+// None of these tests require a database connection or AWS credentials.
+
+#[cfg(test)]
+mod tests_capability_probe_aip {
+    use super::*;
+
+    // ── Test 1: flag=true, AIP-derived entry → probe ──────────────────────────
+
+    /// When `capability_probe_aip_enabled` is `true`, every profile is probed
+    /// regardless of whether it is AIP-derived.  This is the default path.
+    #[test]
+    fn test_should_probe_returns_true_when_flag_enabled_aip_entry() {
+        let aip_derived = vec!["us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string()];
+        let result = should_probe_profile(
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            &aip_derived,
+            true, // flag enabled
+        );
+        assert!(
+            result,
+            "should_probe_profile must return true when flag is enabled, \
+             even for an AIP-derived entry"
+        );
+    }
+
+    // ── Test 2: flag=true, CRI-only entry → probe ─────────────────────────────
+
+    /// When `capability_probe_aip_enabled` is `true`, CRI-only profiles are
+    /// also always probed (this was the pre-Task-5 behaviour).
+    #[test]
+    fn test_should_probe_returns_true_when_flag_enabled_cri_entry() {
+        let aip_derived: Vec<String> =
+            vec!["us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string()];
+        let result = should_probe_profile(
+            "us.anthropic.claude-haiku-4-5", // Haiku — CRI only, not in aip_derived
+            &aip_derived,
+            true, // flag enabled
+        );
+        assert!(
+            result,
+            "should_probe_profile must return true for a CRI-only profile \
+             when flag is enabled"
+        );
+    }
+
+    // ── Test 3: flag=false, AIP-derived entry → skip ─────────────────────────
+
+    /// When `capability_probe_aip_enabled` is `false` and the profile ID is
+    /// present in `aip_derived_profile_ids`, the probe must be skipped.
+    ///
+    /// This is the core gate behaviour added by Task 5.
+    #[test]
+    fn test_should_probe_skips_aip_entry_when_flag_disabled() {
+        let aip_derived = vec![
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string(),
+            "us.anthropic.claude-opus-4-7".to_string(),
+        ];
+        let result = should_probe_profile(
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            &aip_derived,
+            false, // flag disabled
+        );
+        assert!(
+            !result,
+            "should_probe_profile must return false (skip) when flag is disabled \
+             and the profile is AIP-derived"
+        );
+    }
+
+    // ── Test 4: flag=false, CRI-only entry → probe ───────────────────────────
+
+    /// When `capability_probe_aip_enabled` is `false` but the profile is NOT in
+    /// `aip_derived_profile_ids`, the probe must proceed (CRI entries are always
+    /// probed regardless of the flag).
+    #[test]
+    fn test_should_probe_runs_cri_entry_when_flag_disabled() {
+        let aip_derived = vec!["us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string()];
+        let result = should_probe_profile(
+            "us.anthropic.claude-haiku-4-5", // CRI only — not in aip_derived
+            &aip_derived,
+            false, // flag disabled
+        );
+        assert!(
+            result,
+            "should_probe_profile must return true (probe) for a CRI-only profile \
+             even when the capability probe AIP flag is disabled"
+        );
+    }
+
+    // ── Test 5: flag=false, empty AIP set → all profiles probed ──────────────
+
+    /// When `aip_derived_profile_ids` is empty (e.g. a pure CRI endpoint) and
+    /// the flag is `false`, every profile is still probed because none match
+    /// the (empty) AIP-derived set.
+    #[test]
+    fn test_should_probe_empty_aip_set_with_flag_disabled() {
+        let result = should_probe_profile(
+            "us.anthropic.claude-haiku-4-5",
+            &[], // empty AIP-derived set
+            false,
+        );
+        assert!(
+            result,
+            "should_probe_profile must return true when aip_derived_profile_ids \
+             is empty, regardless of flag value"
+        );
+    }
+}
+
+// ── Effective-flag resolution — Task 5 (Slice 2C) tests ─────────────────────
+//
+// These tests exercise:
+//
+//   pub fn effective_capability_probe_aip(
+//       db_setting: Option<&str>,    // value from proxy_settings.capability_probe_aip
+//       env_value: Option<&str>,     // value of CAPABILITY_PROBE_AIP env var if set
+//   ) -> bool
+//
+// Precedence:
+//   1. `db_setting` (if Some) — DB wins.
+//   2. `env_value`  (if Some and parseable) — env used when DB absent.
+//   3. Default `true` — both absent, or env value is malformed.
+//
+// Parsing is case-insensitive: "TRUE", "False", "1", "0", etc. are valid.
+
+#[cfg(test)]
+mod tests_effective_capability_probe_flag {
+    use super::*;
+
+    // ── Test 8: DB setting overrides env (DB=true, env=false → true) ──────────
+
+    /// DB setting `"true"` wins over env var `"false"`.  DB is the highest
+    /// precedence source.
+    #[test]
+    fn test_effective_flag_db_overrides_env_true_over_false() {
+        let result = effective_capability_probe_aip(
+            Some("true"),  // DB setting
+            Some("false"), // env var
+        );
+        assert!(result, "DB setting 'true' must win over env 'false'");
+    }
+
+    // ── Test 9: DB setting overrides env (DB=false, env=true → false) ─────────
+
+    /// DB setting `"false"` wins over env var `"true"`.
+    #[test]
+    fn test_effective_flag_db_overrides_env_false_over_true() {
+        let result = effective_capability_probe_aip(
+            Some("false"), // DB setting
+            Some("true"),  // env var
+        );
+        assert!(!result, "DB setting 'false' must win over env 'true'");
+    }
+
+    // ── Test 10: DB absent → env var used ────────────────────────────────────
+
+    /// When the DB has no row, the env var value is used.
+    #[test]
+    fn test_effective_flag_env_used_when_db_absent() {
+        let result = effective_capability_probe_aip(
+            None,          // no DB row
+            Some("false"), // env var says false
+        );
+        assert!(
+            !result,
+            "env var 'false' must be respected when no DB setting is present"
+        );
+    }
+
+    // ── Test 11: both absent → default true ──────────────────────────────────
+
+    /// When neither the DB row nor the env var is set, the effective flag is
+    /// the hard-coded default: `true` (probe everything).
+    #[test]
+    fn test_effective_flag_default_true_when_both_absent() {
+        let result = effective_capability_probe_aip(
+            None, // no DB row
+            None, // no env var
+        );
+        assert!(
+            result,
+            "effective_capability_probe_aip must default to true when both \
+             db_setting and env_value are absent"
+        );
+    }
+
+    // ── Test 12: malformed env var → fall back to default ────────────────────
+
+    /// An unrecognised env var value (e.g. `"yes"`, `"enabled"`) must fall
+    /// back to the default `true` rather than panic or incorrectly parse.
+    #[test]
+    fn test_effective_flag_malformed_falls_back_to_default() {
+        let result = effective_capability_probe_aip(
+            None,        // no DB row
+            Some("yes"), // unrecognised value
+        );
+        assert!(
+            result,
+            "malformed env var 'yes' must fall back to the default of true"
+        );
+    }
+
+    // ── Test 13: case-insensitive parsing ────────────────────────────────────
+
+    /// Both `"TRUE"` and `"False"` (mixed case) must parse correctly.
+    #[test]
+    fn test_effective_flag_case_insensitive() {
+        let upper_true = effective_capability_probe_aip(Some("TRUE"), None);
+        assert!(
+            upper_true,
+            "DB setting 'TRUE' (upper-case) must parse as true"
+        );
+
+        let mixed_false = effective_capability_probe_aip(Some("False"), None);
+        assert!(
+            !mixed_false,
+            "DB setting 'False' (mixed-case) must parse as false"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod db;
 pub mod detection;
 pub mod endpoint;
+pub mod migrations;
 pub mod pricing;
 pub mod proxy;
 pub mod quota;

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,6 +449,8 @@ async fn main() -> anyhow::Result<()> {
     // Start Bedrock health poll loop (60s interval) — checks gateway default + all endpoints
     {
         let state_for_health = Arc::clone(&state);
+        // Capture CAPABILITY_PROBE_AIP env var once; read fresh DB setting each tick.
+        let capability_probe_aip_env: Option<String> = std::env::var("CAPABILITY_PROBE_AIP").ok();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
             let mut was_healthy = true;
@@ -501,110 +503,173 @@ async fn main() -> anyhow::Result<()> {
                 // Check all endpoint clients
                 let clients = state_for_health.endpoint_pool.get_all_clients().await;
                 for client in &clients {
-                    let ep_ok = if let Some(arn) = &client.config.inference_profile_arn {
-                        // For application inference profile endpoints, validate the specific ARN
-                        client
-                            .control_client
-                            .get_inference_profile()
-                            .inference_profile_identifier(arn)
-                            .send()
-                            .await
-                            .is_ok()
-                    } else {
-                        // For standard CRI endpoints, fetch the full profile list and cache it.
+                    // ── Step 1: CRI list (always fetched) ─────────────────────
+                    let prefix_dot = format!("{}.", client.config.routing_prefix);
+                    let cri_list_result: Result<Vec<String>, String> =
                         match client.control_client.list_inference_profiles().send().await {
-                            Ok(resp) => {
-                                let prefix_dot = format!("{}.", client.config.routing_prefix);
-                                let profile_ids: Vec<String> = resp
-                                    .inference_profile_summaries()
-                                    .iter()
-                                    .map(|p| p.inference_profile_id().to_string())
-                                    .filter(|id| id.starts_with(&prefix_dot))
-                                    .collect();
-                                // Snapshot profiles for seed probing before releasing the lock.
-                                let profiles_snapshot = profile_ids.clone();
-                                let mut models = client.available_models.write().await;
-                                *models = profile_ids;
-                                drop(models);
+                            Ok(resp) => Ok(resp
+                                .inference_profile_summaries()
+                                .iter()
+                                .map(|p| p.inference_profile_id().to_string())
+                                .filter(|id| id.starts_with(&prefix_dot))
+                                .collect()),
+                            Err(e) => Err(format!(
+                                "ListInferenceProfiles failed for {}: {e:?}",
+                                client.config.name
+                            )),
+                        };
 
-                                // ── 1M context seed probe step ──────────────────────────
-                                // For each (profile, beta) pair that is absent or expired,
-                                // fire a synthetic 1-token InvokeModel to learn whether
-                                // the beta is supported on this endpoint.
-                                // Probes are sequenced sequentially (no join_all) — the
-                                // total load is bounded by |profiles| × |SUFFIX_BETA_MAP|.
-                                let pairs = client.expired_seed_pairs(&profiles_snapshot).await;
-                                for (profile, beta) in &pairs {
-                                    // Build Bedrock request body directly — NOT via translate().
-                                    let probe_body = format!(
-                                        r#"{{"anthropic_version":"bedrock-2023-05-31","anthropic_beta":["{beta}"],"max_tokens":1,"messages":[{{"role":"user","content":"hi"}}]}}"#
-                                    );
-                                    let probe_result = client
-                                        .runtime_client
-                                        .invoke_model()
-                                        .model_id(profile)
-                                        .content_type("application/json")
-                                        .accept("application/json")
-                                        .body(aws_sdk_bedrockruntime::primitives::Blob::new(
-                                            probe_body.into_bytes(),
-                                        ))
-                                        .send()
-                                        .await;
-
-                                    let (success, is_validation_exception, error_message) =
-                                        match probe_result {
-                                            Ok(_) => (true, false, String::new()),
-                                            Err(ref sdk_err) => {
-                                                use aws_sdk_bedrockruntime::error::SdkError;
-                                                let err_str = format!("{sdk_err:?}");
-                                                let is_ve = matches!(
-                                                    sdk_err,
-                                                    SdkError::ServiceError(svc)
-                                                    if svc.err().is_validation_exception()
-                                                );
-                                                (false, is_ve, err_str)
-                                            }
-                                        };
-
-                                    let outcome = ccag::endpoint::classify_probe_outcome(
-                                        success,
-                                        is_validation_exception,
-                                        &error_message,
-                                        beta,
-                                    );
-
-                                    if !success
-                                        && matches!(
-                                            outcome,
-                                            ccag::endpoint::ProbeOutcome::Inconclusive
-                                        )
-                                    {
-                                        tracing::warn!(
-                                            profile = %profile,
-                                            beta = %beta,
-                                            err = %error_message,
-                                            "1m_probe failed to invoke (inconclusive)"
-                                        );
-                                    }
-
-                                    tracing::info!(
-                                        profile = %profile,
-                                        beta = %beta,
-                                        outcome = ?outcome,
-                                        "1m_probe outcome"
-                                    );
-
-                                    ccag::endpoint::apply_probe_outcome(
-                                        client, profile, beta, outcome,
-                                    )
-                                    .await;
-                                }
-
-                                true
-                            }
-                            Err(_) => false,
+                    // ── Step 2: get_foundation_model closure ───────────────────
+                    // Calls GetInferenceProfile and returns the raw foundation-model ARN.
+                    let control_client = client.control_client.clone();
+                    let get_foundation_model = |arn: String| {
+                        let control = control_client.clone();
+                        async move {
+                            let resp = control
+                                .get_inference_profile()
+                                .inference_profile_identifier(&arn)
+                                .send()
+                                .await
+                                .map_err(|e| {
+                                    format!("GetInferenceProfile failed for {arn}: {e:?}")
+                                })?;
+                            resp.models()
+                                .iter()
+                                .next()
+                                .and_then(|m| m.model_arn())
+                                .map(|s| s.to_string())
+                                .ok_or_else(|| {
+                                    format!("GetInferenceProfile returned no model ARN for {arn}")
+                                })
                         }
                     };
+
+                    // ── Step 3: compute unified health state ───────────────────
+                    let ccag::endpoint::HealthState {
+                        healthy: ep_ok,
+                        available_models: new_available_models,
+                        aip_derived_profile_ids: new_aip_derived,
+                    } = ccag::endpoint::compute_health_state(
+                        cri_list_result,
+                        &client.aip_overrides,
+                        get_foundation_model,
+                        &client.config.routing_prefix,
+                        client.config.inference_profile_arn.as_deref(),
+                    )
+                    .await;
+
+                    // ── Step 4: update available_models on success ─────────────
+                    // Only overwrite when healthy — keep last good list on failure.
+                    let profiles_snapshot: Vec<String>;
+                    let aip_derived_profile_ids: Vec<String>;
+                    if ep_ok && !new_available_models.is_empty() {
+                        profiles_snapshot = new_available_models.clone();
+                        aip_derived_profile_ids = new_aip_derived.clone();
+                        let mut models = client.available_models.write().await;
+                        *models = new_available_models;
+                        drop(models);
+                        let mut aip_derived = client.aip_derived_profile_ids.write().await;
+                        *aip_derived = new_aip_derived;
+                        drop(aip_derived);
+                    } else {
+                        // Read current list for seed-probe step (no change on failure).
+                        profiles_snapshot = client.available_models.read().await.clone();
+                        aip_derived_profile_ids =
+                            client.aip_derived_profile_ids.read().await.clone();
+                    }
+
+                    // ── Step 5: seed-probe loop ────────────────────────────────
+                    // Only run probes when the endpoint is currently healthy.
+                    if ep_ok {
+                        // Resolve the effective CAPABILITY_PROBE_AIP flag for this tick.
+                        // DB setting wins over env var; missing/malformed falls through to true.
+                        let probe_pool = state_for_health.db_pool.read().await.clone();
+                        let db_probe_setting =
+                            ccag::db::settings::get_setting(&probe_pool, "capability_probe_aip")
+                                .await
+                                .ok()
+                                .flatten();
+                        let effective_probe_aip = ccag::endpoint::effective_capability_probe_aip(
+                            db_probe_setting.as_deref(),
+                            capability_probe_aip_env.as_deref(),
+                        );
+
+                        // For each (profile, beta) pair that is absent or expired,
+                        // fire a synthetic 1-token InvokeModel to learn whether
+                        // the beta is supported on this endpoint.
+                        // Probes are sequenced sequentially (no join_all) — the
+                        // total load is bounded by |profiles| × |SUFFIX_BETA_MAP|.
+                        let pairs = client.expired_seed_pairs(&profiles_snapshot).await;
+                        for (profile, beta) in &pairs {
+                            // Skip AIP-derived profiles when the capability-probe
+                            // AIP flag is disabled.
+                            if !ccag::endpoint::should_probe_profile(
+                                profile,
+                                &aip_derived_profile_ids,
+                                effective_probe_aip,
+                            ) {
+                                continue;
+                            }
+                            // Build Bedrock request body directly — NOT via translate().
+                            let probe_body = format!(
+                                r#"{{"anthropic_version":"bedrock-2023-05-31","anthropic_beta":["{beta}"],"max_tokens":1,"messages":[{{"role":"user","content":"hi"}}]}}"#
+                            );
+                            let probe_result = client
+                                .runtime_client
+                                .invoke_model()
+                                .model_id(profile)
+                                .content_type("application/json")
+                                .accept("application/json")
+                                .body(aws_sdk_bedrockruntime::primitives::Blob::new(
+                                    probe_body.into_bytes(),
+                                ))
+                                .send()
+                                .await;
+
+                            let (success, is_validation_exception, error_message) =
+                                match probe_result {
+                                    Ok(_) => (true, false, String::new()),
+                                    Err(ref sdk_err) => {
+                                        use aws_sdk_bedrockruntime::error::SdkError;
+                                        let err_str = format!("{sdk_err:?}");
+                                        let is_ve = matches!(
+                                            sdk_err,
+                                            SdkError::ServiceError(svc)
+                                            if svc.err().is_validation_exception()
+                                        );
+                                        (false, is_ve, err_str)
+                                    }
+                                };
+
+                            let outcome = ccag::endpoint::classify_probe_outcome(
+                                success,
+                                is_validation_exception,
+                                &error_message,
+                                beta,
+                            );
+
+                            if !success
+                                && matches!(outcome, ccag::endpoint::ProbeOutcome::Inconclusive)
+                            {
+                                tracing::warn!(
+                                    profile = %profile,
+                                    beta = %beta,
+                                    err = %error_message,
+                                    "1m_probe failed to invoke (inconclusive)"
+                                );
+                            }
+
+                            tracing::info!(
+                                profile = %profile,
+                                beta = %beta,
+                                outcome = ?outcome,
+                                "1m_probe outcome"
+                            );
+
+                            ccag::endpoint::apply_probe_outcome(client, profile, beta, outcome)
+                                .await;
+                        }
+                    }
 
                     let now_secs = std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,12 +303,15 @@ async fn main() -> anyhow::Result<()> {
                             // Reload after marking default so is_default is reflected in pool.
                             match ccag::db::endpoints::get_enabled_endpoints(&pool).await {
                                 Ok(eps) => {
-                                    state.endpoint_pool.load_endpoints(eps, &aws_config).await
+                                    state
+                                        .endpoint_pool
+                                        .load_endpoints_with_db(eps, &aws_config, &pool)
+                                        .await
                                 }
                                 Err(_) => {
                                     state
                                         .endpoint_pool
-                                        .load_endpoints(vec![ep], &aws_config)
+                                        .load_endpoints_with_db(vec![ep], &aws_config, &pool)
                                         .await
                                 }
                             }
@@ -319,7 +322,7 @@ async fn main() -> anyhow::Result<()> {
                     let count = endpoints.len();
                     state
                         .endpoint_pool
-                        .load_endpoints(endpoints, &aws_config)
+                        .load_endpoints_with_db(endpoints, &aws_config, &pool)
                         .await;
                     tracing::info!(count, "Loaded endpoints into pool");
                 }
@@ -336,6 +339,99 @@ async fn main() -> anyhow::Result<()> {
 
     // Start cache version polling loop (5s interval)
     start_cache_poll_loop(Arc::clone(&state));
+
+    // Self-healing startup migration: populate endpoint_aip_overrides from the
+    // legacy inference_profile_arn column for endpoints that haven't been migrated yet.
+    {
+        let pool = state.db().await;
+
+        // Build candidate list from all loaded endpoint clients that have a legacy ARN.
+        let all_clients = state.endpoint_pool.get_all_clients().await;
+
+        let candidates: Vec<ccag::migrations::aip_legacy::EndpointMigrationCandidate> = all_clients
+            .iter()
+            .filter_map(|c| {
+                c.config.inference_profile_arn.as_ref().map(|arn| {
+                    ccag::migrations::aip_legacy::EndpointMigrationCandidate {
+                        endpoint_id: c.config.id,
+                        legacy_arn: arn.clone(),
+                    }
+                })
+            })
+            .collect();
+
+        if !candidates.is_empty() {
+            // Build a map from legacy_arn -> control_client so the closure can
+            // call GetInferenceProfile with the correct per-endpoint credentials.
+            let arn_to_client: std::collections::HashMap<
+                String,
+                Arc<ccag::endpoint::EndpointClient>,
+            > = all_clients
+                .iter()
+                .filter_map(|c| {
+                    c.config
+                        .inference_profile_arn
+                        .as_ref()
+                        .map(|arn| (arn.clone(), Arc::clone(c)))
+                })
+                .collect();
+
+            let model_cache_ref = state.model_cache.clone();
+
+            let get_foundation_model = move |arn: &str| {
+                let arn_owned = arn.to_string();
+                let client = arn_to_client.get(&arn_owned).cloned();
+                let mc = model_cache_ref.clone();
+                async move {
+                    let control = match client {
+                        Some(c) => c.control_client.clone(),
+                        None => {
+                            return Err(format!("No endpoint client found for ARN: {arn_owned}"));
+                        }
+                    };
+
+                    // Call GetInferenceProfile to find the foundation-model ARN.
+                    let resp = control
+                        .get_inference_profile()
+                        .inference_profile_identifier(&arn_owned)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            format!("GetInferenceProfile failed for {arn_owned}: {e:?}")
+                        })?;
+
+                    // Extract the first model ARN from the profile.
+                    // `GetInferenceProfileOutput` exposes `models()` directly.
+                    let fm_arn = resp
+                        .models()
+                        .iter()
+                        .next()
+                        .and_then(|m| m.model_arn())
+                        .map(|s| s.to_string())
+                        .ok_or_else(|| {
+                            format!("GetInferenceProfile returned no model ARN for {arn_owned}")
+                        })?;
+
+                    // Parse foundation-model id from ARN tail, then map to Anthropic name.
+                    let tail = ccag::translate::models::parse_foundation_model_from_arn(&fm_arn)?;
+                    let anthropic_id =
+                        ccag::translate::models::bedrock_to_anthropic(tail, Some(&mc));
+                    Ok(anthropic_id)
+                }
+            };
+
+            match ccag::migrations::aip_legacy::migrate_legacy_aip_endpoints(
+                &candidates,
+                &pool,
+                get_foundation_model,
+            )
+            .await
+            {
+                Ok(()) => tracing::info!("Legacy AIP startup migration complete"),
+                Err(e) => tracing::warn!(%e, "Legacy AIP startup migration encountered an error"),
+            }
+        }
+    }
 
     // Start IAM token refresh loop (10 min interval) if IAM auth is enabled
     if let (true, Some(host)) = (iam_auth_enabled, iam_db_host) {
@@ -933,7 +1029,7 @@ fn start_cache_poll_loop(state: Arc<proxy::GatewayState>) {
                         let count = endpoints.len();
                         state
                             .endpoint_pool
-                            .load_endpoints(endpoints, &state.aws_config)
+                            .load_endpoints_with_db(endpoints, &state.aws_config, pool)
                             .await;
                         tracing::debug!(count, "Reloaded endpoints");
                     }

--- a/src/migrations/aip_legacy.rs
+++ b/src/migrations/aip_legacy.rs
@@ -1,0 +1,108 @@
+use uuid::Uuid;
+
+/// A candidate endpoint for the startup auto-migration.
+///
+/// Carries only the minimal data the migration runner needs: the endpoint's
+/// primary key and the legacy `inference_profile_arn` column value.
+#[derive(Debug, Clone)]
+pub struct EndpointMigrationCandidate {
+    pub endpoint_id: Uuid,
+    pub legacy_arn: String,
+}
+
+/// Self-healing startup migration for legacy single-AIP endpoints.
+///
+/// For each `candidate` whose `endpoint_id` has **zero** rows in
+/// `endpoint_aip_overrides`, calls `get_foundation_model(legacy_arn)` to
+/// determine the Anthropic logical model ID and inserts one override row with:
+/// - `model_id`  = the value returned by `get_foundation_model`
+/// - `aip_arn`   = `legacy_arn`
+/// - `set_by`    = `"auto-migration"`
+/// - `reason`    = `"migrated from inference_profile_arn column"`
+///
+/// The legacy `inference_profile_arn` column is **not** cleared.
+///
+/// # Error handling
+///
+/// Per-endpoint errors (from `get_foundation_model` or from the DB insert) are
+/// logged as warnings and the runner continues to the next endpoint.  The function
+/// returns `Ok(())` even when individual endpoints fail, so that startup is never
+/// blocked by a single bad endpoint.
+pub async fn migrate_legacy_aip_endpoints<F, Fut>(
+    candidates: &[EndpointMigrationCandidate],
+    pool: &sqlx::PgPool,
+    get_foundation_model: F,
+) -> anyhow::Result<()>
+where
+    F: Fn(&str) -> Fut + Send + Sync,
+    Fut: std::future::Future<Output = Result<String, String>> + Send,
+{
+    for candidate in candidates {
+        let endpoint_id = candidate.endpoint_id;
+        let legacy_arn = &candidate.legacy_arn;
+
+        // Skip endpoints that already have at least one override row.
+        match crate::db::endpoint_aip_overrides::list_by_endpoint(pool, endpoint_id).await {
+            Ok(rows) if !rows.is_empty() => {
+                tracing::debug!(
+                    %endpoint_id,
+                    existing_rows = rows.len(),
+                    "Skipping endpoint: already has AIP override rows"
+                );
+                continue;
+            }
+            Ok(_) => { /* zero rows — proceed */ }
+            Err(e) => {
+                tracing::warn!(
+                    %endpoint_id,
+                    %e,
+                    "Failed to check existing AIP override rows for endpoint — skipping"
+                );
+                continue;
+            }
+        }
+
+        // Resolve the foundation model via the injected closure.
+        let model_id = match get_foundation_model(legacy_arn).await {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::warn!(
+                    %endpoint_id,
+                    legacy_arn = %legacy_arn,
+                    error = %e,
+                    "get_foundation_model failed for endpoint — skipping migration for this endpoint"
+                );
+                continue;
+            }
+        };
+
+        // Insert the override row.
+        if let Err(e) = crate::db::endpoint_aip_overrides::insert(
+            pool,
+            endpoint_id,
+            &model_id,
+            legacy_arn,
+            "auto-migration",
+            Some("migrated from inference_profile_arn column"),
+        )
+        .await
+        {
+            tracing::warn!(
+                %endpoint_id,
+                model_id = %model_id,
+                %e,
+                "Failed to insert AIP override row for endpoint — skipping"
+            );
+            continue;
+        }
+
+        tracing::info!(
+            %endpoint_id,
+            model_id = %model_id,
+            aip_arn = %legacy_arn,
+            "Auto-migrated legacy inference_profile_arn to endpoint_aip_overrides"
+        );
+    }
+
+    Ok(())
+}

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -1,0 +1,1 @@
+pub mod aip_legacy;

--- a/src/translate/models.rs
+++ b/src/translate/models.rs
@@ -355,6 +355,34 @@ fn hardcoded_anthropic_to_bedrock(model: &str, prefix: &str) -> String {
     }
 }
 
+/// Parse the Bedrock foundation-model ID from the tail of a foundation-model ARN.
+///
+/// Expects an ARN of the form:
+///   `arn:aws:bedrock:<region>:<account>:foundation-model/<model-id>`
+///
+/// Returns `Ok(&str)` containing the model ID after `foundation-model/`, or
+/// `Err(String)` when the segment is absent or the tail is empty.
+pub fn parse_foundation_model_from_arn(arn: &str) -> Result<&str, String> {
+    const SEGMENT: &str = "foundation-model/";
+    match arn.find(SEGMENT) {
+        Some(idx) => {
+            let tail = &arn[idx + SEGMENT.len()..];
+            if tail.is_empty() {
+                Err(format!(
+                    "ARN '{}' has an empty tail after 'foundation-model/'",
+                    arn
+                ))
+            } else {
+                Ok(tail)
+            }
+        }
+        None => Err(format!(
+            "ARN '{}' does not contain a 'foundation-model/' segment",
+            arn
+        )),
+    }
+}
+
 /// Map Bedrock model IDs back to Anthropic-format IDs for responses.
 ///
 /// Checks the dynamic cache first, falls back to hardcoded mappings.
@@ -1291,6 +1319,306 @@ mod tests_t4_suffix_strip {
         assert_eq!(
             result, "claude[1m]-opus-4-7",
             "Bracket not at end of string must NOT be stripped (regex is end-anchored)"
+        );
+    }
+}
+
+// ── Task 2: ARN-tail parser tests ────────────────────────────────────────────
+//
+// These tests cover the pure `parse_foundation_model_from_arn` helper that the
+// self-healing migration runner uses to extract a Bedrock foundation-model id
+// from an inference-profile ARN.
+//
+// BUILDER CONTRACT:
+//   Add `pub fn parse_foundation_model_from_arn(arn: &str) -> Result<&str, String>`
+//   to THIS file (src/translate/models.rs), adjacent to `bedrock_to_anthropic`.
+//
+//   The function must:
+//   1. Accept a full ARN string.
+//   2. Find the `foundation-model/` segment and return everything after the `/`.
+//   3. Return `Err(String)` when the segment is absent or the tail is empty.
+//
+//   The returned `&str` slice is the *Bedrock* model id as found in the ARN tail
+//   (e.g. `"anthropic.claude-sonnet-4-5-20250929-v1:0"`).  The caller then passes
+//   this value to `bedrock_to_anthropic(tail, None)` to get the logical Anthropic
+//   model name.
+//
+// The tests MUST FAIL (unresolved name) until the builder adds the function.
+
+#[cfg(test)]
+mod tests_task2_arn_parser {
+    use super::*;
+
+    // ── 1. Happy-path ARN parsing ─────────────────────────────────────────────
+
+    /// Well-formed foundation-model ARN (Sonnet 4.5) → returns the tail after
+    /// `foundation-model/`.
+    #[test]
+    fn test_parse_foundation_model_from_arn_sonnet_4_5() {
+        let arn = "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0";
+        let result = parse_foundation_model_from_arn(arn);
+        assert!(
+            result.is_ok(),
+            "parse_foundation_model_from_arn must succeed for a well-formed ARN; got {result:?}"
+        );
+        assert_eq!(
+            result.unwrap(),
+            "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "returned tail must be the foundation-model id exactly as it appears in the ARN"
+        );
+    }
+
+    /// Well-formed foundation-model ARN (Haiku 4.5) → returns the tail.
+    #[test]
+    fn test_parse_foundation_model_from_arn_haiku_4_5() {
+        let arn = "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0";
+        let result = parse_foundation_model_from_arn(arn);
+        assert!(result.is_ok(), "haiku ARN must parse successfully");
+        assert_eq!(result.unwrap(), "anthropic.claude-haiku-4-5-20251001-v1:0");
+    }
+
+    /// Well-formed foundation-model ARN (Opus 4.7) → returns the tail.
+    #[test]
+    fn test_parse_foundation_model_from_arn_opus_4_7() {
+        let arn =
+            "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-opus-4-7";
+        let result = parse_foundation_model_from_arn(arn);
+        assert!(result.is_ok(), "opus ARN must parse successfully");
+        assert_eq!(result.unwrap(), "anthropic.claude-opus-4-7");
+    }
+
+    // ── 2. End-to-end: parse → bedrock_to_anthropic ───────────────────────────
+
+    /// Parse a Sonnet 4.5 ARN and map the tail through `bedrock_to_anthropic`.
+    /// The expected Anthropic logical model id is the value the hardcoded map
+    /// produces for `"us.anthropic.claude-sonnet-4-5-20250929-v1:0"`.
+    /// We test against `bedrock_to_anthropic(tail, None)` directly (no cache).
+    #[test]
+    fn test_arn_to_anthropic_model_sonnet_4_5() {
+        let arn = "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0";
+        let tail = parse_foundation_model_from_arn(arn)
+            .expect("parse must succeed for this well-formed ARN");
+
+        // bedrock_to_anthropic needs the full profile id (with regional prefix) in
+        // some code paths, but the hardcoded reverse map uses `contains`, so the
+        // bare tail string still matches.
+        let anthropic_name = bedrock_to_anthropic(tail, None);
+        assert_eq!(
+            anthropic_name, "claude-sonnet-4-5-20250929",
+            "tail of a Sonnet 4.5 ARN must map to 'claude-sonnet-4-5-20250929' via bedrock_to_anthropic"
+        );
+    }
+
+    /// Parse a Haiku 4.5 ARN and map the tail through `bedrock_to_anthropic`.
+    #[test]
+    fn test_arn_to_anthropic_model_haiku_4_5() {
+        let arn = "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0";
+        let tail = parse_foundation_model_from_arn(arn)
+            .expect("parse must succeed for this well-formed ARN");
+
+        let anthropic_name = bedrock_to_anthropic(tail, None);
+        assert_eq!(
+            anthropic_name, "claude-haiku-4-5-20251001",
+            "tail of a Haiku 4.5 ARN must map to 'claude-haiku-4-5-20251001' via bedrock_to_anthropic"
+        );
+    }
+
+    // ── 3. Error cases ────────────────────────────────────────────────────────
+
+    /// ARN with no `foundation-model/` segment → `Err`.
+    #[test]
+    fn test_parse_foundation_model_from_arn_missing_segment() {
+        let arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-tagged-profile";
+        let result = parse_foundation_model_from_arn(arn);
+        assert!(
+            result.is_err(),
+            "ARN without 'foundation-model/' segment must return Err; got {result:?}"
+        );
+    }
+
+    /// Completely wrong string (not an ARN at all) → `Err`.
+    #[test]
+    fn test_parse_foundation_model_from_arn_not_an_arn() {
+        let result = parse_foundation_model_from_arn("not-an-arn");
+        assert!(
+            result.is_err(),
+            "Non-ARN string must return Err; got {result:?}"
+        );
+    }
+
+    /// Empty string → `Err`.
+    #[test]
+    fn test_parse_foundation_model_from_arn_empty_string() {
+        let result = parse_foundation_model_from_arn("");
+        assert!(
+            result.is_err(),
+            "Empty string must return Err; got {result:?}"
+        );
+    }
+
+    /// ARN that ends immediately after `foundation-model/` (empty tail) → `Err`.
+    #[test]
+    fn test_parse_foundation_model_from_arn_empty_tail() {
+        let arn = "arn:aws:bedrock:us-east-1:123456789012:foundation-model/";
+        let result = parse_foundation_model_from_arn(arn);
+        assert!(
+            result.is_err(),
+            "ARN with empty tail after 'foundation-model/' must return Err; got {result:?}"
+        );
+    }
+
+    /// Truncated ARN (no trailing portion after the resource type) → `Err`.
+    #[test]
+    fn test_parse_foundation_model_from_arn_truncated() {
+        let arn = "arn:aws:bedrock:us-east-1:123456789012:foundation-model";
+        let result = parse_foundation_model_from_arn(arn);
+        assert!(
+            result.is_err(),
+            "Truncated ARN (no '/' after resource type) must return Err; got {result:?}"
+        );
+    }
+}
+
+// ── Task 2: Self-healing migration runner unit tests ─────────────────────────
+//
+// Tests for the `migrate_legacy_aip_endpoints` startup function.
+//
+// BUILDER CONTRACT:
+//   Extract (or add) this function — tentatively in a new file
+//   `src/migrations/aip_legacy.rs` — with a signature like:
+//
+//   ```rust
+//   pub async fn migrate_legacy_aip_endpoints<F, Fut>(
+//       endpoints: &[EndpointMigrationCandidate],
+//       pool: &sqlx::PgPool,
+//       get_foundation_model: F,
+//   ) -> anyhow::Result<()>
+//   where
+//       F: Fn(&str) -> Fut + Send + Sync,
+//       Fut: std::future::Future<Output = Result<String, String>> + Send,
+//   {
+//   ```
+//
+//   `EndpointMigrationCandidate` holds `(endpoint_id: Uuid, legacy_arn: String)`.
+//   `get_foundation_model` is the testable seam: in production it calls
+//   `GetInferenceProfile` then `parse_foundation_model_from_arn` +
+//   `bedrock_to_anthropic`; in tests it's a closure.
+//
+//   Behaviour:
+//   - Skip endpoints whose `list_by_endpoint` returns non-empty.
+//   - For each remaining endpoint, call `get_foundation_model(legacy_arn)`.
+//     - On `Ok(model_id)` → insert `(endpoint_id, model_id, legacy_arn,
+//       set_by="auto-migration", reason="migrated from inference_profile_arn column")`.
+//     - On `Err(_)` → `tracing::warn!` the endpoint id, continue loop (no panic/abort).
+//   - Returns Ok(()) regardless of per-endpoint errors.
+//
+//   Wire into `src/main.rs` after `load_endpoints_with_db` and before the health
+//   loop starts.
+//
+// The tests below are integration-style against a real Postgres pool (they are
+// placed here in the lib module so they can be run with `cargo test --lib`
+// alongside unit tests, but they require `make test-integration` to have a DB).
+// The pure-logic cases (skip-if-non-empty, idempotency, error-tolerance) are
+// exercised via the injected closure so no real AWS call is needed.
+//
+// Import: the tests import `migrate_legacy_aip_endpoints` from wherever the
+// builder places it. If it lands in `src/migrations/aip_legacy.rs`, adjust the
+// `use` path below accordingly. The test module is kept here so it's compiled
+// even without the `integration` feature flag — it just requires the DB.
+
+#[cfg(test)]
+mod tests_task2_migration_runner {
+    use super::*;
+
+    // ── In-memory stub DB ─────────────────────────────────────────────────────
+    //
+    // Rather than a real PgPool (which requires Docker), these unit tests use a
+    // minimal stub that tracks "what rows exist per endpoint_id" in memory.
+    // The production runner takes a `&sqlx::PgPool`; the unit tests below
+    // use the *extractable pure logic* path by directly exercising the helper
+    // functions the migration runner delegates to.
+    //
+    // BUILDER NOTE: if you extract the core loop into a helper that accepts a
+    // `list_fn` + `insert_fn` pair (function pointers / closures) in addition to
+    // the `get_foundation_model` seam, these tests become straightforward.
+    // Otherwise, the integration test file covers the full DB path.
+    //
+    // The tests here verify the *decision logic* through the ARN parser + the
+    // `bedrock_to_anthropic` round-trip, keeping them fast and dependency-free.
+
+    // ── ARN-parsing + reverse-mapping round-trips ─────────────────────────────
+
+    /// Full round-trip for Sonnet 4.5:
+    ///   AIP ARN → parse tail → bedrock_to_anthropic → "claude-sonnet-4-5-20250929"
+    ///
+    /// This is the exact computation `migrate_legacy_aip_endpoints` performs
+    /// in step 2. The result becomes `model_id` in the inserted row.
+    #[test]
+    fn test_migration_model_id_derivation_sonnet() {
+        let legacy_arn = "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0";
+        let tail = parse_foundation_model_from_arn(legacy_arn).expect("well-formed ARN must parse");
+        let anthropic_model = bedrock_to_anthropic(tail, None);
+
+        assert_eq!(
+            anthropic_model, "claude-sonnet-4-5-20250929",
+            "migration must derive 'claude-sonnet-4-5-20250929' as the model_id for the Sonnet 4.5 ARN"
+        );
+    }
+
+    /// Full round-trip for Haiku 4.5:
+    ///   AIP ARN → parse tail → bedrock_to_anthropic → "claude-haiku-4-5-20251001"
+    #[test]
+    fn test_migration_model_id_derivation_haiku() {
+        let legacy_arn = "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0";
+        let tail = parse_foundation_model_from_arn(legacy_arn).expect("well-formed ARN must parse");
+        let anthropic_model = bedrock_to_anthropic(tail, None);
+
+        assert_eq!(
+            anthropic_model, "claude-haiku-4-5-20251001",
+            "migration must derive 'claude-haiku-4-5-20251001' as the model_id for the Haiku 4.5 ARN"
+        );
+    }
+
+    /// An ARN whose resource type is `application-inference-profile` (not
+    /// `foundation-model`) must produce an `Err` from `parse_foundation_model_from_arn`,
+    /// simulating the `GetInferenceProfile` failure path in the migration runner.
+    /// The runner must log a warning and continue — this test verifies the Err
+    /// propagation that the runner's error branch receives.
+    #[test]
+    fn test_migration_bad_arn_produces_err() {
+        // An AIP ARN is NOT a foundation-model ARN; the parser must reject it.
+        let bad_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-aip";
+        let result = parse_foundation_model_from_arn(bad_arn);
+        assert!(
+            result.is_err(),
+            "parse_foundation_model_from_arn must return Err for an AIP ARN (not a foundation-model ARN); migration runner must handle this without panicking"
+        );
+    }
+
+    // ── set_by / reason field values ──────────────────────────────────────────
+
+    /// The migration runner must write `set_by = "auto-migration"` and
+    /// `reason = "migrated from inference_profile_arn column"` exactly.
+    /// These string constants are checked here so the builder knows the
+    /// exact values the integration test will assert on.
+    #[test]
+    fn test_migration_metadata_constants() {
+        // The migration runner MUST use these exact constant strings when
+        // calling `db::endpoint_aip_overrides::insert`.
+        // Tested indirectly in the integration test; documented here as a
+        // compile-time-visible contract.
+        const EXPECTED_SET_BY: &str = "auto-migration";
+        const EXPECTED_REASON: &str = "migrated from inference_profile_arn column";
+
+        // No logic to test — this test documents the required constant values
+        // so the builder sees them alongside the ARN-parser tests.
+        assert!(!EXPECTED_SET_BY.is_empty());
+        assert!(!EXPECTED_REASON.is_empty());
+        // Verify the strings match the spec exactly:
+        assert_eq!(EXPECTED_SET_BY, "auto-migration");
+        assert_eq!(
+            EXPECTED_REASON,
+            "migrated from inference_profile_arn column"
         );
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -2137,10 +2137,9 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
               CCAG selects an endpoint per-request based on the team's routing strategy, endpoint priority, and health status.
               Adding multiple endpoints lets you pool quota across accounts or regions.
             </p>
-            <p style="margin:0 0 4px;color:var(--text);font-weight:500;font-size:11px">Routing Target</p>
+            <p style="margin:0 0 4px;color:var(--text);font-weight:500;font-size:11px">Application Inference Profiles (AIPs)</p>
             <ul style="margin:0 0 10px;padding-left:18px">
-              <li><strong>Cross-region inference (standard)</strong> — Bedrock routes the request to the nearest healthy region within your chosen scope (US, EU, APAC, etc.) using system-defined inference profiles.</li>
-              <li><strong>Application inference profile</strong> — Invokes a specific profile ARN directly. Use this for custom profiles with cost-tracking tags or custom throttle limits, or for cross-account access granted via a resource policy (no role assumption needed in that case).</li>
+              <li>AIPs are configured per-model on each endpoint. Use the AIP Overrides panel after creating an endpoint to map specific models to tagged AIP ARNs; models without an override use the system CRI for the endpoint's region scope.</li>
             </ul>
             <p style="margin:0 0 4px;color:var(--text);font-weight:500;font-size:11px">Credentials</p>
             <ul style="margin:0 0 10px;padding-left:18px">
@@ -3056,53 +3055,26 @@ input[type="date"].oa-filter-select { background-image: none; padding-right: 8px
         <input class="form-input" id="me-name" placeholder="e.g. US Production, EU Backup">
       </div>
 
-      <!-- Section 1: Routing Target -->
+      <!-- Section 1: Deployment Region -->
       <div style="margin-bottom:16px">
-        <div style="font-size:11px;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-muted);margin-bottom:8px">Routing Target</div>
-        <div style="display:flex;flex-direction:column;gap:6px">
-          <label style="display:flex;align-items:flex-start;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:var(--radius);cursor:pointer;transition:border-color 0.15s" id="me-routing-standard-label">
-            <input type="radio" name="me-routing" value="standard" onchange="onRoutingChange()" style="margin-top:2px;flex-shrink:0">
-            <div>
-              <div style="font-size:13px;font-weight:500">Cross-region inference <span class="badge badge-blue" style="font-size:10px;margin-left:4px">Standard</span></div>
-              <div class="form-hint" style="margin:2px 0 0">Bedrock routes requests across regions in your chosen scope using system-defined inference profiles.</div>
-            </div>
-          </label>
-          <label style="display:flex;align-items:flex-start;gap:10px;padding:10px 12px;border:1px solid var(--border);border-radius:var(--radius);cursor:pointer;transition:border-color 0.15s" id="me-routing-profile-label">
-            <input type="radio" name="me-routing" value="profile" onchange="onRoutingChange()" style="margin-top:2px;flex-shrink:0">
-            <div>
-              <div style="font-size:13px;font-weight:500">Application inference profile</div>
-              <div class="form-hint" style="margin:2px 0 0">Invoke a specific profile ARN — for custom profiles with cost tags, or cross-account access via resource policy.</div>
-            </div>
-          </label>
-        </div>
-
-        <div id="me-standard-fields" style="margin-top:12px">
-          <div class="form-row">
-            <div class="form-group" style="flex:2">
-              <label class="form-label">Geographic Scope</label>
-              <select class="form-select" id="me-scope" onchange="onScopeChange()">
-                <option value="us">US (Virginia, Oregon, Ohio, N. California, Canada)</option>
-                <option value="eu">Europe (Frankfurt, Paris, London, Stockholm, Ireland)</option>
-                <option value="apac">Asia Pacific (Tokyo, Mumbai, Singapore, Seoul, Osaka)</option>
-                <option value="au">Australia (Sydney, Melbourne)</option>
-                <option value="global">Global (all regions)</option>
-                <option value="us-gov">US GovCloud (GovCloud West, GovCloud East)</option>
-              </select>
-              <div class="form-hint" id="me-scope-hint">Requests are routed across regions within this scope by Bedrock's cross-region inference.</div>
-            </div>
-            <div class="form-group" style="flex:1">
-              <label class="form-label">Home Region</label>
-              <input class="form-input" id="me-region" placeholder="us-east-1">
-              <div class="form-hint">API connection region — pick one within the scope.</div>
-            </div>
+        <div style="font-size:11px;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-muted);margin-bottom:8px">Deployment Region</div>
+        <div class="form-row">
+          <div class="form-group" style="flex:2">
+            <label class="form-label">Geographic Scope</label>
+            <select class="form-select" id="me-scope" onchange="onScopeChange()">
+              <option value="us">US (Virginia, Oregon, Ohio, N. California, Canada)</option>
+              <option value="eu">Europe (Frankfurt, Paris, London, Stockholm, Ireland)</option>
+              <option value="apac">Asia Pacific (Tokyo, Mumbai, Singapore, Seoul, Osaka)</option>
+              <option value="au">Australia (Sydney, Melbourne)</option>
+              <option value="global">Global (all regions)</option>
+              <option value="us-gov">US GovCloud (GovCloud West, GovCloud East)</option>
+            </select>
+            <div class="form-hint" id="me-scope-hint">Requests are routed across regions within this scope by Bedrock's cross-region inference.</div>
           </div>
-        </div>
-
-        <div id="me-profile-fields" style="display:none;margin-top:12px">
-          <div class="form-group">
-            <label class="form-label">Inference Profile ARN</label>
-            <input class="form-input" id="me-profile-arn" placeholder="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/..." oninput="onProfileArnChange()">
-            <div class="form-hint" id="me-profile-arn-hint">Region and account are auto-detected from the ARN.</div>
+          <div class="form-group" style="flex:1">
+            <label class="form-label">Home Region</label>
+            <input class="form-input" id="me-region" placeholder="us-east-1">
+            <div class="form-hint">API connection region — pick one within the scope.</div>
           </div>
         </div>
       </div>
@@ -4840,6 +4812,7 @@ function toggleEndpointCard(id) {
     details.style.display = '';
     if (chevron) chevron.style.transform = 'rotate(90deg)';
     loadEndpointCapability(id);
+    loadAipOverrides(id);
   }
 }
 
@@ -4906,6 +4879,7 @@ function renderEndpoints() {
           </div>` : ''}
         </div>
         <div id="ep-capability-${ep.id}" style="margin-top:12px"></div>
+        <div id="ep-aip-overrides-${ep.id}" style="margin-top:12px"></div>
         <div style="display:flex;align-items:center;justify-content:space-between;margin-top:10px" onclick="event.stopPropagation()">
           <div style="display:flex;gap:6px">
             ${!ep.is_default ? `<button class="btn btn-sm" onclick="setDefaultEndpoint('${ep.id}')" title="Set as default endpoint for teams with no assignment">Set as Default</button>` : ''}
@@ -4920,6 +4894,7 @@ function renderEndpoints() {
   eps.forEach(ep => {
     if (expandedEndpoints.has(ep.id)) {
       loadEndpointCapability(ep.id);
+      loadAipOverrides(ep.id);
     }
   });
 }
@@ -5115,6 +5090,131 @@ async function loadEndpointCapability(id) {
   el.innerHTML = finalHtml;
 }
 
+// ---- AIP Overrides panel ----
+
+async function loadAipOverrides(id) {
+  const el = document.getElementById('ep-aip-overrides-' + id);
+  if (!el) return;
+  el.innerHTML = '<span style="color:var(--text-muted);font-size:12px">Loading AIP overrides…</span>';
+  const res = await api('GET', `/admin/endpoints/${id}/aip-overrides`);
+  renderAipOverridesPanel(id, res.overrides || res || []);
+}
+
+function renderAipOverridesPanel(id, overrides) {
+  const el = document.getElementById('ep-aip-overrides-' + id);
+  if (!el) return;
+
+  const rowsHtml = overrides.length === 0
+    ? `<div style="font-size:12px;color:var(--text-muted);padding:8px 0">No AIP overrides for this endpoint. Models route via cross-region inference.</div>`
+    : `<table style="width:100%;border-collapse:collapse;font-size:12px">
+        <thead>
+          <tr style="color:var(--text-muted);font-size:11px;text-transform:uppercase;letter-spacing:0.05em">
+            <th style="text-align:left;padding:4px 8px 6px 0;font-weight:500">Model</th>
+            <th style="text-align:left;padding:4px 8px 6px 0;font-weight:500">AIP ARN</th>
+            <th style="text-align:left;padding:4px 8px 6px 0;font-weight:500">Set</th>
+            <th style="text-align:left;padding:4px 8px 6px 0;font-weight:500">By</th>
+            <th style="padding:4px 0 6px 0;font-weight:500"></th>
+          </tr>
+        </thead>
+        <tbody>
+          ${overrides.map(o => {
+            const arn = o.aip_arn || '';
+            const shortArn = arn.length > 55 ? arn.slice(0, 25) + '…' + arn.slice(-27) : arn;
+            const setAt = o.set_at ? relativeTime(o.set_at) : '';
+            return `<tr>
+              <td style="padding:4px 8px 4px 0;vertical-align:middle"><code style="font-family:var(--font-mono);font-size:11px">${esc(o.model_id)}</code></td>
+              <td style="padding:4px 8px 4px 0;vertical-align:middle;max-width:260px;overflow:hidden" title="${esc(arn)}"><code style="font-family:var(--font-mono);font-size:11px;white-space:nowrap">${esc(shortArn)}</code></td>
+              <td style="padding:4px 8px 4px 0;vertical-align:middle;white-space:nowrap;color:var(--text-muted)">${esc(setAt)}</td>
+              <td style="padding:4px 8px 4px 0;vertical-align:middle;color:var(--text-muted)">${esc(o.set_by || '')}</td>
+              <td style="padding:4px 0 4px 0;vertical-align:middle;text-align:right">
+                <button class="btn btn-danger btn-sm" onclick="removeAipOverride('${esc(id)}','${esc(o.model_id)}')" style="padding:2px 8px;font-size:11px">Remove</button>
+              </td>
+            </tr>`;
+          }).join('')}
+        </tbody>
+      </table>`;
+
+  const panelHtml = `<div style="padding:8px 12px;background:var(--bg-inset);border-radius:var(--radius);border:1px solid var(--border)" onclick="event.stopPropagation()">
+    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+      <div>
+        <span style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-muted);font-weight:500">AIP Overrides</span>
+        <span style="display:block;font-size:11px;color:var(--text-muted);margin-top:2px">Map specific models to tagged AIP ARNs. Models without an override use the system CRI for this endpoint's region scope.</span>
+      </div>
+      <button class="btn btn-secondary btn-sm" style="white-space:nowrap;margin-left:12px" onclick="showAipAddForm('${esc(id)}')">Add Override</button>
+    </div>
+    ${rowsHtml}
+    <div id="ep-aip-add-form-${esc(id)}" style="display:none;margin-top:10px;padding-top:10px;border-top:1px solid var(--border)">
+      <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
+        <div class="form-group" style="flex:1;min-width:140px;margin-bottom:0">
+          <label class="form-label" style="font-size:11px">Model ID</label>
+          <input class="form-input" id="ep-aip-model-${esc(id)}" placeholder="claude-sonnet-4-5" style="font-family:var(--font-mono);font-size:12px">
+        </div>
+        <div class="form-group" style="flex:3;min-width:220px;margin-bottom:0">
+          <label class="form-label" style="font-size:11px">AIP ARN</label>
+          <input class="form-input" id="ep-aip-arn-${esc(id)}" placeholder="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/..." style="font-family:var(--font-mono);font-size:12px">
+        </div>
+        <div class="form-group" style="flex:2;min-width:140px;margin-bottom:0">
+          <label class="form-label" style="font-size:11px">Reason (optional)</label>
+          <input class="form-input" id="ep-aip-reason-${esc(id)}" placeholder="cost-tracking, cross-account…" style="font-size:12px">
+        </div>
+        <div style="display:flex;gap:6px;margin-bottom:0;padding-bottom:1px">
+          <button class="btn btn-primary btn-sm" onclick="saveAipOverride('${esc(id)}')">Save</button>
+          <button class="btn btn-secondary btn-sm" onclick="hideAipAddForm('${esc(id)}')">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </div>`;
+
+  el.innerHTML = panelHtml;
+}
+
+function showAipAddForm(id) {
+  const form = document.getElementById('ep-aip-add-form-' + id);
+  if (form) { form.style.display = ''; document.getElementById('ep-aip-model-' + id)?.focus(); }
+}
+
+function hideAipAddForm(id) {
+  const form = document.getElementById('ep-aip-add-form-' + id);
+  if (form) {
+    form.style.display = 'none';
+    const modelEl = document.getElementById('ep-aip-model-' + id);
+    const arnEl = document.getElementById('ep-aip-arn-' + id);
+    const reasonEl = document.getElementById('ep-aip-reason-' + id);
+    if (modelEl) modelEl.value = '';
+    if (arnEl) arnEl.value = '';
+    if (reasonEl) reasonEl.value = '';
+  }
+}
+
+async function saveAipOverride(id) {
+  const model_id = (document.getElementById('ep-aip-model-' + id)?.value || '').trim();
+  const aip_arn = (document.getElementById('ep-aip-arn-' + id)?.value || '').trim();
+  const reason = (document.getElementById('ep-aip-reason-' + id)?.value || '').trim() || undefined;
+  if (!model_id) { toast('Model ID is required', 'error'); return; }
+  if (!aip_arn) { toast('AIP ARN is required', 'error'); return; }
+  const body = reason ? { model_id, aip_arn, reason } : { model_id, aip_arn };
+  const res = await api('POST', `/admin/endpoints/${id}/aip-overrides`, body);
+  if (res.error) { toast(res.error.message || 'Failed to save override', 'error'); return; }
+  toast('AIP override saved', 'success');
+  loadAipOverrides(id);
+}
+
+async function removeAipOverride(id, model_id) {
+  if (!confirm(`Remove AIP override for model "${model_id}"?`)) return;
+  const res = await api('DELETE', `/admin/endpoints/${id}/aip-overrides/${encodeURIComponent(model_id)}`);
+  if (res.error) { toast(res.error.message || 'Failed to remove override', 'error'); return; }
+  toast('AIP override removed', 'success');
+  loadAipOverrides(id);
+}
+
+function relativeTime(iso) {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 60000) return 'just now';
+  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago';
+  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago';
+  return Math.floor(diff / 86400000) + 'd ago';
+}
+
 async function validateEndpoint(id) {
   toast('Validating endpoint…', 'info');
   delete capabilityCache[id]; // force fresh load after health state changes
@@ -5133,7 +5233,7 @@ async function validateEndpoint(id) {
     } catch (e) { /* ignore */ }
     // Expand card and load quotas/models (endpoint is now healthy in data)
     if (!expandedEndpoints.has(id)) toggleEndpointCard(id);
-    else { loadEndpointCapability(id); }
+    else { loadEndpointCapability(id); loadAipOverrides(id); }
   } catch (e) {
     // Parse error message for common AWS failure patterns
     const raw = e.message || '';
@@ -5201,13 +5301,6 @@ function routingPrefixFromRegion(region) {
   return 'us';
 }
 
-function onRoutingChange() {
-  const mode = document.querySelector('input[name="me-routing"]:checked').value;
-  document.getElementById('me-standard-fields').style.display = mode === 'standard' ? '' : 'none';
-  document.getElementById('me-profile-fields').style.display = mode === 'profile' ? '' : 'none';
-  document.getElementById('me-routing-standard-label').style.borderColor = mode === 'standard' ? 'var(--accent)' : '';
-  document.getElementById('me-routing-profile-label').style.borderColor = mode === 'profile' ? 'var(--accent)' : '';
-}
 
 function onCredsChange() {
   const mode = document.querySelector('input[name="me-creds"]:checked').value;
@@ -5216,20 +5309,6 @@ function onCredsChange() {
   document.getElementById('me-creds-assume-label').style.borderColor = mode === 'assume' ? 'var(--accent)' : '';
 }
 
-function onProfileArnChange() {
-  const arn = document.getElementById('me-profile-arn').value.trim();
-  const region = regionFromBedrockArn(arn);
-  const account = accountFromArn(arn);
-  const hint = document.getElementById('me-profile-arn-hint');
-  if (region || account) {
-    const parts = [];
-    if (region) parts.push(`Region: ${region}`);
-    if (account) parts.push(`Account: ${account}`);
-    hint.textContent = parts.join(' · ');
-  } else {
-    hint.textContent = 'Region and account are auto-detected from the ARN.';
-  }
-}
 
 function onScopeChange() {
   const scope = document.getElementById('me-scope').value;
@@ -5252,23 +5331,11 @@ function showEndpointModal(ep) {
   document.getElementById('me-enabled-group').style.display = ep ? '' : 'none';
   if (ep) document.getElementById('me-enabled').checked = ep.enabled;
 
-  // Routing target
-  const hasProfile = ep && !!ep.inference_profile_arn;
-  document.querySelector(`input[name="me-routing"][value="${hasProfile ? 'profile' : 'standard'}"]`).checked = true;
-  document.getElementById('me-standard-fields').style.display = hasProfile ? 'none' : '';
-  document.getElementById('me-profile-fields').style.display = hasProfile ? '' : 'none';
-  document.getElementById('me-routing-standard-label').style.borderColor = hasProfile ? '' : 'var(--accent)';
-  document.getElementById('me-routing-profile-label').style.borderColor = hasProfile ? 'var(--accent)' : '';
-  if (hasProfile) {
-    document.getElementById('me-profile-arn').value = ep.inference_profile_arn;
-    onProfileArnChange();
-  } else {
-    document.getElementById('me-profile-arn').value = '';
-    document.getElementById('me-scope').value = ep ? ep.routing_prefix : 'us';
-    document.getElementById('me-region').value = '';
-    onScopeChange();
-    if (ep) document.getElementById('me-region').value = ep.region;
-  }
+  // Deployment region defaults
+  document.getElementById('me-scope').value = ep ? ep.routing_prefix : 'us';
+  document.getElementById('me-region').value = '';
+  onScopeChange();
+  if (ep) document.getElementById('me-region').value = ep.region;
 
   // Credentials
   const hasRole = ep && !!ep.role_arn;
@@ -5292,21 +5359,11 @@ async function saveEndpoint() {
   const name = document.getElementById('me-name').value.trim();
   if (!name) { toast('Name is required', 'error'); return; }
 
-  const routingMode = document.querySelector('input[name="me-routing"]:checked').value;
   const credsMode = document.querySelector('input[name="me-creds"]:checked').value;
 
-  let region, routing_prefix, inference_profile_arn = null;
-  if (routingMode === 'profile') {
-    inference_profile_arn = document.getElementById('me-profile-arn').value.trim() || null;
-    if (!inference_profile_arn) { toast('Inference profile ARN is required', 'error'); return; }
-    region = regionFromBedrockArn(inference_profile_arn);
-    if (!region) { toast('Could not detect region from ARN — check the format', 'error'); return; }
-    routing_prefix = routingPrefixFromRegion(region);
-  } else {
-    region = document.getElementById('me-region').value.trim();
-    routing_prefix = document.getElementById('me-scope').value;
-    if (!region) { toast('Home region is required', 'error'); return; }
-  }
+  const region = document.getElementById('me-region').value.trim();
+  const routing_prefix = document.getElementById('me-scope').value;
+  if (!region) { toast('Home region is required', 'error'); return; }
 
   let role_arn = null, external_id = null;
   if (credsMode === 'assume') {
@@ -5319,11 +5376,11 @@ async function saveEndpoint() {
 
   if (editingEndpointId) {
     const enabled = document.getElementById('me-enabled').checked;
-    const res = await api('PUT', `/admin/endpoints/${editingEndpointId}`, { name, region, routing_prefix, role_arn, external_id, inference_profile_arn, priority, enabled });
+    const res = await api('PUT', `/admin/endpoints/${editingEndpointId}`, { name, region, routing_prefix, role_arn, external_id, priority, enabled });
     if (res.updated) { toast('Endpoint updated', 'success'); closeModal(); loadAll(); }
     else toast(res.error?.message || 'Failed to update', 'error');
   } else {
-    const res = await api('POST', '/admin/endpoints', { name, region, routing_prefix, role_arn, external_id, inference_profile_arn, priority });
+    const res = await api('POST', '/admin/endpoints', { name, region, routing_prefix, role_arn, external_id, priority });
     if (res.id) { toast('Endpoint created', 'success'); closeModal(); loadAll(); }
     else toast(res.error?.message || 'Failed to create', 'error');
   }

--- a/tests/integration/aip_compat_shim_tests.rs
+++ b/tests/integration/aip_compat_shim_tests.rs
@@ -1,0 +1,1163 @@
+/// Integration tests for Task 7: Backwards-compat shim on POST /admin/endpoints
+/// and GET /admin/endpoints/{id} response shape.
+///
+/// # Contract points covered (numbered per the Task 7 spec)
+///
+/// 1. POST without `inference_profile_arn`
+///      → endpoint created, `aip_overrides: []`, `inference_profile_arn: null`,
+///        NO Deprecation/Sunset headers.
+///
+/// 2. POST with `inference_profile_arn` (shim compat path — GetInferenceProfile succeeds)
+///      → endpoint created, exactly ONE row in `endpoint_aip_overrides` with
+///        `set_by = COMPAT_SHIM_SET_BY` and `aip_arn = <supplied ARN>`.
+///        Response body: `aip_overrides: [{...one row...}]` AND
+///        `inference_profile_arn = <supplied>`.
+///        Response headers: `Deprecation: true`, `Sunset: <EXPECTED_SUNSET_DATE>`.
+///
+/// 3. POST with `inference_profile_arn` but GetInferenceProfile errors
+///      → endpoint IS created (operator not blocked), zero override rows, legacy
+///        column populated.  Response: `aip_overrides: []`,
+///        `inference_profile_arn = <supplied>`.  Deprecation header present.
+///        Endpoint creation NOT rolled back.
+///
+/// 4. GET /admin/endpoints/{id}: zero override rows + legacy column null
+///      → `aip_overrides: []`, `inference_profile_arn: null`,
+///        no Deprecation/Sunset headers.
+///
+/// 5. GET /admin/endpoints/{id}: exactly one override row + legacy null
+///      → `aip_overrides: [{row}]`, `inference_profile_arn = row.aip_arn`,
+///        Deprecation + Sunset headers.
+///
+/// 6. GET /admin/endpoints/{id}: two override rows + legacy null
+///      → `aip_overrides: [{...}, {...}]`, `inference_profile_arn: null`,
+///        NO Deprecation/Sunset headers (can't represent multiple ARNs).
+///
+/// 7. GET /admin/endpoints/{id}: zero rows + legacy column populated
+///    (auto-migration not yet completed)
+///      → `aip_overrides: []`, `inference_profile_arn = <legacy>`,
+///        Deprecation + Sunset headers (signals legacy field in use).
+///
+/// Extra smoke: admin auth still required on both POST and GET.
+/// Extra smoke: cache_version is bumped when the shim auto-inserts an override row.
+///
+/// # Deprecation header contract (snapshot — builder must match these exactly)
+///
+/// Header name:  `Deprecation`
+/// Header value: `true`
+///
+/// Header name:  `Sunset`
+/// Header value: `Wed, 01 Jan 2027 00:00:00 GMT`
+///   (RFC 1123 / HTTP-date format; one minor release ahead of the current 1.x
+///    series, chosen per spec §Slice 3 backwards compat shim guidance)
+///
+/// # BUILDER CONTRACT
+///
+/// The compat shim logic in `POST /admin/endpoints` needs to call
+/// `GetInferenceProfile` after creating the endpoint, parse the foundation model
+/// via `parse_foundation_model_from_arn` + `bedrock_to_anthropic`, and insert
+/// a row with `set_by = "compat-shim-on-create"`.
+///
+/// Because the handler runs in an integration context without real AWS creds,
+/// the builder MUST make the `GetInferenceProfile` call injectable — either by
+/// accepting a generic closure (like `migrate_legacy_aip_endpoints` does in
+/// `src/migrations/aip_legacy.rs`) or by extracting a small helper fn:
+///
+/// ```rust
+/// pub async fn try_create_compat_override<F, Fut>(
+///     endpoint_id: uuid::Uuid,
+///     legacy_arn: &str,
+///     pool: &sqlx::PgPool,
+///     get_foundation_model: F,
+/// ) -> Result<(), String>
+/// where
+///     F: Fn(&str) -> Fut + Send + Sync,
+///     Fut: std::future::Future<Output = Result<String, String>> + Send,
+/// { ... }
+/// ```
+///
+/// This helper is what makes contract points 2 and 3 testable in isolation
+/// (via `aip_compat_shim_try_create_compat_override_*` tests below) without
+/// requiring real Bedrock credentials.
+///
+/// The integration tests for `POST /admin/endpoints` (contract points 1-3) test
+/// the HTTP handler and therefore rely on GatewayState wiring. See the note in
+/// `test_app` about the endpoint pool and how the mock is injected.
+///
+/// Run with: make test-integration
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI64};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::helpers;
+use ccag::budget::BudgetSpendCache;
+use ccag::db;
+use ccag::db::endpoint_aip_overrides;
+
+// ── Snapshot constants (builder must match these exactly) ─────────────────────
+
+/// The `set_by` value written by the compat shim at POST /admin/endpoints time.
+/// This constant is also baked into assertions so the builder has one place to
+/// change if they choose a different string.
+const COMPAT_SHIM_SET_BY: &str = "compat-shim-on-create";
+
+/// The exact value of the `Deprecation` response header.
+const DEPRECATION_HEADER_VALUE: &str = "true";
+
+/// The exact value of the `Sunset` response header.
+/// RFC 1123 / HTTP-date format, one minor release ahead.
+const SUNSET_HEADER_VALUE: &str = "Wed, 01 Jan 2027 00:00:00 GMT";
+
+/// A valid AIP ARN used in POST /admin/endpoints shim tests.
+const SHIM_ARN: &str =
+    "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-compat";
+
+/// A second AIP ARN (Opus) used in multi-row GET tests.
+const SHIM_ARN_OPUS: &str =
+    "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-compat";
+
+// ── shared test app factory ────────────────────────────────────────────────────
+
+/// Build a minimal test router backed by a real DB pool.
+///
+/// Mirrors the pattern in `aip_overrides_admin_tests.rs::test_app`.
+async fn test_app(pool: &sqlx::PgPool) -> (axum::Router, String) {
+    let config = ccag::config::GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 9999,
+        admin_username: "admin".to_string(),
+        admin_password: "admin".to_string(),
+        bedrock_routing_prefix: "us".to_string(),
+        database_url: "postgres://test@localhost/test".to_string(),
+        admin_users: vec![],
+        notification_url: None,
+        rds_iam_auth: false,
+        database_host: None,
+        database_port: 5432,
+        database_name: "test".to_string(),
+        database_user: "test".to_string(),
+        pricing_refresh_interval: 86400,
+        pricing_refresh_enabled: false,
+    };
+
+    let signing_key = "test-signing-key-compat-shim";
+
+    let _ = ccag::db::users::create_user(pool, "admin", None, "admin").await;
+
+    let identity = ccag::auth::oidc::OidcIdentity {
+        sub: "admin".to_string(),
+        email: None,
+        idp_name: "Local".to_string(),
+    };
+    let admin_token = ccag::auth::session::issue(signing_key, &identity, 24);
+
+    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let (metrics, _provider) = ccag::telemetry::Metrics::new(None).unwrap();
+    let metrics = Arc::new(metrics);
+    let db_pool = Arc::new(tokio::sync::RwLock::new(pool.clone()));
+
+    let state = Arc::new(ccag::proxy::GatewayState {
+        bedrock_client: aws_sdk_bedrockruntime::Client::new(&aws_config),
+        bedrock_control_client: aws_sdk_bedrock::Client::new(&aws_config),
+        model_cache: ccag::translate::models::ModelCache::new(),
+        config,
+        key_cache: ccag::auth::KeyCache::new(),
+        rate_limiter: ccag::ratelimit::RateLimiter::new(),
+        idp_validator: Arc::new(ccag::auth::oidc::MultiIdpValidator::new()),
+        db_pool: db_pool.clone(),
+        spend_tracker: Arc::new(ccag::spend::SpendTracker::new(db_pool, metrics.clone())),
+        metrics,
+        virtual_keys_enabled: AtomicBool::new(true),
+        admin_login_enabled: AtomicBool::new(true),
+        cache_version: AtomicI64::new(1),
+        session_token_ttl_hours: AtomicI64::new(24),
+        session_signing_key: signing_key.to_string(),
+        cli_sessions: ccag::api::cli_auth::new_session_store(),
+        setup_tokens: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+        http_client: reqwest::Client::new(),
+        budget_cache: Arc::new(BudgetSpendCache::new(30)),
+        sns_client: None,
+        eb_client: None,
+        quota_cache: None,
+        aws_config: aws_config.clone(),
+        bedrock_health: tokio::sync::RwLock::new(None),
+        endpoint_pool: Arc::new(ccag::endpoint::EndpointPool::new()),
+        endpoint_stats: Arc::new(ccag::endpoint::stats::EndpointStats::new()),
+        started_at: std::time::Instant::now(),
+        login_attempts: tokio::sync::Mutex::new(Vec::new()),
+        pricing_client: Arc::new(aws_sdk_pricing::Client::new(&aws_config)),
+    });
+
+    (ccag::api::router(state), admin_token)
+}
+
+/// Read the current `cache_version` counter from the DB.
+async fn get_cache_version(pool: &sqlx::PgPool) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT MAX(version) FROM cache_version")
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0)
+}
+
+/// Parse a response body as JSON.
+async fn parse_body(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .expect("failed to read response body");
+    serde_json::from_slice(&bytes).expect("response body is not valid JSON")
+}
+
+/// Create a minimal endpoint via the DB, returning its UUID string.
+/// Used for GET endpoint shape tests (no API call, so no shim involved).
+async fn create_endpoint_db(
+    pool: &sqlx::PgPool,
+    name: &str,
+    inference_profile_arn: Option<&str>,
+) -> Uuid {
+    db::endpoints::create_endpoint(
+        pool,
+        name,
+        None,
+        None,
+        inference_profile_arn,
+        "us-east-1",
+        "us",
+        0,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("create_endpoint_db({name}) failed: {e}"))
+    .id
+}
+
+// ── Contract point 1: POST without inference_profile_arn ─────────────────────
+
+/// POST /admin/endpoints WITHOUT `inference_profile_arn`:
+/// - Endpoint is created (201).
+/// - Response body contains `aip_overrides: []`.
+/// - Response body contains `inference_profile_arn: null`.
+/// - No `Deprecation` or `Sunset` headers in the response.
+#[tokio::test]
+async fn post_endpoint_no_arn_no_overrides_no_deprecation_headers() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/endpoints")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"name":"ep-no-arn","region":"us-east-1","routing_prefix":"us"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+
+    // Check headers before consuming the body
+    let deprecation = resp.headers().get("deprecation").cloned();
+    let sunset = resp.headers().get("sunset").cloned();
+
+    let body = parse_body(resp).await;
+
+    assert!(
+        status == StatusCode::CREATED || status == StatusCode::OK,
+        "POST without inference_profile_arn must return 200 or 201, got {status}; body={body}"
+    );
+
+    // Response body must contain aip_overrides as an empty array
+    let aip_overrides = body
+        .get("aip_overrides")
+        .expect("response body must include 'aip_overrides' field; got {body}");
+    assert_eq!(
+        aip_overrides,
+        &Value::Array(vec![]),
+        "aip_overrides must be [] when no inference_profile_arn is supplied; got {aip_overrides}"
+    );
+
+    // inference_profile_arn must be null (not absent — always present)
+    let ipa = body.get("inference_profile_arn").expect(
+        "response body must include 'inference_profile_arn' field (always present); got {body}",
+    );
+    assert!(
+        ipa.is_null(),
+        "inference_profile_arn must be null when no ARN supplied; got {ipa}"
+    );
+
+    // Deprecation and Sunset headers must NOT be present
+    assert!(
+        deprecation.is_none(),
+        "Deprecation header must NOT be present when inference_profile_arn is absent"
+    );
+    assert!(
+        sunset.is_none(),
+        "Sunset header must NOT be present when inference_profile_arn is absent"
+    );
+
+    // Verify DB: the created endpoint has zero override rows
+    let endpoint_id: Uuid = body["id"]
+        .as_str()
+        .and_then(|s| s.parse().ok())
+        .expect("response body must include 'id' field with a UUID string");
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, endpoint_id)
+        .await
+        .expect("list_by_endpoint must not fail");
+
+    assert!(
+        rows.is_empty(),
+        "zero override rows must exist in DB when no inference_profile_arn is supplied; got {rows:?}"
+    );
+}
+
+// ── Contract point 2: POST with inference_profile_arn — shim succeeds ─────────
+
+/// POST /admin/endpoints WITH `inference_profile_arn`, GetInferenceProfile succeeds:
+/// - Endpoint is created (201).
+/// - Exactly ONE row in `endpoint_aip_overrides` with `set_by = COMPAT_SHIM_SET_BY`
+///   and `aip_arn = SHIM_ARN`.
+/// - Response body: `aip_overrides: [{one row with the ARN}]`
+///   AND `inference_profile_arn = SHIM_ARN`.
+/// - Response headers: `Deprecation: true` and `Sunset: <SUNSET_HEADER_VALUE>`.
+///
+/// NOTE FOR BUILDER: This test runs against the real HTTP handler via `test_app`.
+/// Because the test environment has no Bedrock credentials, `GetInferenceProfile`
+/// will fail with a credentials/dispatch error at test time.  The handler should
+/// therefore treat that as a "GetInferenceProfile failed" scenario (contract
+/// point 3), and this test will exercise the "no-credentials fallback" variant.
+///
+/// To make this test green for contract point 2 (the success branch), the builder
+/// must either:
+///   (a) Inject the `get_foundation_model` closure into GatewayState so the
+///       test_app can supply a mock; OR
+///   (b) Use a unit-level helper (`try_create_compat_override`) that is tested
+///       separately (see `aip_compat_shim_try_create_compat_override_success` below).
+///
+/// The HTTP-level tests (this function and `post_endpoint_with_arn_get_infprof_fails`)
+/// assert the observable HTTP shape without caring HOW the builder wires
+/// the injection — they simply check what the response contains.
+///
+/// The contract-point-2 SUCCESS case (shim row is actually inserted) is also
+/// covered by the helper-level test `aip_compat_shim_try_create_compat_override_success`
+/// which bypasses the handler.
+#[tokio::test]
+async fn post_endpoint_with_arn_response_shape_has_deprecation_headers() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+
+    let body_str = format!(
+        r#"{{"name":"ep-with-arn","region":"us-east-1","routing_prefix":"us","inference_profile_arn":"{SHIM_ARN}"}}"#
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/endpoints")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(body_str))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+
+    // Snapshot the deprecation/sunset headers before consuming body
+    let deprecation = resp
+        .headers()
+        .get("deprecation")
+        .map(|v| v.to_str().unwrap_or("").to_string());
+    let sunset = resp
+        .headers()
+        .get("sunset")
+        .map(|v| v.to_str().unwrap_or("").to_string());
+
+    let body = parse_body(resp).await;
+
+    assert!(
+        status == StatusCode::CREATED || status == StatusCode::OK,
+        "POST with inference_profile_arn must return 200 or 201, got {status}; body={body}"
+    );
+
+    // Response body must always include `aip_overrides` (array, possibly empty if shim failed)
+    let aip_overrides = body
+        .get("aip_overrides")
+        .expect("response body must include 'aip_overrides' field when inference_profile_arn is present; body={body}");
+    assert!(
+        aip_overrides.is_array(),
+        "aip_overrides must be a JSON array; got {aip_overrides}"
+    );
+
+    // Response body must include inference_profile_arn = SHIM_ARN (not null)
+    let ipa = body
+        .get("inference_profile_arn")
+        .expect("response body must include 'inference_profile_arn' field; body={body}");
+    assert_eq!(
+        ipa.as_str().unwrap_or(""),
+        SHIM_ARN,
+        "inference_profile_arn in response must equal the supplied ARN; got {ipa}"
+    );
+
+    // Deprecation header MUST be present and equal DEPRECATION_HEADER_VALUE
+    assert_eq!(
+        deprecation.as_deref(),
+        Some(DEPRECATION_HEADER_VALUE),
+        "Deprecation header must be '{DEPRECATION_HEADER_VALUE}' when inference_profile_arn is set; got {deprecation:?}"
+    );
+
+    // Sunset header MUST be present and equal SUNSET_HEADER_VALUE
+    assert_eq!(
+        sunset.as_deref(),
+        Some(SUNSET_HEADER_VALUE),
+        "Sunset header must be '{SUNSET_HEADER_VALUE}' when inference_profile_arn is set; got {sunset:?}"
+    );
+}
+
+// ── Contract point 3: POST with inference_profile_arn — GetInferenceProfile fails ──
+
+/// POST /admin/endpoints WITH `inference_profile_arn`, GetInferenceProfile errors:
+/// - Endpoint IS still created (operator not blocked).
+/// - Zero override rows in `endpoint_aip_overrides`.
+/// - Legacy column (`inference_profile_arn`) IS populated in the DB.
+/// - Response: `aip_overrides: []`, `inference_profile_arn = SHIM_ARN`.
+/// - Response headers: Deprecation present.
+/// - Endpoint creation is NOT rolled back.
+///
+/// In the test environment there are no Bedrock credentials, so GetInferenceProfile
+/// will always fail — this test exercises that path directly.
+#[tokio::test]
+async fn post_endpoint_with_arn_get_infprof_fails_endpoint_still_created() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+
+    let body_str = format!(
+        r#"{{"name":"ep-with-arn-fail","region":"us-east-1","routing_prefix":"us","inference_profile_arn":"{SHIM_ARN}"}}"#
+    );
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/endpoints")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(body_str))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+
+    let deprecation = resp
+        .headers()
+        .get("deprecation")
+        .map(|v| v.to_str().unwrap_or("").to_string());
+
+    let body = parse_body(resp).await;
+
+    // Endpoint creation must succeed even when GetInferenceProfile fails
+    assert!(
+        status == StatusCode::CREATED || status == StatusCode::OK,
+        "POST with inference_profile_arn must still return 200/201 even when GetInferenceProfile fails; got {status}; body={body}"
+    );
+
+    // Extract endpoint id
+    let endpoint_id: Uuid = body["id"]
+        .as_str()
+        .and_then(|s| s.parse().ok())
+        .expect("response body must include 'id' field with a UUID string; body={body}");
+
+    // Endpoint must exist in DB (not rolled back)
+    let ep_row =
+        sqlx::query_as::<_, ccag::db::schema::Endpoint>("SELECT * FROM endpoints WHERE id = $1")
+            .bind(endpoint_id)
+            .fetch_optional(&pool)
+            .await
+            .expect("DB query must not fail");
+
+    assert!(
+        ep_row.is_some(),
+        "endpoint must exist in DB even when GetInferenceProfile fails (not rolled back)"
+    );
+
+    // Legacy column must be populated
+    let ep = ep_row.unwrap();
+    assert_eq!(
+        ep.inference_profile_arn.as_deref(),
+        Some(SHIM_ARN),
+        "inference_profile_arn column must be populated in DB when ARN supplied; got {:?}",
+        ep.inference_profile_arn
+    );
+
+    // Response body: aip_overrides must be [] (shim did not insert a row)
+    let aip_overrides = body
+        .get("aip_overrides")
+        .expect("response body must include 'aip_overrides' field; body={body}");
+    assert_eq!(
+        aip_overrides,
+        &Value::Array(vec![]),
+        "aip_overrides must be [] when GetInferenceProfile fails; got {aip_overrides}"
+    );
+
+    // Response body: inference_profile_arn must equal the supplied ARN (not null)
+    let ipa = body
+        .get("inference_profile_arn")
+        .expect("response body must include 'inference_profile_arn' field; body={body}");
+    assert_eq!(
+        ipa.as_str().unwrap_or(""),
+        SHIM_ARN,
+        "inference_profile_arn in response must equal the supplied ARN even on GetInferenceProfile failure"
+    );
+
+    // Deprecation header must still be present (the legacy field IS populated)
+    assert_eq!(
+        deprecation.as_deref(),
+        Some(DEPRECATION_HEADER_VALUE),
+        "Deprecation header must still be present even when GetInferenceProfile fails; got {deprecation:?}"
+    );
+
+    // Zero override rows in DB
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, endpoint_id)
+        .await
+        .expect("list_by_endpoint must not fail");
+
+    assert!(
+        rows.is_empty(),
+        "zero override rows must be in DB when GetInferenceProfile fails (auto-migration retries at next startup); got {rows:?}"
+    );
+}
+
+// ── Contract point 4: GET /admin/endpoints/{id} — zero rows + legacy null ─────
+
+/// GET /admin/endpoints/{id}: no override rows, inference_profile_arn = null:
+/// - `aip_overrides: []`
+/// - `inference_profile_arn: null`
+/// - No Deprecation/Sunset headers.
+#[tokio::test]
+async fn get_endpoint_no_overrides_no_legacy_clean_shape() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+
+    // Create a CRI endpoint with no legacy ARN
+    let ep_id = create_endpoint_db(&pool, "ep-get-clean", None).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+
+    let deprecation = resp.headers().get("deprecation").cloned();
+    let sunset = resp.headers().get("sunset").cloned();
+
+    let body = parse_body(resp).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "GET on existing endpoint must return 200; got {status}; body={body}"
+    );
+
+    // aip_overrides must be present and empty
+    let aip_overrides = body
+        .get("aip_overrides")
+        .expect("GET response must include 'aip_overrides' field (always present); body={body}");
+    assert_eq!(
+        aip_overrides,
+        &Value::Array(vec![]),
+        "aip_overrides must be [] when endpoint has no overrides and no legacy ARN; got {aip_overrides}"
+    );
+
+    // inference_profile_arn must be null
+    let ipa = body
+        .get("inference_profile_arn")
+        .expect("GET response must include 'inference_profile_arn' field; body={body}");
+    assert!(
+        ipa.is_null(),
+        "inference_profile_arn must be null when no legacy ARN and no overrides; got {ipa}"
+    );
+
+    // No Deprecation or Sunset headers
+    assert!(
+        deprecation.is_none(),
+        "Deprecation header must NOT be present when inference_profile_arn is null in GET response"
+    );
+    assert!(
+        sunset.is_none(),
+        "Sunset header must NOT be present when inference_profile_arn is null in GET response"
+    );
+}
+
+// ── Contract point 5: GET /admin/endpoints/{id} — exactly one override row ────
+
+/// GET /admin/endpoints/{id}: exactly one override row, legacy null:
+/// - `aip_overrides: [{the row}]`
+/// - `inference_profile_arn = row.aip_arn`
+/// - Deprecation + Sunset headers present.
+#[tokio::test]
+async fn get_endpoint_one_override_row_legacy_ipa_populated_with_deprecation() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+
+    // Create endpoint with no legacy ARN, then insert one override row via DB
+    let ep_id = create_endpoint_db(&pool, "ep-get-one-row", None).await;
+
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_id,
+        "claude-sonnet-4-5",
+        SHIM_ARN,
+        "admin",
+        Some("test override"),
+    )
+    .await
+    .expect("insert override must succeed");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+
+    let deprecation = resp
+        .headers()
+        .get("deprecation")
+        .map(|v| v.to_str().unwrap_or("").to_string());
+    let sunset = resp
+        .headers()
+        .get("sunset")
+        .map(|v| v.to_str().unwrap_or("").to_string());
+
+    let body = parse_body(resp).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "GET must return 200; got {status}; body={body}"
+    );
+
+    // aip_overrides must have exactly one row
+    let aip_overrides = body
+        .get("aip_overrides")
+        .and_then(|v| v.as_array())
+        .expect("aip_overrides must be a JSON array; body={body}");
+    assert_eq!(
+        aip_overrides.len(),
+        1,
+        "aip_overrides must have exactly one row; got {aip_overrides:?}"
+    );
+    assert_eq!(
+        aip_overrides[0]["model_id"].as_str().unwrap_or(""),
+        "claude-sonnet-4-5",
+        "aip_overrides[0].model_id must match the inserted row"
+    );
+    assert_eq!(
+        aip_overrides[0]["aip_arn"].as_str().unwrap_or(""),
+        SHIM_ARN,
+        "aip_overrides[0].aip_arn must match the inserted row"
+    );
+
+    // inference_profile_arn must equal the single row's aip_arn (legacy client compat)
+    let ipa = body
+        .get("inference_profile_arn")
+        .expect("GET response must include 'inference_profile_arn' field; body={body}");
+    assert_eq!(
+        ipa.as_str().unwrap_or(""),
+        SHIM_ARN,
+        "inference_profile_arn must equal the single override row's aip_arn; got {ipa}"
+    );
+
+    // Deprecation header must be present
+    assert_eq!(
+        deprecation.as_deref(),
+        Some(DEPRECATION_HEADER_VALUE),
+        "Deprecation header must be '{DEPRECATION_HEADER_VALUE}' when inference_profile_arn is non-null in GET; got {deprecation:?}"
+    );
+
+    // Sunset header must be present and match snapshot
+    assert_eq!(
+        sunset.as_deref(),
+        Some(SUNSET_HEADER_VALUE),
+        "Sunset header must be '{SUNSET_HEADER_VALUE}' when inference_profile_arn is non-null in GET; got {sunset:?}"
+    );
+}
+
+// ── Contract point 6: GET /admin/endpoints/{id} — two override rows ───────────
+
+/// GET /admin/endpoints/{id}: two override rows, legacy null:
+/// - `aip_overrides: [{row1}, {row2}]`
+/// - `inference_profile_arn: null` (can't represent multiple ARNs)
+/// - NO Deprecation/Sunset headers.
+#[tokio::test]
+async fn get_endpoint_two_override_rows_ipa_null_no_deprecation() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+
+    let ep_id = create_endpoint_db(&pool, "ep-get-two-rows", None).await;
+
+    // Insert Sonnet override
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_id,
+        "claude-sonnet-4-5",
+        SHIM_ARN,
+        "admin",
+        Some("sonnet"),
+    )
+    .await
+    .expect("insert sonnet override must succeed");
+
+    // Insert Opus override
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_id,
+        "claude-opus-4-7",
+        SHIM_ARN_OPUS,
+        "admin",
+        Some("opus"),
+    )
+    .await
+    .expect("insert opus override must succeed");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+
+    let deprecation = resp.headers().get("deprecation").cloned();
+    let sunset = resp.headers().get("sunset").cloned();
+
+    let body = parse_body(resp).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "GET must return 200; got {status}; body={body}"
+    );
+
+    // aip_overrides must have two rows
+    let aip_overrides = body
+        .get("aip_overrides")
+        .and_then(|v| v.as_array())
+        .expect("aip_overrides must be a JSON array; body={body}");
+    assert_eq!(
+        aip_overrides.len(),
+        2,
+        "aip_overrides must have two rows; got {aip_overrides:?}"
+    );
+
+    let model_ids: Vec<&str> = aip_overrides
+        .iter()
+        .map(|o| o["model_id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        model_ids.contains(&"claude-sonnet-4-5"),
+        "aip_overrides must include sonnet row"
+    );
+    assert!(
+        model_ids.contains(&"claude-opus-4-7"),
+        "aip_overrides must include opus row"
+    );
+
+    // inference_profile_arn must be null (can't represent 2 ARNs as one field)
+    let ipa = body
+        .get("inference_profile_arn")
+        .expect("GET response must include 'inference_profile_arn' field; body={body}");
+    assert!(
+        ipa.is_null(),
+        "inference_profile_arn must be null when there are 2+ override rows; got {ipa}"
+    );
+
+    // No Deprecation or Sunset headers when ipa is null
+    assert!(
+        deprecation.is_none(),
+        "Deprecation header must NOT be present when inference_profile_arn is null in GET (two-row case)"
+    );
+    assert!(
+        sunset.is_none(),
+        "Sunset header must NOT be present when inference_profile_arn is null in GET (two-row case)"
+    );
+}
+
+// ── Contract point 7: GET /admin/endpoints/{id} — zero rows + legacy column ───
+
+/// GET /admin/endpoints/{id}: zero override rows, legacy column populated
+/// (auto-migration not yet completed):
+/// - `aip_overrides: []`
+/// - `inference_profile_arn = <legacy value>`
+/// - Deprecation + Sunset headers (signals legacy field in use).
+#[tokio::test]
+async fn get_endpoint_zero_rows_legacy_column_set_deprecation_headers() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+
+    // Create endpoint WITH legacy ARN in the column but zero rows in new table
+    let legacy_arn =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/legacy-only";
+    let ep_id = create_endpoint_db(&pool, "ep-get-legacy-only", Some(legacy_arn)).await;
+
+    // Confirm no override rows were inserted
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+    assert!(rows.is_empty(), "precondition: no rows in new table");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+
+    let deprecation = resp
+        .headers()
+        .get("deprecation")
+        .map(|v| v.to_str().unwrap_or("").to_string());
+    let sunset = resp
+        .headers()
+        .get("sunset")
+        .map(|v| v.to_str().unwrap_or("").to_string());
+
+    let body = parse_body(resp).await;
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "GET must return 200; got {status}; body={body}"
+    );
+
+    // aip_overrides must be empty (no rows in new table)
+    let aip_overrides = body
+        .get("aip_overrides")
+        .expect("GET response must include 'aip_overrides' field; body={body}");
+    assert_eq!(
+        aip_overrides,
+        &Value::Array(vec![]),
+        "aip_overrides must be [] when no rows in new table; got {aip_overrides}"
+    );
+
+    // inference_profile_arn must equal the legacy column value
+    let ipa = body
+        .get("inference_profile_arn")
+        .expect("GET response must include 'inference_profile_arn' field; body={body}");
+    assert_eq!(
+        ipa.as_str().unwrap_or(""),
+        legacy_arn,
+        "inference_profile_arn must equal the legacy column value; got {ipa}"
+    );
+
+    // Deprecation header must be present (legacy field in use)
+    assert_eq!(
+        deprecation.as_deref(),
+        Some(DEPRECATION_HEADER_VALUE),
+        "Deprecation header must be '{DEPRECATION_HEADER_VALUE}' when legacy column populated (zero new-table rows); got {deprecation:?}"
+    );
+
+    // Sunset header must be present and match snapshot
+    assert_eq!(
+        sunset.as_deref(),
+        Some(SUNSET_HEADER_VALUE),
+        "Sunset header must be '{SUNSET_HEADER_VALUE}' when legacy column populated; got {sunset:?}"
+    );
+}
+
+// ── Auth smoke: POST and GET still require admin auth ─────────────────────────
+
+/// POST /admin/endpoints without auth → 401/403.
+#[tokio::test]
+async fn post_endpoint_requires_admin_auth() {
+    let pool = helpers::setup_test_db().await;
+    let (app, _) = test_app(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/endpoints")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"name":"unauth-ep","region":"us-east-1","routing_prefix":"us"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN,
+        "POST /admin/endpoints without auth must return 401/403; got {}",
+        resp.status()
+    );
+}
+
+/// GET /admin/endpoints/{id} without auth → 401/403.
+#[tokio::test]
+async fn get_endpoint_by_id_requires_admin_auth() {
+    let pool = helpers::setup_test_db().await;
+    let (app, _) = test_app(&pool).await;
+    let ep_id = create_endpoint_db(&pool, "ep-auth-smoke", None).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN,
+        "GET /admin/endpoints/{{id}} without auth must return 401/403; got {}",
+        resp.status()
+    );
+}
+
+/// GET /admin/endpoints/{nonexistent-id} with valid admin auth → 404.
+#[tokio::test]
+async fn get_endpoint_by_id_nonexistent_returns_404() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let fake_id = Uuid::new_v4();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{fake_id}"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "GET /admin/endpoints/{{nonexistent}} must return 404; got {}",
+        resp.status()
+    );
+}
+
+// ── Cache version bump: shim auto-insert bumps cache_version ──────────────────
+
+/// When the shim auto-inserts an override row via POST /admin/endpoints,
+/// cache_version must be bumped (same contract as the explicit
+/// POST /admin/endpoints/{id}/aip-overrides endpoint from Task 6).
+///
+/// Because GetInferenceProfile always fails in the test environment (no creds),
+/// this test checks the "GetInferenceProfile fails" path — in which case
+/// no override row is inserted and therefore no cache bump from the shim.
+/// The test documents this behaviour explicitly so the builder knows what
+/// to assert in the success path.
+///
+/// If/when the builder injects the get_foundation_model closure into GatewayState
+/// to allow test overrides, this test should be updated to verify that the
+/// SUCCESS path (shim inserts a row) ALSO bumps cache_version.
+#[tokio::test]
+async fn post_endpoint_with_arn_no_creds_no_cache_bump_from_shim() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+
+    let v0 = get_cache_version(&pool).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/endpoints")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"name":"ep-cache-arn","region":"us-east-1","routing_prefix":"us","inference_profile_arn":"{SHIM_ARN}"}}"#
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = parse_body(resp).await;
+
+    assert!(
+        status == StatusCode::CREATED || status == StatusCode::OK,
+        "POST must succeed; got {status}; body={body}"
+    );
+
+    let endpoint_id: Uuid = body["id"]
+        .as_str()
+        .and_then(|s| s.parse().ok())
+        .expect("response body must include 'id' with a UUID string; body={body}");
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, endpoint_id)
+        .await
+        .unwrap();
+
+    if rows.is_empty() {
+        // GetInferenceProfile failed (expected in test env without creds).
+        // No shim row → no shim cache bump (the endpoint creation itself does not
+        // bump cache_version by default).
+        // This branch documents the no-creds behaviour; no assertion on v1 needed.
+        let _v1 = get_cache_version(&pool).await;
+        // intentionally no assertion here — this path is informational
+    } else {
+        // GetInferenceProfile succeeded (possible if test env has creds).
+        // Shim inserted a row → cache_version MUST be bumped.
+        let v1 = get_cache_version(&pool).await;
+        assert!(
+            v1 > v0,
+            "cache_version must be bumped when shim auto-inserts an override row (before={v0}, after={v1})"
+        );
+    }
+}
+
+// ── Helper-level unit test for try_create_compat_override (injectable seam) ───
+
+/// Tests for the `try_create_compat_override` helper (or equivalent injectable
+/// function) that the builder should extract to allow unit-level testing of the
+/// shim logic without running the full HTTP handler.
+///
+/// BUILDER CONTRACT:
+/// Expose a public function in `src/api/admin.rs` (or a sibling module) like:
+///
+/// ```rust
+/// pub async fn try_create_compat_override<F, Fut>(
+///     endpoint_id: uuid::Uuid,
+///     legacy_arn: &str,
+///     pool: &sqlx::PgPool,
+///     get_foundation_model: F,
+/// ) -> Result<String, String>   // Ok(model_id) on success, Err(reason) on failure
+/// where
+///     F: Fn(&str) -> Fut + Send + Sync,
+///     Fut: std::future::Future<Output = Result<String, String>> + Send,
+/// ```
+///
+/// Once the builder exposes this symbol, delete the `#[cfg(FALSE_UNTIL_BUILDER_EXPOSES_HELPER)]`
+/// wrapper below and remove the `#[ignore]` attributes from each test.
+///
+/// The HTTP-level tests above (contract points 1-7) are the primary contract;
+/// these helper-level tests are an optional seam for isolated unit verification.
+// ─────────────────────────────────────────────────────────────────────────────
+// The two tests below are intentionally DISABLED at compile time via
+// `#[cfg(any())]` (always-false predicate) because `try_create_compat_override`
+// doesn't exist yet.  The builder should:
+//   1. Expose `pub async fn try_create_compat_override(...)` in src/api/admin.rs
+//      (re-exported from the crate root so the path below resolves).
+//   2. Replace `#[cfg(any())]` with `#[cfg(feature = "integration")]`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Helper success path: inserts exactly one override row with COMPAT_SHIM_SET_BY.
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn aip_compat_shim_try_create_compat_override_success() {
+    let pool = helpers::setup_test_db().await;
+
+    let ep_id = create_endpoint_db(&pool, "ep-helper-success", Some(SHIM_ARN)).await;
+
+    // Mock: GetInferenceProfile succeeds and returns "claude-sonnet-4-5"
+    let get_model = |_arn: &str| std::future::ready(Ok("claude-sonnet-4-5".to_string()));
+
+    let result: Result<String, String> =
+        ccag::api::admin::try_create_compat_override(ep_id, SHIM_ARN, &pool, get_model).await;
+
+    assert!(
+        result.is_ok(),
+        "try_create_compat_override must return Ok when get_foundation_model succeeds; got {result:?}"
+    );
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "exactly one override row must be inserted by the compat shim; got {rows:?}"
+    );
+
+    let row = &rows[0];
+    assert_eq!(
+        row.set_by, COMPAT_SHIM_SET_BY,
+        "set_by must be '{COMPAT_SHIM_SET_BY}'; got '{}'",
+        row.set_by
+    );
+    assert_eq!(
+        row.aip_arn, SHIM_ARN,
+        "aip_arn must equal the supplied legacy ARN"
+    );
+    assert_eq!(
+        row.model_id, "claude-sonnet-4-5",
+        "model_id must be the value returned by get_foundation_model"
+    );
+}
+
+/// Helper failure path: GetInferenceProfile returns Err → returns Err, zero rows.
+#[cfg(feature = "integration")]
+#[tokio::test]
+async fn aip_compat_shim_try_create_compat_override_get_infprof_fails_no_row() {
+    let pool = helpers::setup_test_db().await;
+
+    let ep_id = create_endpoint_db(&pool, "ep-helper-fail", Some(SHIM_ARN)).await;
+
+    let get_model =
+        |_arn: &str| std::future::ready(Err("simulated GetInferenceProfile failure".to_string()));
+
+    let result: Result<String, String> =
+        ccag::api::admin::try_create_compat_override(ep_id, SHIM_ARN, &pool, get_model).await;
+
+    // The helper should return Err to signal the caller, so the handler can
+    // log a warning without aborting the endpoint creation.
+    assert!(
+        result.is_err(),
+        "try_create_compat_override must return Err when get_foundation_model fails"
+    );
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+
+    assert!(
+        rows.is_empty(),
+        "zero override rows must be inserted when get_foundation_model fails; got {rows:?}"
+    );
+}

--- a/tests/integration/aip_legacy_migration_tests.rs
+++ b/tests/integration/aip_legacy_migration_tests.rs
@@ -1,0 +1,475 @@
+/// Integration tests for the Task 2 self-healing auto-migration runner.
+///
+/// # What is tested
+///
+/// These tests exercise `migrate_legacy_aip_endpoints` (the startup-time
+/// function the Builder Agent will add, likely in `src/migrations/aip_legacy.rs`)
+/// against a real Postgres instance.  All five contract points are covered:
+///
+/// 1. **Skip case A** — endpoint with no `inference_profile_arn` is untouched.
+/// 2. **Skip case B** — endpoint with a legacy ARN AND ≥1 pre-existing rows in
+///    `endpoint_aip_overrides` is skipped; the pre-inserted row survives unchanged.
+/// 3. **Happy path** — endpoint with legacy ARN and zero override rows → exactly
+///    one row inserted with the correct `model_id`, `aip_arn`, `set_by`, and
+///    `reason`; the legacy column is NOT cleared.
+/// 4. **Failure path** — `get_foundation_model` mock returns `Err` → no row
+///    inserted, migration as a whole still returns `Ok(())` (no panic, no abort).
+/// 5. **Idempotency** — running the migration twice produces exactly one row;
+///    the second run is a complete no-op.
+///
+/// # BUILDER CONTRACT
+///
+/// Expose:
+/// ```rust
+/// pub async fn migrate_legacy_aip_endpoints<F, Fut>(
+///     candidates: &[EndpointMigrationCandidate],
+///     pool: &sqlx::PgPool,
+///     get_foundation_model: F,
+/// ) -> anyhow::Result<()>
+/// where
+///     F: Fn(&str) -> Fut + Send + Sync,
+///     Fut: std::future::Future<Output = Result<String, String>> + Send,
+/// ```
+///
+/// where:
+/// ```rust
+/// pub struct EndpointMigrationCandidate {
+///     pub endpoint_id: uuid::Uuid,
+///     pub legacy_arn:  String,
+/// }
+/// ```
+///
+/// in `src/migrations/aip_legacy.rs` (or wherever the builder places it),
+/// re-exported from the crate root as `ccag::migrations::aip_legacy::*`.
+///
+/// The `get_foundation_model` closure receives the raw legacy ARN and must
+/// return the logical Anthropic model id (e.g. `"claude-sonnet-4-5-20250929"`).
+/// In production it calls `GetInferenceProfile`, parses the ARN tail, and maps
+/// via `bedrock_to_anthropic`. In tests we stub it out directly.
+///
+/// Wiring: call `migrate_legacy_aip_endpoints` in `src/main.rs` after
+/// `load_endpoints_with_db` and before the health loop starts.
+///
+/// Run: `make test-integration`
+use ccag::db;
+use ccag::db::endpoint_aip_overrides;
+use ccag::migrations::aip_legacy::{EndpointMigrationCandidate, migrate_legacy_aip_endpoints};
+use uuid::Uuid;
+
+use crate::helpers;
+
+// ── helper ────────────────────────────────────────────────────────────────────
+
+/// Create a bare test endpoint with no `inference_profile_arn`.
+async fn create_cri_endpoint(pool: &sqlx::PgPool, name: &str) -> Uuid {
+    db::endpoints::create_endpoint(pool, name, None, None, None, "us-east-1", "us", 0)
+        .await
+        .unwrap_or_else(|e| panic!("create_cri_endpoint({name}) failed: {e}"))
+        .id
+}
+
+/// Create a test endpoint with `inference_profile_arn` set (legacy AIP column).
+async fn create_aip_endpoint(pool: &sqlx::PgPool, name: &str, legacy_arn: &str) -> Uuid {
+    // `create_endpoint` signature: (pool, name, role_arn, external_id,
+    //   inference_profile_arn, region, routing_prefix, priority)
+    db::endpoints::create_endpoint(
+        pool,
+        name,
+        None,
+        None,
+        Some(legacy_arn),
+        "us-east-1",
+        "us",
+        0,
+    )
+    .await
+    .unwrap_or_else(|e| panic!("create_aip_endpoint({name}) failed: {e}"))
+    .id
+}
+
+/// A mock `get_foundation_model` that always returns `Ok(model_id.to_string())`.
+fn mock_get_model_ok(
+    model_id: &'static str,
+) -> impl Fn(&str) -> std::future::Ready<Result<String, String>> {
+    move |_arn: &str| std::future::ready(Ok(model_id.to_string()))
+}
+
+/// A mock `get_foundation_model` that always returns `Err`.
+fn mock_get_model_err() -> impl Fn(&str) -> std::future::Ready<Result<String, String>> {
+    |_arn: &str| std::future::ready(Err("simulated GetInferenceProfile failure".to_string()))
+}
+
+// ── Contract test 1: Skip case A (CRI endpoint, no legacy ARN) ───────────────
+
+/// An endpoint with `inference_profile_arn = NULL` (CRI endpoint) must be
+/// completely ignored by the migration runner; no rows are inserted in
+/// `endpoint_aip_overrides` for that endpoint.
+#[tokio::test]
+async fn migration_skip_cri_endpoint_without_legacy_arn() {
+    let pool = helpers::setup_test_db().await;
+    let cri_id = create_cri_endpoint(&pool, "cri-skip-a").await;
+
+    // Build a candidate list containing only this CRI endpoint.
+    // (In production the runner filters from DB; we inject the list here.)
+    let candidates: Vec<EndpointMigrationCandidate> = vec![]; // empty — no legacy ARN
+
+    migrate_legacy_aip_endpoints(
+        &candidates,
+        &pool,
+        mock_get_model_ok("claude-sonnet-4-5-20250929"),
+    )
+    .await
+    .expect("migration runner must return Ok even with zero candidates");
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, cri_id)
+        .await
+        .expect("list_by_endpoint must not fail");
+
+    assert!(
+        rows.is_empty(),
+        "CRI endpoint (no legacy ARN) must have zero override rows after migration; got {rows:?}"
+    );
+}
+
+// ── Contract test 2: Skip case B (legacy ARN + pre-existing rows) ─────────────
+
+/// An endpoint that already has ≥1 rows in `endpoint_aip_overrides` must NOT
+/// be processed by the migration runner — even though it has a legacy ARN.
+/// The pre-inserted row must survive unchanged (same count, same fields).
+#[tokio::test]
+async fn migration_skip_endpoint_with_existing_rows() {
+    let pool = helpers::setup_test_db().await;
+    let legacy_arn =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/existing-aip";
+    let ep_id = create_aip_endpoint(&pool, "aip-skip-b", legacy_arn).await;
+
+    // Pre-insert a manual override row (simulates a previously migrated or
+    // admin-created row).
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_id,
+        "claude-sonnet-4-5",
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/pre-existing",
+        "admin",
+        Some("manually set"),
+    )
+    .await
+    .expect("pre-insert must succeed");
+
+    // Run migration with this endpoint in the candidate list.
+    let candidates = vec![EndpointMigrationCandidate {
+        endpoint_id: ep_id,
+        legacy_arn: legacy_arn.to_string(),
+    }];
+
+    migrate_legacy_aip_endpoints(
+        &candidates,
+        &pool,
+        mock_get_model_ok("claude-opus-4-7"), // would insert a different model if the runner were wrong
+    )
+    .await
+    .expect("migration runner must return Ok");
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .expect("list must succeed");
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "endpoint with a pre-existing row must still have exactly 1 row after migration; the runner must not add a second row; got {rows:?}"
+    );
+    // The surviving row must be the original, not one written by the migration runner.
+    assert_eq!(
+        rows[0].model_id, "claude-sonnet-4-5",
+        "the surviving row must be the pre-existing admin-inserted row, not a runner-inserted row"
+    );
+    assert_eq!(
+        rows[0].set_by, "admin",
+        "set_by must still be 'admin' (the pre-existing row), not 'auto-migration'"
+    );
+}
+
+// ── Contract test 3: Happy path ───────────────────────────────────────────────
+
+/// Endpoint with a legacy ARN and zero override rows → runner inserts exactly
+/// one row with:
+/// - `model_id`  = the value returned by `get_foundation_model`
+/// - `aip_arn`   = the legacy ARN itself
+/// - `set_by`    = "auto-migration"
+/// - `reason`    = "migrated from inference_profile_arn column"
+///
+/// The legacy column must remain set after the migration (not cleared).
+#[tokio::test]
+async fn migration_happy_path_inserts_one_row() {
+    let pool = helpers::setup_test_db().await;
+    let legacy_arn =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged";
+    let ep_id = create_aip_endpoint(&pool, "aip-happy", legacy_arn).await;
+
+    let expected_model_id = "claude-sonnet-4-5-20250929";
+
+    let candidates = vec![EndpointMigrationCandidate {
+        endpoint_id: ep_id,
+        legacy_arn: legacy_arn.to_string(),
+    }];
+
+    migrate_legacy_aip_endpoints(&candidates, &pool, mock_get_model_ok(expected_model_id))
+        .await
+        .expect("migration runner must return Ok on happy path");
+
+    // Exactly one row must be inserted.
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .expect("list must succeed");
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "happy path: exactly one override row must be inserted; got {rows:?}"
+    );
+
+    let row = &rows[0];
+
+    assert_eq!(
+        row.model_id, expected_model_id,
+        "inserted model_id must equal the value returned by get_foundation_model"
+    );
+    assert_eq!(
+        row.aip_arn, legacy_arn,
+        "inserted aip_arn must equal the legacy ARN"
+    );
+    assert_eq!(
+        row.set_by, "auto-migration",
+        "set_by must be exactly 'auto-migration'"
+    );
+    assert_eq!(
+        row.reason.as_deref(),
+        Some("migrated from inference_profile_arn column"),
+        "reason must be exactly 'migrated from inference_profile_arn column'"
+    );
+
+    // Verify the legacy column was NOT cleared: re-fetch the endpoint from DB.
+    let ep_row =
+        sqlx::query_as::<_, ccag::db::schema::Endpoint>("SELECT * FROM endpoints WHERE id = $1")
+            .bind(ep_id)
+            .fetch_one(&pool)
+            .await
+            .expect("re-fetch endpoint must succeed");
+
+    assert_eq!(
+        ep_row.inference_profile_arn.as_deref(),
+        Some(legacy_arn),
+        "inference_profile_arn column must NOT be cleared after auto-migration (intentional during transition)"
+    );
+}
+
+// ── Contract test 4: Failure path (GetInferenceProfile error) ────────────────
+
+/// When `get_foundation_model` returns `Err`, the migration runner must:
+/// - Insert zero rows for that endpoint.
+/// - Continue without panicking.
+/// - Return `Ok(())` (startup is not blocked).
+#[tokio::test]
+async fn migration_failure_path_no_row_inserted_startup_continues() {
+    let pool = helpers::setup_test_db().await;
+    let legacy_arn =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/broken-aip";
+    let ep_id = create_aip_endpoint(&pool, "aip-failure", legacy_arn).await;
+
+    let candidates = vec![EndpointMigrationCandidate {
+        endpoint_id: ep_id,
+        legacy_arn: legacy_arn.to_string(),
+    }];
+
+    // The mock returns an error simulating a failed GetInferenceProfile call.
+    let result = migrate_legacy_aip_endpoints(&candidates, &pool, mock_get_model_err()).await;
+
+    assert!(
+        result.is_ok(),
+        "migration runner must return Ok even when get_foundation_model fails; startup must not be blocked; got {result:?}"
+    );
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .expect("list must succeed");
+
+    assert!(
+        rows.is_empty(),
+        "when get_foundation_model fails, zero override rows must be inserted; got {rows:?}"
+    );
+}
+
+/// Multi-endpoint mix: CRI endpoint untouched, healthy AIP endpoint migrated,
+/// broken AIP endpoint logged-and-skipped — all in one runner call.
+#[tokio::test]
+async fn migration_mixed_endpoints_correct_per_endpoint_behaviour() {
+    let pool = helpers::setup_test_db().await;
+
+    // (a) CRI endpoint — NOT in the candidate list (already filtered upstream)
+    let cri_id = create_cri_endpoint(&pool, "cri-mixed").await;
+
+    // (b) Healthy AIP endpoint
+    let healthy_arn =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/healthy";
+    let healthy_id = create_aip_endpoint(&pool, "aip-healthy-mixed", healthy_arn).await;
+
+    // (c) Broken AIP endpoint
+    let broken_arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/broken";
+    let broken_id = create_aip_endpoint(&pool, "aip-broken-mixed", broken_arn).await;
+
+    // Candidate list contains only the AIP endpoints (CRI has no legacy ARN).
+    let candidates = vec![
+        EndpointMigrationCandidate {
+            endpoint_id: healthy_id,
+            legacy_arn: healthy_arn.to_string(),
+        },
+        EndpointMigrationCandidate {
+            endpoint_id: broken_id,
+            legacy_arn: broken_arn.to_string(),
+        },
+    ];
+
+    // Mock: healthy endpoint returns Ok, broken endpoint returns Err.
+    let healthy_id_copy = healthy_id;
+    let get_model = move |arn: &str| {
+        // Only "healthy" ARN succeeds; all others fail.
+        if arn.contains("healthy") {
+            std::future::ready(Ok("claude-sonnet-4-5-20250929".to_string()))
+        } else {
+            std::future::ready(Err("simulated failure".to_string()))
+        }
+    };
+
+    let result = migrate_legacy_aip_endpoints(&candidates, &pool, get_model).await;
+    assert!(
+        result.is_ok(),
+        "runner must return Ok on mixed-endpoint run"
+    );
+
+    // CRI endpoint: still zero rows
+    let cri_rows = endpoint_aip_overrides::list_by_endpoint(&pool, cri_id)
+        .await
+        .unwrap();
+    assert!(cri_rows.is_empty(), "CRI endpoint must have zero rows");
+
+    // Healthy AIP endpoint: exactly one row
+    let healthy_rows = endpoint_aip_overrides::list_by_endpoint(&pool, healthy_id_copy)
+        .await
+        .unwrap();
+    assert_eq!(
+        healthy_rows.len(),
+        1,
+        "healthy AIP endpoint must have exactly one row after migration"
+    );
+    assert_eq!(healthy_rows[0].set_by, "auto-migration");
+
+    // Broken AIP endpoint: zero rows
+    let broken_rows = endpoint_aip_overrides::list_by_endpoint(&pool, broken_id)
+        .await
+        .unwrap();
+    assert!(
+        broken_rows.is_empty(),
+        "broken AIP endpoint must have zero rows after migration"
+    );
+}
+
+// ── Contract test 5: Idempotency ─────────────────────────────────────────────
+
+/// Running the migration twice on the same DB state must be a no-op on the
+/// second run.  After both runs, the endpoint still has exactly one override
+/// row, and its `set_at` / other fields are unchanged from the first run.
+#[tokio::test]
+async fn migration_idempotent_second_run_is_noop() {
+    let pool = helpers::setup_test_db().await;
+    let legacy_arn =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/idem-aip";
+    let ep_id = create_aip_endpoint(&pool, "aip-idempotent", legacy_arn).await;
+
+    let candidates = vec![EndpointMigrationCandidate {
+        endpoint_id: ep_id,
+        legacy_arn: legacy_arn.to_string(),
+    }];
+
+    let model_id = "claude-sonnet-4-5-20250929";
+
+    // First run: inserts one row.
+    migrate_legacy_aip_endpoints(&candidates, &pool, mock_get_model_ok(model_id))
+        .await
+        .expect("first run must succeed");
+
+    let rows_after_first = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        rows_after_first.len(),
+        1,
+        "should have one row after first run"
+    );
+    let set_at_first = rows_after_first[0].set_at;
+
+    // Second run: must be a complete no-op — the predicate "zero rows for this
+    // endpoint" is now false, so the runner skips the endpoint.
+    migrate_legacy_aip_endpoints(&candidates, &pool, mock_get_model_ok(model_id))
+        .await
+        .expect("second run must also succeed");
+
+    let rows_after_second = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows_after_second.len(),
+        1,
+        "second run must not add a duplicate row; still exactly one row expected"
+    );
+    assert_eq!(
+        rows_after_second[0].set_at, set_at_first,
+        "set_at must be unchanged on the second run (the row was not touched)"
+    );
+    assert_eq!(
+        rows_after_second[0].set_by, "auto-migration",
+        "set_by must still be 'auto-migration' after second run"
+    );
+}
+
+// ── Race / concurrent safety (sequential idempotency stand-in) ────────────────
+
+/// Calling `migrate_legacy_aip_endpoints` three times in a row (in the same
+/// process, serially) must not produce PK violations and must leave exactly one
+/// row per AIP endpoint.
+///
+/// This covers the "double-startup" scenario described in the task spec.
+#[tokio::test]
+async fn migration_serial_triple_run_no_pk_violation() {
+    let pool = helpers::setup_test_db().await;
+    let legacy_arn =
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/triple-run-aip";
+    let ep_id = create_aip_endpoint(&pool, "aip-triple", legacy_arn).await;
+
+    let candidates = vec![EndpointMigrationCandidate {
+        endpoint_id: ep_id,
+        legacy_arn: legacy_arn.to_string(),
+    }];
+
+    let model_id = "claude-haiku-4-5-20251001";
+
+    for run in 1..=3 {
+        let result =
+            migrate_legacy_aip_endpoints(&candidates, &pool, mock_get_model_ok(model_id)).await;
+        assert!(
+            result.is_ok(),
+            "run {run}: migration runner must not return Err (no PK violation propagated)"
+        );
+    }
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows.len(),
+        1,
+        "after 3 serial runs, must still have exactly one row (no duplicates)"
+    );
+}

--- a/tests/integration/aip_overrides_admin_tests.rs
+++ b/tests/integration/aip_overrides_admin_tests.rs
@@ -1,0 +1,839 @@
+/// Integration tests for the three new admin REST endpoints:
+///
+///   GET    /admin/endpoints/{id}/aip-overrides
+///   POST   /admin/endpoints/{id}/aip-overrides
+///   DELETE /admin/endpoints/{id}/aip-overrides/{model_id}
+///
+/// Contract points covered (numbered per Task 6 spec):
+///   1. Auth:    all three endpoints without admin auth → 401/403
+///   2. 404:     nonexistent endpoint id for all three verbs
+///   3. POST happy path + round-trip via GET
+///   4. POST conflict:  same (endpoint_id, model_id) twice → 409
+///   5. DELETE happy path + subsequent GET no longer shows the row
+///   6. DELETE 404: model_id not present on this endpoint
+///   7a. POST validation: missing model_id → 400
+///   7b. POST validation: malformed ARN (doesn't start with `arn:aws:bedrock:`) → 400
+///   8. cache_version bump on each successful write
+///
+/// Run with: make test-integration (requires Docker Postgres on port 5433)
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI64};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::helpers;
+use ccag::budget::BudgetSpendCache;
+
+// ── shared test app factory ────────────────────────────────────────────────────
+
+/// Build a minimal test router backed by a real DB pool. Returns the router
+/// and a valid admin session token.
+///
+/// Mirrors the pattern in `admin_tests.rs::test_app`.
+async fn test_app(pool: &sqlx::PgPool) -> (axum::Router, String) {
+    let config = ccag::config::GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 9999,
+        admin_username: "admin".to_string(),
+        admin_password: "admin".to_string(),
+        bedrock_routing_prefix: "us".to_string(),
+        database_url: "postgres://test@localhost/test".to_string(),
+        admin_users: vec![],
+        notification_url: None,
+        rds_iam_auth: false,
+        database_host: None,
+        database_port: 5432,
+        database_name: "test".to_string(),
+        database_user: "test".to_string(),
+        pricing_refresh_interval: 86400,
+        pricing_refresh_enabled: false,
+    };
+
+    let signing_key = "test-signing-key-aip-overrides";
+
+    // Seed the admin user so `resolve_oidc_role` resolves "admin".
+    let _ = ccag::db::users::create_user(pool, "admin", None, "admin").await;
+
+    let identity = ccag::auth::oidc::OidcIdentity {
+        sub: "admin".to_string(),
+        email: None,
+        idp_name: "Local".to_string(),
+    };
+    let admin_token = ccag::auth::session::issue(signing_key, &identity, 24);
+
+    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let (metrics, _provider) = ccag::telemetry::Metrics::new(None).unwrap();
+    let metrics = Arc::new(metrics);
+    let db_pool = Arc::new(tokio::sync::RwLock::new(pool.clone()));
+
+    let state = Arc::new(ccag::proxy::GatewayState {
+        bedrock_client: aws_sdk_bedrockruntime::Client::new(&aws_config),
+        bedrock_control_client: aws_sdk_bedrock::Client::new(&aws_config),
+        model_cache: ccag::translate::models::ModelCache::new(),
+        config,
+        key_cache: ccag::auth::KeyCache::new(),
+        rate_limiter: ccag::ratelimit::RateLimiter::new(),
+        idp_validator: Arc::new(ccag::auth::oidc::MultiIdpValidator::new()),
+        db_pool: db_pool.clone(),
+        spend_tracker: Arc::new(ccag::spend::SpendTracker::new(db_pool, metrics.clone())),
+        metrics,
+        virtual_keys_enabled: AtomicBool::new(true),
+        admin_login_enabled: AtomicBool::new(true),
+        cache_version: AtomicI64::new(1),
+        session_token_ttl_hours: AtomicI64::new(24),
+        session_signing_key: signing_key.to_string(),
+        cli_sessions: ccag::api::cli_auth::new_session_store(),
+        setup_tokens: tokio::sync::RwLock::new(std::collections::HashMap::new()),
+        http_client: reqwest::Client::new(),
+        budget_cache: Arc::new(BudgetSpendCache::new(30)),
+        sns_client: None,
+        eb_client: None,
+        quota_cache: None,
+        aws_config: aws_config.clone(),
+        bedrock_health: tokio::sync::RwLock::new(None),
+        endpoint_pool: Arc::new(ccag::endpoint::EndpointPool::new()),
+        endpoint_stats: Arc::new(ccag::endpoint::stats::EndpointStats::new()),
+        started_at: std::time::Instant::now(),
+        login_attempts: tokio::sync::Mutex::new(Vec::new()),
+        pricing_client: Arc::new(aws_sdk_pricing::Client::new(&aws_config)),
+    });
+
+    (ccag::api::router(state), admin_token)
+}
+
+/// Create an endpoint via the DB directly and return its UUID string.
+async fn create_endpoint(pool: &sqlx::PgPool, name: &str) -> String {
+    ccag::db::endpoints::create_endpoint(pool, name, None, None, None, "us-east-1", "us", 0)
+        .await
+        .unwrap_or_else(|e| panic!("create_endpoint({name}) failed: {e}"))
+        .id
+        .to_string()
+}
+
+/// Read the current `cache_version` counter from the DB.
+async fn get_cache_version(pool: &sqlx::PgPool) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT MAX(version) FROM cache_version")
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0)
+}
+
+/// Parse a response body as JSON.
+async fn parse_body(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .expect("failed to read response body");
+    serde_json::from_slice(&bytes).expect("response body is not valid JSON")
+}
+
+/// A valid AIP ARN used throughout the tests.
+const VALID_ARN: &str =
+    "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged";
+
+/// A valid AIP ARN for a second model (Opus).
+const VALID_ARN_OPUS: &str =
+    "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-tagged";
+
+// ── Contract point 1: Auth ────────────────────────────────────────────────────
+
+/// GET /admin/endpoints/{id}/aip-overrides without auth → 401
+#[tokio::test]
+async fn aip_overrides_get_requires_auth() {
+    let pool = helpers::setup_test_db().await;
+    let (app, _) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "auth-test-get").await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN,
+        "GET without auth must return 401 or 403, got {}",
+        resp.status()
+    );
+}
+
+/// POST /admin/endpoints/{id}/aip-overrides without auth → 401
+#[tokio::test]
+async fn aip_overrides_post_requires_auth() {
+    let pool = helpers::setup_test_db().await;
+    let (app, _) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "auth-test-post").await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"model_id":"claude-sonnet-4-5","aip_arn":"{VALID_ARN}"}}"#
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN,
+        "POST without auth must return 401 or 403, got {}",
+        resp.status()
+    );
+}
+
+/// DELETE /admin/endpoints/{id}/aip-overrides/{model_id} without auth → 401
+#[tokio::test]
+async fn aip_overrides_delete_requires_auth() {
+    let pool = helpers::setup_test_db().await;
+    let (app, _) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "auth-test-delete").await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/endpoints/{ep_id}/aip-overrides/claude-sonnet-4-5"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN,
+        "DELETE without auth must return 401 or 403, got {}",
+        resp.status()
+    );
+}
+
+/// A non-admin (member) token should also be rejected on all three verbs.
+#[tokio::test]
+async fn aip_overrides_member_token_rejected() {
+    let pool = helpers::setup_test_db().await;
+    let (app, _) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "member-auth").await;
+
+    // Create a member user and issue their token
+    let _ = ccag::db::users::create_user(&pool, "member@test.com", None, "member").await;
+    let member_identity = ccag::auth::oidc::OidcIdentity {
+        sub: "member@test.com".to_string(),
+        email: None,
+        idp_name: "Local".to_string(),
+    };
+    let member_token =
+        ccag::auth::session::issue("test-signing-key-aip-overrides", &member_identity, 24);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {member_token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"model_id":"claude-sonnet-4-5","aip_arn":"{VALID_ARN}"}}"#
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.status() == StatusCode::UNAUTHORIZED || resp.status() == StatusCode::FORBIDDEN,
+        "member token must be rejected with 401/403, got {}",
+        resp.status()
+    );
+}
+
+// ── Contract point 2: 404 on nonexistent endpoint id ─────────────────────────
+
+/// GET /admin/endpoints/{nonexistent}/aip-overrides → 404
+#[tokio::test]
+async fn aip_overrides_get_nonexistent_endpoint_404() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let fake_id = Uuid::new_v4();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{fake_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "GET on nonexistent endpoint id must return 404"
+    );
+}
+
+/// POST /admin/endpoints/{nonexistent}/aip-overrides → 404
+#[tokio::test]
+async fn aip_overrides_post_nonexistent_endpoint_404() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let fake_id = Uuid::new_v4();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/admin/endpoints/{fake_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"model_id":"claude-sonnet-4-5","aip_arn":"{VALID_ARN}"}}"#
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "POST on nonexistent endpoint id must return 404"
+    );
+}
+
+/// DELETE /admin/endpoints/{nonexistent}/aip-overrides/{model_id} → 404
+#[tokio::test]
+async fn aip_overrides_delete_nonexistent_endpoint_404() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let fake_id = Uuid::new_v4();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/endpoints/{fake_id}/aip-overrides/claude-sonnet-4-5"
+                ))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "DELETE on nonexistent endpoint id must return 404"
+    );
+}
+
+// ── Contract point 3: POST happy path ─────────────────────────────────────────
+
+/// POST inserts a row; response echoes it; subsequent GET shows it.
+#[tokio::test]
+async fn aip_overrides_post_happy_path() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-post-happy").await;
+
+    // POST a new override
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"model_id":"claude-sonnet-4-5","aip_arn":"{VALID_ARN}","reason":"test reason"}}"#
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    assert!(
+        status == StatusCode::CREATED || status == StatusCode::OK,
+        "POST happy path must return 200 or 201, got {status}"
+    );
+
+    let body = parse_body(resp).await;
+    // Response must echo the inserted row's key fields
+    assert_eq!(
+        body["model_id"].as_str().unwrap_or(""),
+        "claude-sonnet-4-5",
+        "response must echo model_id"
+    );
+    assert_eq!(
+        body["aip_arn"].as_str().unwrap_or(""),
+        VALID_ARN,
+        "response must echo aip_arn"
+    );
+
+    // GET must show the inserted row
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = parse_body(resp).await;
+    let overrides = body["overrides"]
+        .as_array()
+        .expect("GET response must have 'overrides' array");
+    assert_eq!(
+        overrides.len(),
+        1,
+        "GET must return exactly one override after POST"
+    );
+    assert_eq!(
+        overrides[0]["model_id"].as_str().unwrap_or(""),
+        "claude-sonnet-4-5"
+    );
+    assert_eq!(overrides[0]["aip_arn"].as_str().unwrap_or(""), VALID_ARN);
+}
+
+// ── Contract point 4: POST conflict → 409 ────────────────────────────────────
+
+/// POSTing the same (endpoint_id, model_id) twice must return 409.
+///
+/// This covers the `DbError::Conflict` path (PK violation, Postgres code 23505)
+/// that Task 1's CRUD layer surfaces and Task 6's handler must map to HTTP 409.
+#[tokio::test]
+async fn aip_overrides_post_conflict_returns_409() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-conflict").await;
+
+    let body_str = format!(r#"{{"model_id":"claude-sonnet-4-5","aip_arn":"{VALID_ARN}"}}"#);
+
+    // First insert succeeds
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(body_str.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let first_status = resp.status();
+    assert!(
+        first_status == StatusCode::CREATED || first_status == StatusCode::OK,
+        "first POST must succeed, got {first_status}"
+    );
+
+    // Second insert with the same (endpoint_id, model_id) must return 409
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(body_str))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "duplicate (endpoint_id, model_id) must return 409 Conflict"
+    );
+
+    // The 409 response should carry a structured error body
+    let body = parse_body(resp).await;
+    assert!(
+        body.get("error").is_some() || body.get("type").is_some(),
+        "409 response must carry a structured error body, got: {body}"
+    );
+}
+
+// ── Contract point 5: DELETE happy path ──────────────────────────────────────
+
+/// DELETE removes the override; subsequent GET no longer shows it.
+#[tokio::test]
+async fn aip_overrides_delete_happy_path() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-delete-happy").await;
+
+    // Insert two overrides (Sonnet + Opus)
+    for (model, arn) in [
+        ("claude-sonnet-4-5", VALID_ARN),
+        ("claude-opus-4-7", VALID_ARN_OPUS),
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"model_id":"{model}","aip_arn":"{arn}"}}"#
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status() == StatusCode::CREATED || resp.status() == StatusCode::OK,
+            "setup POST for {model} must succeed"
+        );
+    }
+
+    // DELETE the Sonnet override
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/endpoints/{ep_id}/aip-overrides/claude-sonnet-4-5"
+                ))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let del_status = resp.status();
+    assert!(
+        del_status == StatusCode::OK || del_status == StatusCode::NO_CONTENT,
+        "DELETE must return 200 or 204, got {del_status}"
+    );
+
+    // GET must show only Opus (Sonnet gone)
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = parse_body(resp).await;
+    let overrides = body["overrides"]
+        .as_array()
+        .expect("GET response must have 'overrides' array");
+
+    assert_eq!(
+        overrides.len(),
+        1,
+        "only one override should remain after DELETE"
+    );
+    assert_eq!(
+        overrides[0]["model_id"].as_str().unwrap_or(""),
+        "claude-opus-4-7",
+        "remaining override must be Opus, not the deleted Sonnet"
+    );
+}
+
+// ── Contract point 6: DELETE 404 on missing model_id ─────────────────────────
+
+/// DELETE /admin/endpoints/{id}/aip-overrides/{model_id} when model_id is not
+/// present on this endpoint → 404.
+#[tokio::test]
+async fn aip_overrides_delete_missing_model_returns_404() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-delete-missing").await;
+
+    // No overrides inserted — DELETE of any model must be 404
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/endpoints/{ep_id}/aip-overrides/claude-sonnet-4-5"
+                ))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "DELETE of a model_id not present on this endpoint must return 404"
+    );
+}
+
+// ── Contract point 7a: POST validation — missing model_id → 400 ──────────────
+
+/// POST with body that omits `model_id` must return 400.
+#[tokio::test]
+async fn aip_overrides_post_missing_model_id_returns_400() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-validation-no-model").await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(r#"{{"aip_arn":"{VALID_ARN}"}}"#)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "POST without model_id must return 400"
+    );
+}
+
+// ── Contract point 7b: POST validation — malformed ARN → 400 ─────────────────
+
+/// POST with an ARN that doesn't start with `arn:aws:bedrock:` must return 400.
+///
+/// This is a best-effort syntactic check. Deep validation (ARN reachable,
+/// AIP resolves) happens at health-loop time, not at write time.
+#[tokio::test]
+async fn aip_overrides_post_malformed_arn_returns_400() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-validation-bad-arn").await;
+
+    for bad_arn in [
+        "not-an-arn-at-all",
+        "arn:aws:iam::123456789012:role/some-role", // wrong service
+        "arn:aws:bedrock",                          // too short / incomplete
+        "",                                         // empty
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"model_id":"claude-sonnet-4-5","aip_arn":"{bad_arn}"}}"#
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "POST with malformed ARN '{bad_arn}' must return 400"
+        );
+    }
+}
+
+// ── Contract point 8: cache_version bump on successful writes ─────────────────
+
+/// Each successful POST bumps cache_version; each successful DELETE bumps it too.
+///
+/// Mirrors the pattern used by other admin write endpoints (e.g. IDP SCIM
+/// admin-group update, `set_scim_admin_groups` in admin.rs which calls
+/// `db::settings::bump_cache_version`).
+#[tokio::test]
+async fn aip_overrides_writes_bump_cache_version() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-cache-bump").await;
+
+    let v0 = get_cache_version(&pool).await;
+
+    // POST → cache_version must increase
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"model_id":"claude-sonnet-4-5","aip_arn":"{VALID_ARN}"}}"#
+                )))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let post_status = resp.status();
+    assert!(
+        post_status == StatusCode::CREATED || post_status == StatusCode::OK,
+        "POST must succeed, got {post_status}"
+    );
+
+    let v1 = get_cache_version(&pool).await;
+    assert!(
+        v1 > v0,
+        "cache_version must be bumped after a successful POST (before={v0}, after={v1})"
+    );
+
+    // DELETE → cache_version must increase again
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/admin/endpoints/{ep_id}/aip-overrides/claude-sonnet-4-5"
+                ))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let del_status = resp.status();
+    assert!(
+        del_status == StatusCode::OK || del_status == StatusCode::NO_CONTENT,
+        "DELETE must succeed, got {del_status}"
+    );
+
+    let v2 = get_cache_version(&pool).await;
+    assert!(
+        v2 > v1,
+        "cache_version must be bumped after a successful DELETE (before={v1}, after={v2})"
+    );
+}
+
+// ── Bonus: GET returns all rows for an endpoint, multiple overrides ────────────
+
+/// GET lists all override rows for the endpoint, including multiple models.
+#[tokio::test]
+async fn aip_overrides_get_lists_all_rows() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-get-all").await;
+
+    // Insert Sonnet + Opus
+    for (model, arn) in [
+        ("claude-sonnet-4-5", VALID_ARN),
+        ("claude-opus-4-7", VALID_ARN_OPUS),
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"model_id":"{model}","aip_arn":"{arn}"}}"#
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status() == StatusCode::CREATED || resp.status() == StatusCode::OK,
+            "setup POST for {model} must succeed"
+        );
+    }
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = parse_body(resp).await;
+    let overrides = body["overrides"]
+        .as_array()
+        .expect("GET response must have 'overrides' array");
+
+    assert_eq!(
+        overrides.len(),
+        2,
+        "GET must return both inserted overrides"
+    );
+    let model_ids: Vec<&str> = overrides
+        .iter()
+        .map(|o| o["model_id"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        model_ids.contains(&"claude-sonnet-4-5"),
+        "Sonnet must be in the list"
+    );
+    assert!(
+        model_ids.contains(&"claude-opus-4-7"),
+        "Opus must be in the list"
+    );
+}
+
+/// GET for an endpoint with no overrides returns an empty array (not 404 or error).
+#[tokio::test]
+async fn aip_overrides_get_empty_is_ok() {
+    let pool = helpers::setup_test_db().await;
+    let (app, token) = test_app(&pool).await;
+    let ep_id = create_endpoint(&pool, "ep-get-empty").await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/admin/endpoints/{ep_id}/aip-overrides"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = parse_body(resp).await;
+    let overrides = body["overrides"]
+        .as_array()
+        .expect("GET response must have 'overrides' array");
+    assert!(
+        overrides.is_empty(),
+        "GET for an endpoint with no overrides must return empty array"
+    );
+}

--- a/tests/integration/endpoint_aip_overrides_tests.rs
+++ b/tests/integration/endpoint_aip_overrides_tests.rs
@@ -1,0 +1,334 @@
+/// Integration tests for the `endpoint_aip_overrides` CRUD layer.
+///
+/// Contract points tested:
+/// - insert + list_by_endpoint happy path
+/// - delete_by_model removes exactly one row
+/// - FK CASCADE: deleting the parent endpoint removes all override rows
+/// - PK violation on duplicate (endpoint_id, model_id) → sqlx database error
+///   with code 23505 (the pattern the admin handler will downcast to return 409)
+///
+/// These tests require a real Postgres instance. Run with `make test-integration`.
+use ccag::db;
+use ccag::db::endpoint_aip_overrides::{self, AipOverride};
+use uuid::Uuid;
+
+use crate::helpers;
+
+// ── helper ────────────────────────────────────────────────────────────────────
+
+async fn create_test_endpoint(pool: &sqlx::PgPool, name: &str) -> Uuid {
+    db::endpoints::create_endpoint(pool, name, None, None, None, "us-east-1", "us", 0)
+        .await
+        .unwrap_or_else(|e| panic!("create_test_endpoint({name}) failed: {e}"))
+        .id
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// `insert` followed by `list_by_endpoint` returns the inserted row with all
+/// fields populated correctly.
+#[tokio::test]
+async fn aip_override_insert_and_list() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_test_endpoint(&pool, "ep-aip-1").await;
+
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_id,
+        "claude-sonnet-4-5",
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged",
+        "test-user",
+        Some("test insertion"),
+    )
+    .await
+    .expect("insert should succeed");
+
+    let rows: Vec<AipOverride> = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .expect("list_by_endpoint should succeed");
+
+    assert_eq!(rows.len(), 1, "should have exactly one override row");
+    let row = &rows[0];
+    assert_eq!(row.endpoint_id, ep_id);
+    assert_eq!(row.model_id, "claude-sonnet-4-5");
+    assert_eq!(
+        row.aip_arn,
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sonnet-tagged"
+    );
+    assert_eq!(row.set_by, "test-user");
+    assert_eq!(row.reason.as_deref(), Some("test insertion"));
+}
+
+/// `insert` with `reason = None` is accepted; the reason column is nullable.
+#[tokio::test]
+async fn aip_override_insert_null_reason() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_test_endpoint(&pool, "ep-aip-null-reason").await;
+
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_id,
+        "claude-opus-4-7",
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/opus-tagged",
+        "admin",
+        None,
+    )
+    .await
+    .expect("insert with null reason should succeed");
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .expect("list should succeed");
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].reason.is_none(), "reason should be None");
+}
+
+/// `list_by_endpoint` returns only the rows for the requested endpoint;
+/// rows for other endpoints are not included.
+#[tokio::test]
+async fn aip_override_list_scoped_to_endpoint() {
+    let pool = helpers::setup_test_db().await;
+    let ep_a = create_test_endpoint(&pool, "ep-a").await;
+    let ep_b = create_test_endpoint(&pool, "ep-b").await;
+
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_a,
+        "claude-sonnet-4-5",
+        "arn:aws:bedrock:us-east-1:111111111111:application-inference-profile/sonnet-a",
+        "admin",
+        None,
+    )
+    .await
+    .unwrap();
+
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_b,
+        "claude-sonnet-4-5",
+        "arn:aws:bedrock:us-east-1:222222222222:application-inference-profile/sonnet-b",
+        "admin",
+        None,
+    )
+    .await
+    .unwrap();
+
+    let rows_a = endpoint_aip_overrides::list_by_endpoint(&pool, ep_a)
+        .await
+        .unwrap();
+    let rows_b = endpoint_aip_overrides::list_by_endpoint(&pool, ep_b)
+        .await
+        .unwrap();
+
+    assert_eq!(rows_a.len(), 1, "ep_a should have exactly 1 row");
+    assert_eq!(rows_a[0].endpoint_id, ep_a);
+    assert_eq!(rows_b.len(), 1, "ep_b should have exactly 1 row");
+    assert_eq!(rows_b[0].endpoint_id, ep_b);
+}
+
+/// `list_by_endpoint` returns all rows when multiple overrides exist on one endpoint.
+#[tokio::test]
+async fn aip_override_list_multiple_rows() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_test_endpoint(&pool, "ep-multi").await;
+
+    for (model, arn_suffix) in [
+        ("claude-sonnet-4-5", "sonnet"),
+        ("claude-opus-4-7", "opus"),
+        ("claude-haiku-4-5", "haiku"),
+    ] {
+        endpoint_aip_overrides::insert(
+            &pool,
+            ep_id,
+            model,
+            &format!(
+                "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/{arn_suffix}"
+            ),
+            "admin",
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("insert {model} failed: {e}"));
+    }
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3, "should have 3 override rows");
+
+    let model_ids: Vec<&str> = rows.iter().map(|r| r.model_id.as_str()).collect();
+    assert!(model_ids.contains(&"claude-sonnet-4-5"));
+    assert!(model_ids.contains(&"claude-opus-4-7"));
+    assert!(model_ids.contains(&"claude-haiku-4-5"));
+}
+
+/// `delete_by_model` removes exactly the targeted row; sibling rows on the same
+/// endpoint survive.
+#[tokio::test]
+async fn aip_override_delete_by_model_removes_one_row() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_test_endpoint(&pool, "ep-del").await;
+
+    for (model, suffix) in [("claude-sonnet-4-5", "sonnet"), ("claude-opus-4-7", "opus")] {
+        endpoint_aip_overrides::insert(
+            &pool,
+            ep_id,
+            model,
+            &format!(
+                "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/{suffix}"
+            ),
+            "admin",
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // Delete only the sonnet override
+    endpoint_aip_overrides::delete_by_model(&pool, ep_id, "claude-sonnet-4-5")
+        .await
+        .expect("delete_by_model should succeed");
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1, "only one row should remain after deletion");
+    assert_eq!(
+        rows[0].model_id, "claude-opus-4-7",
+        "the surviving row must be opus, not sonnet"
+    );
+}
+
+/// `delete_by_model` on a non-existent `(endpoint_id, model_id)` completes
+/// without error (idempotent delete; 0 rows affected is not an error at the DB
+/// layer — the admin handler will return 404, but the CRUD function itself is Ok).
+#[tokio::test]
+async fn aip_override_delete_nonexistent_is_ok() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_test_endpoint(&pool, "ep-del-missing").await;
+
+    // No overrides have been inserted; delete of a non-existent row must not error.
+    let result = endpoint_aip_overrides::delete_by_model(&pool, ep_id, "claude-sonnet-4-5").await;
+
+    assert!(
+        result.is_ok(),
+        "delete_by_model on a missing row should return Ok, not an error"
+    );
+}
+
+/// FK CASCADE: deleting an endpoint via `delete_endpoint` removes all of its
+/// `endpoint_aip_overrides` rows automatically (ON DELETE CASCADE).
+#[tokio::test]
+async fn aip_override_fk_cascade_on_endpoint_delete() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_test_endpoint(&pool, "ep-cascade").await;
+
+    // Insert two override rows on the endpoint
+    for (model, suffix) in [("claude-sonnet-4-5", "sonnet"), ("claude-opus-4-7", "opus")] {
+        endpoint_aip_overrides::insert(
+            &pool,
+            ep_id,
+            model,
+            &format!(
+                "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/{suffix}"
+            ),
+            "admin",
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // Confirm rows exist before deletion
+    let before = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        before.len(),
+        2,
+        "should have 2 rows before endpoint deletion"
+    );
+
+    // Delete the endpoint itself
+    db::endpoints::delete_endpoint(&pool, ep_id)
+        .await
+        .expect("delete_endpoint should succeed");
+
+    // Verify the override rows were cascade-deleted
+    let after = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .unwrap();
+    assert!(
+        after.is_empty(),
+        "all endpoint_aip_overrides rows must be removed by FK CASCADE when the endpoint is deleted"
+    );
+}
+
+/// PK violation: inserting two rows with the same `(endpoint_id, model_id)` must
+/// return a sqlx database error with Postgres error code 23505.
+///
+/// This is the signal the admin handler will downcast to return HTTP 409 Conflict.
+#[tokio::test]
+async fn aip_override_pk_violation_on_duplicate() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_test_endpoint(&pool, "ep-pk-dup").await;
+
+    endpoint_aip_overrides::insert(
+        &pool,
+        ep_id,
+        "claude-sonnet-4-5",
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/first",
+        "admin",
+        None,
+    )
+    .await
+    .expect("first insert should succeed");
+
+    // Second insert with the same (endpoint_id, model_id) must fail
+    let err = endpoint_aip_overrides::insert(
+        &pool,
+        ep_id,
+        "claude-sonnet-4-5",
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/second",
+        "admin",
+        None,
+    )
+    .await
+    .expect_err("second insert with same (endpoint_id, model_id) must error");
+
+    // The error must be a Postgres unique-constraint violation (code 23505).
+    // This is the code the admin handler checks before returning 409 Conflict.
+    let db_err = err
+        .downcast_ref::<sqlx::Error>()
+        .and_then(|e| {
+            if let sqlx::Error::Database(dbe) = e {
+                Some(dbe)
+            } else {
+                None
+            }
+        })
+        .expect("error must be a sqlx::Error::Database wrapping a PG error");
+
+    assert_eq!(
+        db_err.code().as_deref(),
+        Some("23505"),
+        "PK violation must produce Postgres error code 23505 (unique_violation)"
+    );
+}
+
+/// `list_by_endpoint` on an endpoint with no overrides returns an empty vec
+/// (not an error).
+#[tokio::test]
+async fn aip_override_list_empty_for_endpoint_with_no_overrides() {
+    let pool = helpers::setup_test_db().await;
+    let ep_id = create_test_endpoint(&pool, "ep-empty").await;
+
+    let rows = endpoint_aip_overrides::list_by_endpoint(&pool, ep_id)
+        .await
+        .expect("list_by_endpoint on endpoint with no rows should succeed");
+
+    assert!(
+        rows.is_empty(),
+        "list_by_endpoint must return empty vec for an endpoint with no overrides"
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,9 +1,13 @@
 pub mod admin_tests;
+pub mod aip_compat_shim_tests;
+pub mod aip_legacy_migration_tests;
+pub mod aip_overrides_admin_tests;
 pub mod beta_overrides_admin_tests;
 pub mod beta_overrides_db_tests;
 pub mod beta_overrides_replay_tests;
 pub mod budget_tests;
 pub mod db_tests;
+pub mod endpoint_aip_overrides_tests;
 pub mod endpoint_tests;
 pub mod model_seed_tests;
 pub mod notification_tests;


### PR DESCRIPTION
## Summary

Decouples deployment target (endpoint) from routing target (per-model AIP override). Multiple Claude models can now be tagged to distinct Application Inference Profile ARNs on a single endpoint — previously each AIP-tagged model required its own endpoint with duplicated credentials, and the legacy `inference_profile_arn` column silently force-substituted *every* request through one ARN regardless of model.

Spec: `.claude/specs/aip-multi-model-routing.md` (gitignored). Builds on `feat/1m-context-support` (#83) which shipped the seed-probe / capability cache the new health-loop union flows into.

## What changes

- **New table** `endpoint_aip_overrides` mapping `(endpoint_id, model_id) → aip_arn`. Auto-migration at startup converts every endpoint with a populated legacy column and zero override rows into a single auto-migrated row (via `GetInferenceProfile` ARN-tail introspection). Legacy column kept populated for one release.
- **Health loop** now advertises `available_models` as the dedup'd union of CRI list (filtered by routing prefix) ∪ AIP-resolved foundation models. Endpoint healthy iff CRI list succeeds AND every override resolves.
- **Request path precedence chain** replaces the unconditional legacy-ARN substitution: (1) new table has the model → use that ARN; (2) new table has rows but not for this model → fall through to CRI; (3) new table empty + legacy column set → force-substitute (compat); (4) new table empty + legacy column null → pure CRI.
- **`CAPABILITY_PROBE_AIP`** env var (default `true`) gates whether seed probes run against AIP-mapped entries — opt-out for strict-attribution operators.
- **Admin REST**: `GET/POST /admin/endpoints/{id}/aip-overrides`, `DELETE /admin/endpoints/{id}/aip-overrides/{model_id}`. Compat shim on `POST /admin/endpoints` keeps old clients working with `Deprecation`/`Sunset` headers.
- **CLI**: `ccag endpoints aip-overrides {list,add,remove}`. Legacy `--inference-profile-arn` flag still works with a stderr deprecation note.
- **Portal**: routing-target radio gone from create modal; new lazy-loaded "AIP Overrides" panel on endpoint card details with add/remove inline form.
- **Docs**: `docs/endpoints.md` reframed end-to-end with worked example, migration section, behaviour-change callout. `docs/configuration.md` documents `CAPABILITY_PROBE_AIP` and synthetic-probe baseline.

## Behaviour change to call out

Previously, an endpoint with `inference_profile_arn` set forced *every* request through that ARN regardless of the requested model. After this change, only requests for the model the AIP is tagged with route through the AIP; other models route via CRI. Operators relying on the old behaviour should configure overrides for each model they want tagged. Auto-migration creates a row for the existing legacy ARN's foundation model so the *previously-tagged* model continues to behave the same; only requests for *other* models on that endpoint change.

## Test coverage

- DB CRUD: 9 tests (`tests/integration/endpoint_aip_overrides_tests.rs`)
- Auto-migration: 7 tests (`tests/integration/aip_legacy_migration_tests.rs`) — happy path, failure, idempotency, race, mixed endpoints
- Admin REST: 16 tests (`tests/integration/aip_overrides_admin_tests.rs`) — auth, 404/409/400 paths, cache-version bump
- Compat shim: 13 tests (`tests/integration/aip_compat_shim_tests.rs`) — POST/GET response shape, `Deprecation`/`Sunset` headers, infprof-fail-but-create
- Health loop union (3 tests) and dispatch precedence chain (4 snapshot tests) unit-tested in `src/endpoint/mod.rs` and `src/api/handlers.rs`

Total: 502/0 unit, 45+ AIP-specific integration tests. `cargo clippy --workspace --all-targets -- -D warnings` clean. `scripts/check-docs.sh` clean.

## Test plan

- [ ] CI passes (`make check` + `make test-integration`)
- [ ] Manual smoke against staging: load portal, create endpoint (verify no routing radio), expand card, add Sonnet + Opus AIP overrides via panel, send Sonnet then Opus requests through Claude Code, confirm both succeed and `spend_log` shows the right ARNs
- [ ] Manual smoke: send a Haiku request to the same endpoint, confirm it routes via CRI (no force-substitution)
- [ ] Manual smoke: restart the gateway with a pre-existing AIP-only endpoint (legacy column populated, new table empty) → confirm `ccag endpoints aip-overrides list <id>` shows one row with `set_by="auto-migration"` and the legacy column is still populated
- [ ] Verify `Deprecation`/`Sunset` headers on legacy `POST /admin/endpoints` calls