### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"


### PR DESCRIPTION
## Summary

Bump version to 1.9.0 to enable the prod release tag for #84 (per-endpoint per-model AIP overrides).

#83 (1m-context) shipped under 1.8.0 and the tag was pushed. #84 squash-merged into main but didn't bump because the worktree branched before #83 landed. Bumping now so `/deploy --prod --release` can tag.

## Test plan

- [ ] CI passes (`Cargo.lock` regenerated alongside the version bump)
- [ ] After merge, `/deploy --prod --release` tags v1.9.0 and deploys to prod