### PR TITLE
fix(oidc): resolve team_id from user record and gate inactive accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -497,6 +497,26 @@ pub async fn messages(
         Err(resp) => return resp,
     };
 
+    // Hoisted OIDC user lookup: a single get_user_by_email call drives both
+    // the inactive-user gate and the team_id resolution below. For virtual
+    // keys this stays None and the lookup is skipped entirely.
+    let oidc_user = match &auth_result {
+        AuthResult::Oidc(id) => {
+            crate::db::users::get_user_by_email(&state.db().await, id.user_id())
+                .await
+                .ok()
+                .flatten()
+        }
+        AuthResult::VirtualKey(_) => None,
+    };
+
+    // Inactive-user gate: an OIDC user whose row is `active=false` is rejected
+    // BEFORE budget/rate-limit/endpoint resolution. Mirrors the portal-side
+    // check in `resolve_oidc_role`.
+    if let Some(resp) = crate::api::oidc_resolution::oidc_inactive_response(oidc_user.as_ref()) {
+        return resp;
+    }
+
     // Extract identity for spend tracking
     let identity = match &auth_result {
         AuthResult::VirtualKey(k) => AuthIdentity {
@@ -504,18 +524,11 @@ pub async fn messages(
             user_identity: k.user_email.clone().or_else(|| k.name.clone()),
             user_id: k.user_id,
         },
-        AuthResult::Oidc(id) => {
-            let user_id = crate::db::users::get_user_by_email(&state.db().await, id.user_id())
-                .await
-                .ok()
-                .flatten()
-                .map(|u| u.id);
-            AuthIdentity {
-                key_id: None,
-                user_identity: Some(id.user_id().to_string()),
-                user_id,
-            }
-        }
+        AuthResult::Oidc(id) => AuthIdentity {
+            key_id: None,
+            user_identity: Some(id.user_id().to_string()),
+            user_id: oidc_user.as_ref().map(|u| u.id),
+        },
     };
 
     // Resolve budget identity: OIDC email, or virtual key's assigned user email
@@ -590,7 +603,9 @@ pub async fn messages(
     // Resolve endpoint for this request
     let team_id = match &auth_result {
         AuthResult::VirtualKey(k) => k.team_id,
-        AuthResult::Oidc(_) => None, // TODO: resolve team from user's DB record
+        AuthResult::Oidc(_) => {
+            crate::api::oidc_resolution::resolve_oidc_team_id(oidc_user.as_ref())
+        }
     };
     let (team_endpoints, routing_strategy) = if let Some(tid) = team_id {
         let pool = state.db().await;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,7 @@ pub mod cli_auth;
 mod handlers;
 #[cfg(feature = "mock-bedrock")]
 pub mod mock_bedrock;
+pub mod oidc_resolution;
 
 use std::sync::Arc;
 

--- a/src/api/oidc_resolution.rs
+++ b/src/api/oidc_resolution.rs
@@ -1,0 +1,119 @@
+//! Pure helpers for resolving OIDC requests' team membership and gating
+//! inactive accounts at the `/v1/messages` boundary.
+//!
+//! Spec: `.claude/specs/oidc-team-resolution.md`
+//!
+//! These helpers operate on the already-fetched `users` row that the
+//! `messages` handler hoists out of the OIDC arm — no DB round-trips here.
+
+use axum::{
+    body::Body,
+    http::{Response, StatusCode},
+};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::db::schema::User;
+
+/// Resolve the `team_id` for an OIDC-authenticated user.
+///
+/// Returns the user's `team_id` when a row was found, otherwise `None`.
+/// Pure function — no I/O. The caller must perform the single
+/// `get_user_by_email` lookup up front and pass the result here.
+pub fn resolve_oidc_team_id(user: Option<&User>) -> Option<Uuid> {
+    user.and_then(|u| u.team_id)
+}
+
+/// If the OIDC user has been deactivated (`active=false`), return a ready-to-send
+/// 403 response. Otherwise return `None` so the caller proceeds with normal
+/// dispatch.
+///
+/// Body shape mirrors `error_response` in `handlers.rs`:
+///   { "type": "error", "error": { "type": "permission_error", "message": "..." } }
+///
+/// Message exactly matches the portal-side gate in `resolve_oidc_role`
+/// (`handlers.rs:457-459`): "Your account has been deactivated".
+pub fn oidc_inactive_response(user: Option<&User>) -> Option<Response<Body>> {
+    if user.is_some_and(|u| !u.active) {
+        let request_id = format!("req_{}", Uuid::new_v4().simple());
+        let body = serde_json::to_string(&json!({
+            "type": "error",
+            "error": {
+                "type": "permission_error",
+                "message": "Your account has been deactivated"
+            }
+        }))
+        .expect("static JSON serialization is infallible");
+        Some(
+            Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .header("content-type", "application/json")
+                .header("x-request-id", &request_id)
+                .body(Body::from(body))
+                .expect("response builder inputs are valid"),
+        )
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn user(team_id: Option<Uuid>, active: bool) -> User {
+        User {
+            id: Uuid::new_v4(),
+            email: "u@test.com".to_string(),
+            team_id,
+            role: "member".to_string(),
+            spend_limit_monthly_usd: None,
+            budget_period: "monthly".to_string(),
+            created_at: Utc::now(),
+            active,
+            external_id: None,
+            display_name: None,
+            given_name: None,
+            family_name: None,
+            scim_managed: false,
+            idp_id: None,
+        }
+    }
+
+    #[test]
+    fn resolves_team_when_set() {
+        let team_id = Uuid::new_v4();
+        let u = user(Some(team_id), true);
+        assert_eq!(resolve_oidc_team_id(Some(&u)), Some(team_id));
+    }
+
+    #[test]
+    fn resolves_none_when_no_team() {
+        let u = user(None, true);
+        assert_eq!(resolve_oidc_team_id(Some(&u)), None);
+    }
+
+    #[test]
+    fn resolves_none_when_no_user() {
+        assert_eq!(resolve_oidc_team_id(None), None);
+    }
+
+    #[test]
+    fn inactive_user_yields_403() {
+        let u = user(None, false);
+        let resp = oidc_inactive_response(Some(&u)).expect("inactive yields response");
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn active_user_yields_none() {
+        let u = user(None, true);
+        assert!(oidc_inactive_response(Some(&u)).is_none());
+    }
+
+    #[test]
+    fn missing_user_yields_none() {
+        assert!(oidc_inactive_response(None).is_none());
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -11,6 +11,7 @@ pub mod endpoint_aip_overrides_tests;
 pub mod endpoint_tests;
 pub mod model_seed_tests;
 pub mod notification_tests;
+pub mod oidc_team_resolution_tests;
 pub mod pricing_api_tests;
 pub mod pricing_csv_tests;
 pub mod pricing_tests;

--- a/tests/integration/oidc_team_resolution_tests.rs
+++ b/tests/integration/oidc_team_resolution_tests.rs
@@ -1,0 +1,366 @@
+//! Tests for OIDC team_id resolution and inactive-user gate at /v1/messages.
+//!
+//! Spec: `.claude/specs/oidc-team-resolution.md`
+//! Tasks: `.claude/specs/oidc-team-resolution-tasks.md`
+//!
+//! These tests target two helpers that the Builder Agent must extract from
+//! `src/api/handlers.rs::messages`:
+//!
+//! - `resolve_oidc_team_id(user: Option<&User>) -> Option<Uuid>`
+//! - `oidc_inactive_response(user: Option<&User>) -> Option<Response>`
+//!
+//! Both are expected to live in a new `pub mod oidc_resolution` under
+//! `src/api/`, exported via `crate::api::oidc_resolution`.
+
+use axum::http::StatusCode;
+use ccag::api::oidc_resolution::{oidc_inactive_response, resolve_oidc_team_id};
+use ccag::db;
+use ccag::db::schema::User;
+use serde_json::Value;
+
+use crate::helpers;
+
+// ============================================================
+// AC1.1 — resolve_oidc_team_id: pure helper unit tests
+// ============================================================
+
+/// AC1.1: A user row with `team_id=Some(T)` resolves to `Some(T)`.
+#[tokio::test]
+async fn resolve_oidc_team_id_returns_team_when_user_has_team() {
+    let pool = helpers::setup_test_db().await;
+
+    let team = helpers::create_test_team(&pool, "ac11-team").await;
+    let user = helpers::create_test_user(&pool, "ac11@test.com", Some(team.id), "member").await;
+
+    assert_eq!(user.team_id, Some(team.id));
+    assert_eq!(resolve_oidc_team_id(Some(&user)), Some(team.id));
+}
+
+/// AC1.1: A user row with `team_id=None` resolves to `None`.
+#[tokio::test]
+async fn resolve_oidc_team_id_returns_none_when_user_has_no_team() {
+    let pool = helpers::setup_test_db().await;
+
+    let user = helpers::create_test_user(&pool, "ac11-noteam@test.com", None, "member").await;
+
+    assert_eq!(user.team_id, None);
+    assert_eq!(resolve_oidc_team_id(Some(&user)), None);
+}
+
+/// AC1.1: An absent user row (`None`) resolves to `None`.
+#[tokio::test]
+async fn resolve_oidc_team_id_returns_none_when_no_user_row() {
+    // No DB needed — pure function.
+    let no_user: Option<&User> = None;
+    assert_eq!(resolve_oidc_team_id(no_user), None);
+}
+
+// ============================================================
+// AC1.2 — OIDC user with team_id=Some(T) routes to T's endpoint
+// ============================================================
+
+/// AC1.2: When the resolver yields `Some(T)`, `get_team_endpoints(T)` returns
+/// the endpoint bound to that team — proving the team→endpoint pipeline that
+/// the handler will plug the resolver into actually selects T's endpoint
+/// rather than the pool default.
+#[tokio::test]
+async fn oidc_user_with_team_routes_via_team_endpoint() {
+    let pool = helpers::setup_test_db().await;
+
+    // Two endpoints: one bound to the team, another marked as the pool default.
+    let team_ep =
+        db::endpoints::create_endpoint(&pool, "team-ep", None, None, None, "us-east-1", "us", 0)
+            .await
+            .unwrap();
+    let default_ep = db::endpoints::create_endpoint(
+        &pool,
+        "pool-default-ep",
+        None,
+        None,
+        None,
+        "us-west-2",
+        "us",
+        0,
+    )
+    .await
+    .unwrap();
+    db::endpoints::set_default_endpoint(&pool, default_ep.id)
+        .await
+        .unwrap();
+
+    // Bind team_ep to the team (priority 0).
+    let team = helpers::create_test_team(&pool, "ac12-team").await;
+    db::endpoints::set_team_endpoints(&pool, team.id, &[(team_ep.id, 0)])
+        .await
+        .unwrap();
+
+    // OIDC user belongs to team T.
+    let user =
+        helpers::create_test_user(&pool, "ac12-user@test.com", Some(team.id), "member").await;
+
+    // Resolver picks Some(T).
+    let resolved = resolve_oidc_team_id(Some(&user));
+    assert_eq!(resolved, Some(team.id));
+
+    // The team→endpoint pipeline yields team_ep (NOT default_ep).
+    let team_id = resolved.expect("resolver returned None for team-bound user");
+    let endpoints = db::endpoints::get_team_endpoints(&pool, team_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        endpoints.len(),
+        1,
+        "expected exactly one team-bound endpoint"
+    );
+    assert_eq!(endpoints[0].id, team_ep.id);
+    assert_ne!(
+        endpoints[0].id, default_ep.id,
+        "OIDC team-routed request must not fall through to the pool default"
+    );
+}
+
+// ============================================================
+// AC1.3 — OIDC user without team falls through to pool default
+// ============================================================
+
+/// AC1.3: When the resolver yields `None`, the team-endpoints lookup is
+/// skipped (handler builds an empty `team_endpoints` Vec) and `select_endpoint`
+/// falls through to the pool default — same as pre-fix behavior.
+#[tokio::test]
+async fn oidc_user_without_team_falls_through_to_pool_default() {
+    let pool = helpers::setup_test_db().await;
+
+    // A pool-default endpoint exists.
+    let default_ep = db::endpoints::create_endpoint(
+        &pool,
+        "pool-default-ep",
+        None,
+        None,
+        None,
+        "us-east-1",
+        "us",
+        0,
+    )
+    .await
+    .unwrap();
+    db::endpoints::set_default_endpoint(&pool, default_ep.id)
+        .await
+        .unwrap();
+
+    // OIDC user with NO team membership.
+    let user = helpers::create_test_user(&pool, "ac13-user@test.com", None, "member").await;
+
+    // Resolver yields None.
+    assert_eq!(resolve_oidc_team_id(Some(&user)), None);
+
+    // Pool default is configured and would be selected by the handler
+    // via `select_endpoint(&[], …)` empty-list branch.
+    let pool_default = db::endpoints::get_default_endpoint(&pool).await.unwrap();
+    assert!(
+        pool_default.is_some(),
+        "pool default endpoint should be set"
+    );
+    assert_eq!(pool_default.unwrap().id, default_ep.id);
+}
+
+/// AC1.3 (no-row variant): an OIDC identity for an email with no users-row
+/// resolves to `None` exactly like the team_id=None case. Mirrors the
+/// behavior matrix row "OIDC + no users row at all".
+#[tokio::test]
+async fn oidc_user_with_no_db_row_resolves_to_none() {
+    let pool = helpers::setup_test_db().await;
+
+    // Look up an email that was never provisioned.
+    let row = db::users::get_user_by_email(&pool, "never-seen@test.com")
+        .await
+        .unwrap();
+    assert!(row.is_none());
+
+    assert_eq!(resolve_oidc_team_id(row.as_ref()), None);
+}
+
+// ============================================================
+// AC2.1 — Inactive OIDC user produces 403 with exact body
+// ============================================================
+
+/// AC2.1: An OIDC user with `active=false` must be rejected with HTTP 403
+/// and a JSON body whose `error` object matches the spec exactly:
+/// `{"type":"permission_error","message":"Your account has been deactivated"}`.
+#[tokio::test]
+async fn inactive_oidc_user_returns_403_with_deactivated_message() {
+    let pool = helpers::setup_test_db().await;
+
+    let user = helpers::create_test_user(&pool, "ac21-inactive@test.com", None, "member").await;
+
+    // Mark inactive (helpers::create_test_user defaults to active=true).
+    sqlx::query("UPDATE users SET active = false WHERE id = $1")
+        .bind(user.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let inactive = db::users::get_user_by_email(&pool, "ac21-inactive@test.com")
+        .await
+        .unwrap()
+        .expect("user row should exist");
+    assert!(!inactive.active, "test setup: user must be inactive");
+
+    let resp =
+        oidc_inactive_response(Some(&inactive)).expect("inactive user must produce a 403 Response");
+
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v: &axum::http::HeaderValue| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        ct.starts_with("application/json"),
+        "expected JSON content-type, got {ct:?}"
+    );
+
+    let bytes = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let v: Value = serde_json::from_slice(&bytes).expect("response body must be JSON");
+    let err = v
+        .get("error")
+        .expect("response body must contain top-level `error` object");
+    assert_eq!(
+        err.get("type").and_then(Value::as_str),
+        Some("permission_error")
+    );
+    assert_eq!(
+        err.get("message").and_then(Value::as_str),
+        Some("Your account has been deactivated")
+    );
+}
+
+/// AC2.1 (negative): an active user yields `None` (helper does not fire), and
+/// an absent user (None) also yields `None` so unprovisioned identities fall
+/// through to the existing logic rather than getting a spurious 403.
+#[tokio::test]
+async fn active_or_missing_user_does_not_trigger_inactive_response() {
+    let pool = helpers::setup_test_db().await;
+
+    let active_user =
+        helpers::create_test_user(&pool, "ac21-active@test.com", None, "member").await;
+    assert!(active_user.active);
+
+    assert!(oidc_inactive_response(Some(&active_user)).is_none());
+    assert!(oidc_inactive_response(None).is_none());
+}
+
+// ============================================================
+// AC2.2 — Inactive check fires BEFORE team_id resolution
+// ============================================================
+
+/// AC2.2: A user row with `(active=false, team_id=Some(T))` produces the 403
+/// from `oidc_inactive_response`. The handler must invoke the inactive check
+/// before `resolve_oidc_team_id`, so the team-bound endpoint is never
+/// reached. We assert the documented call ordering by checking that the
+/// inactive helper still fires (returns Some) on a row that ALSO has a
+/// team — and we exercise both helpers in the prescribed order:
+///   1. oidc_inactive_response(user)  ->  Some(403) (short-circuit)
+///   2. resolve_oidc_team_id(user)   (only reached if step 1 was None)
+#[tokio::test]
+async fn inactive_user_with_team_short_circuits_before_team_resolution() {
+    let pool = helpers::setup_test_db().await;
+
+    let team = helpers::create_test_team(&pool, "ac22-team").await;
+    let team_ep = db::endpoints::create_endpoint(
+        &pool,
+        "ac22-team-ep",
+        None,
+        None,
+        None,
+        "us-east-1",
+        "us",
+        0,
+    )
+    .await
+    .unwrap();
+    db::endpoints::set_team_endpoints(&pool, team.id, &[(team_ep.id, 0)])
+        .await
+        .unwrap();
+
+    let user =
+        helpers::create_test_user(&pool, "ac22-inactive@test.com", Some(team.id), "member").await;
+    sqlx::query("UPDATE users SET active = false WHERE id = $1")
+        .bind(user.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let inactive = db::users::get_user_by_email(&pool, "ac22-inactive@test.com")
+        .await
+        .unwrap()
+        .expect("user row must exist");
+    assert!(!inactive.active);
+    assert_eq!(inactive.team_id, Some(team.id));
+
+    // Step 1 — inactive check MUST fire even though team_id is Some.
+    let resp = oidc_inactive_response(Some(&inactive))
+        .expect("inactive user with a team must still produce a 403");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    // Step 2 (would-be reached only on active users): if the handler ever
+    // got here, it would route to T's endpoint. We document the contract:
+    // the inactive 403 short-circuits before this happens.
+    //
+    // If a future refactor accidentally inverts the order, the assertion
+    // above would still pass — but the production handler test (manual
+    // diff inspection per AC1.5 / AC2.2) is the structural guarantee.
+    // Here we additionally verify that the team-routing path WOULD have
+    // chosen T's endpoint (so any downstream regression that swallows the
+    // inactive check would be observable as a routed request to team_ep).
+    let endpoints = db::endpoints::get_team_endpoints(&pool, team.id)
+        .await
+        .unwrap();
+    assert_eq!(endpoints.len(), 1);
+    assert_eq!(endpoints[0].id, team_ep.id);
+}
+
+// ============================================================
+// AC0.2 — Virtual-key path is structurally unchanged
+// ============================================================
+
+/// AC0.2: A virtual key with `team_id=Some(T)` continues to carry the team
+/// id, and `get_team_endpoints(T)` continues to return T's bound endpoint.
+/// The smoke test in `tests/integration_tests.rs` covers key creation; this
+/// test additionally ties it through to endpoint binding so the virtual-key
+/// arm of the handler's team_id resolution stays observably correct.
+#[tokio::test]
+async fn virtual_key_with_team_still_routes_via_team_endpoint() {
+    let pool = helpers::setup_test_db().await;
+
+    let team = helpers::create_test_team(&pool, "ac02-team").await;
+    let team_ep = db::endpoints::create_endpoint(
+        &pool,
+        "ac02-team-ep",
+        None,
+        None,
+        None,
+        "us-east-1",
+        "us",
+        0,
+    )
+    .await
+    .unwrap();
+    db::endpoints::set_team_endpoints(&pool, team.id, &[(team_ep.id, 0)])
+        .await
+        .unwrap();
+
+    let user =
+        helpers::create_test_user(&pool, "ac02-user@test.com", Some(team.id), "member").await;
+    let (_raw, key) =
+        helpers::create_test_key(&pool, Some("ac02-key"), Some(user.id), Some(team.id)).await;
+
+    assert_eq!(key.team_id, Some(team.id));
+
+    let endpoints = db::endpoints::get_team_endpoints(&pool, team.id)
+        .await
+        .unwrap();
+    assert_eq!(endpoints.len(), 1);
+    assert_eq!(endpoints[0].id, team_ep.id);
+}


### PR DESCRIPTION
## Summary

OIDC requests previously hardcoded `team_id = None` at `handlers.rs:592-595`, so team→endpoint bindings only ever applied to virtual-key traffic. Customer symptom: AIP overrides bound to a team-scoped endpoint never fired for OIDC users — they fell through to the gateway-default Bedrock client where AIP overrides cannot be consulted.

This PR hoists the existing `get_user_by_email` call out of the `AuthIdentity` construction block and reuses the same row to drive three consumers: `AuthIdentity.user_id`, an inactive-user gate (returns 403 before any endpoint resolution), and `team_id` resolution. **Zero net-new DB round-trips on the hot path.**

- New `src/api/oidc_resolution.rs` — pure helpers `resolve_oidc_team_id` + `oidc_inactive_response` (6 unit tests).
- Inactive-user gate mirrors the literal message from `resolve_oidc_role` (`handlers.rs:457-459`): `"Your account has been deactivated"`.
- Closes the routing bug for OIDC users in teams; closes the security gap where deactivated OIDC users could still hit `/v1/messages`.

Spec: `.claude/specs/oidc-team-resolution.md`
Tasks: `.claude/specs/oidc-team-resolution-tasks.md`

## New runtime I/O

**None.** Reuses the existing `get_user_by_email` call. No AWS API calls, no env vars, no schema changes, no background loops, no network reach.

## Test plan

- [x] 6 unit tests in `src/api/oidc_resolution.rs` (helper logic).
- [x] 10 integration tests in `tests/integration/oidc_team_resolution_tests.rs` covering AC1.1, AC1.2, AC1.3, AC2.1, AC2.2, AC0.2.
- [x] `make check` (508 unit + 297 integration) — green locally.
- [ ] AC1.4 `[env]`: at staging, OIDC user `u` in team `T` (with endpoint `E` bound to `T` carrying AIP override for `claude-sonnet-4-6`) sends a sonnet request; log line `Forwarding request to Bedrock` shows `endpoint: Some(<E.id>)` AND `bedrock_model: arn:aws:bedrock:…:application-inference-profile/…`. Captured in `.claude/deploys/<sha>-evidence.md` per Release Evidence Gate.
- [ ] AC2.3 `[env]`: at staging, deactivate an OIDC user via `PATCH /admin/users/<id>` with `active=false`; `/v1/messages` with their token returns 403; an active virtual key for the same human (if any) continues to work.

## Version

Bumped to `1.9.2` (patch — bug fix).