### PR TITLE
fix(infra): grant bedrock:GetInferenceProfile + AIP resource scope (1.9.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/infra/stack.ts
+++ b/infra/stack.ts
@@ -98,9 +98,12 @@ export class GatewayStack extends cdk.Stack {
       },
     });
 
-    // Bedrock access — need both foundation-model and inference-profile ARNs
-    // Foundation models: arn:aws:bedrock:*::foundation-model/anthropic.claude*
-    // Inference profiles: arn:aws:bedrock:*:ACCOUNT:inference-profile/*anthropic.claude*
+    // Bedrock access — need foundation-model, system inference-profile, and
+    // application-inference-profile ARNs. Application inference profiles (AIPs)
+    // are user-created profiles that wrap a system profile or foundation model
+    // and can be tagged for cost tracking. Per-model AIP overrides (v1.9.0)
+    // require InvokeModel against AIPs and GetInferenceProfile to resolve them
+    // at health-check time.
     taskDef.taskRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         actions: [
@@ -110,14 +113,19 @@ export class GatewayStack extends cdk.Stack {
         resources: [
           'arn:aws:bedrock:*::foundation-model/anthropic.claude*',
           `arn:aws:bedrock:*:${this.account}:inference-profile/*anthropic.claude*`,
+          `arn:aws:bedrock:*:${this.account}:application-inference-profile/*`,
         ],
       }),
     );
 
-    // ListInferenceProfiles requires wildcard resource (no resource-level permissions)
+    // ListInferenceProfiles + GetInferenceProfile require wildcard resource
+    // (Bedrock does not support resource-level permissions for these actions).
     taskDef.taskRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
-        actions: ['bedrock:ListInferenceProfiles'],
+        actions: [
+          'bedrock:ListInferenceProfiles',
+          'bedrock:GetInferenceProfile',
+        ],
         resources: ['*'],
       }),
     );


### PR DESCRIPTION
## Summary

PR #84 shipped per-endpoint per-model AIP overrides (v1.9.0) but the CDK task role wasn't updated to match. Caught during prod E2E smoke today: every endpoint with an AIP override marked itself unhealthy because the new health-loop union calls `bedrock:GetInferenceProfile` per override and the role can't.

## New runtime I/O

- **AWS API calls:**
  - `bedrock:GetInferenceProfile` on `*` (newly granted; required by health-loop union, auto-migration, and compat shim — was missing entirely from the deployed task role)
  - `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` against `arn:aws:bedrock:*:<account>:application-inference-profile/*` (newly granted resource scope; previously only system inference profiles were granted)
- Env vars: none new
- External network: none new (same Bedrock endpoint)
- Schema: none new
- Background loops: existing health-loop now exercises the new permissions per-tick; no new cadence
- Dependencies: none new

`docs/endpoints.md` already lists `bedrock:GetInferenceProfile` in the required-permissions table from PR #84 — the public docs were correct, the CDK was the gap.

## Two gaps fixed

1. **`bedrock:GetInferenceProfile` was missing.** Required by:
   - Health-loop union (Slice 2A) — resolves every AIP override per endpoint per tick
   - Auto-migration on startup (Slice 1B) — introspects legacy `inference_profile_arn` to derive foundation model
   - Compat shim on `POST /admin/endpoints` (Slice 3B) — same flow

2. **`InvokeModel*` resource scope didn't include AIPs.** Was scoped to `inference-profile/*anthropic.claude*` (system profiles only). Added `application-inference-profile/*`.

## Test plan

**Offline (mocks / CI):**
- [x] CDK app synthesises clean (`npx ts-node app.ts`)
- [x] `cargo check --workspace` clean (Cargo.lock regenerated for 1.9.1 bump)
- [x] CI green (build, lint, unit, integration, frontend, load smoke, security audit, supply chain)

**Online (deployed environment, evidence captured):**

These are the verifications that would have caught the original v1.9.0 gap and motivated the new release-evidence-gate discipline. Capture during staging deploy:

- [ ] **Default endpoint stays `healthy` after an AIP override is added** — evidence: `/admin/endpoints/{id}` returns `health: "healthy"` after the next health-loop tick (not `unhealthy`); CloudWatch logs contain no `AccessDeniedException` for `GetInferenceProfile` against the AIP ARN.
- [ ] **Sonnet request dispatches via the AIP ARN, not the CRI form** — evidence: `Forwarding request to Bedrock` log line shows `bedrock_model = arn:aws:bedrock:us-east-1:<account>:application-inference-profile/<id>` (not `<prefix>.anthropic.claude-sonnet-4-5-...`).
- [ ] **Auto-migration row stays after restart** — evidence: `ccag endpoints aip-overrides list <id>` shows the row with `set_by="auto-migration"` after a fresh task rotation.

## Sequencing

Patch release (1.9.0 → 1.9.1) since this is a bug fix that unblocks the v1.9.0 feature. No semver-breaking changes. Staging evidence captured in `.claude/deploys/<sha>-evidence.md` before prod release per the new evidence gate.