### PR TITLE
feat: advertise claude-fable-5 with canonical id (1.9.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.9.2"
+version = "1.9.3"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.9.2"
+version = "1.9.3"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/src/translate/models.rs
+++ b/src/translate/models.rs
@@ -330,6 +330,7 @@ pub fn anthropic_to_bedrock(model: &str, prefix: &str, model_cache: Option<&Mode
 /// Hardcoded forward mapping (no-DB fallback).
 fn hardcoded_anthropic_to_bedrock(model: &str, prefix: &str) -> String {
     match model {
+        "claude-fable-5" => format!("{prefix}.anthropic.claude-fable-5"),
         "claude-opus-4-7" => format!("{prefix}.anthropic.claude-opus-4-7"),
         "claude-opus-4-6" | "claude-opus-4-6-20250605" => {
             format!("{prefix}.anthropic.claude-opus-4-6-v1")
@@ -401,6 +402,7 @@ pub fn bedrock_to_anthropic(model: &str, model_cache: Option<&ModelCache>) -> St
 /// Hardcoded reverse mapping (no-DB fallback).
 fn hardcoded_bedrock_to_anthropic(model: &str) -> String {
     match model {
+        s if s.contains("claude-fable-5") => "claude-fable-5".to_string(),
         s if s.contains("claude-opus-4-7") => "claude-opus-4-7".to_string(),
         s if s.contains("claude-opus-4-6") => "claude-opus-4-6-20250605".to_string(),
         s if s.contains("claude-sonnet-4-6") => "claude-sonnet-4-6-20250514".to_string(),
@@ -1173,17 +1175,55 @@ mod tests {
             "profile_prefix fallback: entire string when no dot found"
         );
     }
+
+    // ── Fable 5 forward mapping ───────────────────────────────────────────────
+
+    /// `claude-fable-5` with the `global` prefix must map to
+    /// `global.anthropic.claude-fable-5`.
+    #[test]
+    fn test_model_mapping_fable_5_global() {
+        assert_eq!(
+            anthropic_to_bedrock("claude-fable-5", "global", None),
+            "global.anthropic.claude-fable-5"
+        );
+    }
+
+    /// Forward mapping for `claude-fable-5` with `us`, `au`, `apac`, `eu` prefixes.
+    #[test]
+    fn test_model_mapping_fable_5_all_prefixes() {
+        assert_eq!(
+            anthropic_to_bedrock("claude-fable-5", "us", None),
+            "us.anthropic.claude-fable-5"
+        );
+        assert_eq!(
+            anthropic_to_bedrock("claude-fable-5", "au", None),
+            "au.anthropic.claude-fable-5"
+        );
+        assert_eq!(
+            anthropic_to_bedrock("claude-fable-5", "apac", None),
+            "apac.anthropic.claude-fable-5"
+        );
+        assert_eq!(
+            anthropic_to_bedrock("claude-fable-5", "eu", None),
+            "eu.anthropic.claude-fable-5"
+        );
+    }
+
+    /// Reverse mapping: any prefixed Bedrock ID for fable-5 maps back to `"claude-fable-5"`.
+    #[test]
+    fn test_bedrock_to_anthropic_fable_5_all_prefixes() {
+        for prefix in &["us", "au", "apac", "eu", "global"] {
+            let bedrock_id = format!("{}.anthropic.claude-fable-5", prefix);
+            assert_eq!(
+                bedrock_to_anthropic(&bedrock_id, None),
+                "claude-fable-5",
+                "prefix '{}' must reverse-map to 'claude-fable-5'",
+                prefix
+            );
+        }
+    }
 }
 
-/// Task 4 — Generic `[\w+]` suffix stripping in `anthropic_to_bedrock`.
-///
-/// The function must strip a trailing `[\w+]` (regex `\[\w+\]$`) from the
-/// model ID before all other logic (dot-passthrough check, cache lookup,
-/// hardcoded match, discovery fallback).
-///
-/// The suffix is silently discarded — it is not used to inject betas.
-/// That remains the responsibility of the client (CC sends the beta header;
-/// the gateway forwards it via the Slice 3 mechanism).
 #[cfg(test)]
 mod tests_t4_suffix_strip {
     use super::*;
@@ -1475,6 +1515,42 @@ mod tests_task2_arn_parser {
         assert!(
             result.is_err(),
             "Truncated ARN (no '/' after resource type) must return Err; got {result:?}"
+        );
+    }
+
+    // ── Fable 5 ARN tests ─────────────────────────────────────────────────────
+
+    /// Well-formed foundation-model ARN (Fable 5) returns the tail.
+    /// Mirror of `test_parse_foundation_model_from_arn_haiku_4_5`.
+    #[test]
+    fn test_parse_foundation_model_from_arn_fable_5() {
+        let arn =
+            "arn:aws:bedrock:ap-southeast-2:123456789012:foundation-model/anthropic.claude-fable-5";
+        let result = parse_foundation_model_from_arn(arn);
+        assert!(
+            result.is_ok(),
+            "fable-5 ARN must parse successfully; got {result:?}"
+        );
+        assert_eq!(
+            result.unwrap(),
+            "anthropic.claude-fable-5",
+            "returned tail must be the foundation-model id exactly as it appears in the ARN"
+        );
+    }
+
+    /// Parse a Fable 5 ARN and map the tail through `bedrock_to_anthropic`.
+    /// Mirror of `test_arn_to_anthropic_model_haiku_4_5`.
+    #[test]
+    fn test_arn_to_anthropic_model_fable_5() {
+        let arn =
+            "arn:aws:bedrock:ap-southeast-2:123456789012:foundation-model/anthropic.claude-fable-5";
+        let tail = parse_foundation_model_from_arn(arn)
+            .expect("parse must succeed for this well-formed ARN");
+
+        let anthropic_name = bedrock_to_anthropic(tail, None);
+        assert_eq!(
+            anthropic_name, "claude-fable-5",
+            "tail of a Fable 5 ARN must map to 'claude-fable-5' via bedrock_to_anthropic"
         );
     }
 }

--- a/src/translate/response.rs
+++ b/src/translate/response.rs
@@ -63,4 +63,29 @@ mod tests {
         assert_eq!(usage["cache_read_input_tokens"], 0);
         assert_eq!(normalized["model"], "claude-sonnet-4-6-20250514");
     }
+
+    /// Regression lock: `stop_reason: "refusal"` on a Bedrock HTTP-200 response
+    /// must pass through `normalize_response` unchanged. Fable 5 can return this
+    /// stop reason; the gateway must not rewrite or drop it.
+    #[test]
+    fn test_stop_reason_refusal_passthrough() {
+        let resp = json!({
+            "id": "msg_456",
+            "type": "message",
+            "role": "assistant",
+            "content": [],
+            "model": "global.anthropic.claude-fable-5",
+            "stop_reason": "refusal",
+            "usage": {
+                "input_tokens": 8,
+                "output_tokens": 0
+            }
+        });
+
+        let normalized = normalize_response(resp, "claude-fable-5", None);
+        assert_eq!(
+            normalized["stop_reason"], "refusal",
+            "stop_reason 'refusal' must survive normalize_response unchanged"
+        );
+    }
 }

--- a/src/translate/streaming.rs
+++ b/src/translate/streaming.rs
@@ -101,4 +101,28 @@ mod tests {
             0
         );
     }
+
+    /// Regression lock: a `message_delta` SSE event with `delta.stop_reason: "refusal"`
+    /// must pass through `normalize_stream_event` with the field intact. Fable 5
+    /// can emit this stop reason over streaming; the gateway must not rewrite or drop it.
+    #[test]
+    fn test_stream_message_delta_refusal_stop_reason() {
+        let event = json!({
+            "type": "message_delta",
+            "delta": {
+                "type": "message_delta",
+                "stop_reason": "refusal",
+                "stop_sequence": null
+            },
+            "usage": {
+                "output_tokens": 0
+            }
+        });
+
+        let normalized = normalize_stream_event(event, "claude-fable-5", None);
+        assert_eq!(
+            normalized["delta"]["stop_reason"], "refusal",
+            "stop_reason 'refusal' in message_delta must survive normalize_stream_event unchanged"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add hardcoded forward + reverse mapping arms for `claude-fable-5` in `src/translate/models.rs`. Mirrors the `claude-opus-4-7` shape (dateless id, no `-vN:0` suffix per the new dateless model-id convention).
- Lock in regression tests for Fable 5's new `stop_reason: "refusal"` (HTTP 200 success value) in both Messages responses and SSE `message_delta` events. The current passthrough behavior is already correct; the tests prevent future drift.
- Bump 1.9.2 → 1.9.3 (additive patch — no behavior change for existing models).

## Why

Anthropic released Claude Fable 5 (`claude-fable-5`) on 2026-06-09. AWS published `global.anthropic.claude-fable-5` as a system inference profile, and our auto-discovery already routes requests correctly via the 3-pass exact-stem selection in `discover_model`. **However**, `bedrock_to_anthropic` had no arm for fable, so:

- `/v1/models` was advertising `global.anthropic.claude-fable-5` (raw bedrock id) instead of canonical `claude-fable-5` — confirmed live on staging and prod before this PR.
- The `response.model` field echoed the raw bedrock id back to Claude Code.

This PR closes that normalization gap. No production code outside the two new match arms changes.

Foundation-model authorization is already in place in both staging (`021721386746`) and prod (`935934578497`) — `bedrock get-foundation-model-availability` returns `authorizationStatus: AUTHORIZED` for `anthropic.claude-fable-5` in `ap-southeast-2`. No Bedrock console opt-in or data-retention contract action required: per Anthropic docs, the 30-day-retention "Covered Model" rule applies to the Claude API only, not to Bedrock invocations.

## New runtime I/O

**None.** Pure mapping change. The new model id resolves through the same `bedrock:InvokeModel` / `bedrock:ListInferenceProfiles` calls already covered by the wildcard `*anthropic.claude*` resource pattern in `infra/stack.ts:107-130`. No new env vars, no new AWS API actions, no schema migrations, no new background loops.

## Test plan

### Offline (locked in this PR)

- [x] `SQLX_OFFLINE=true cargo test --lib translate` — 95 pass, 0 fail
- [x] `make check` — 297 pass, 0 fail (lib + integration + check-docs)
- [x] New tests:
  - `translate::models::tests::test_model_mapping_fable_5_global`
  - `translate::models::tests::test_model_mapping_fable_5_all_prefixes` (us / au / apac / eu)
  - `translate::models::tests::test_bedrock_to_anthropic_fable_5_all_prefixes`
  - `translate::models::tests_task2_arn_parser::test_parse_foundation_model_from_arn_fable_5`
  - `translate::models::tests_task2_arn_parser::test_arn_to_anthropic_model_fable_5`
  - `translate::response::tests::test_stop_reason_refusal_passthrough`
  - `translate::streaming::tests::test_stream_message_delta_refusal_stop_reason`

### Online (post-deploy evidence)

After `/deploy --staging`:

- [ ] `curl … /v1/messages -d '{"model":"claude-fable-5",...}'` returns HTTP 200 with `response.model == "claude-fable-5"`.
- [ ] Staging `/v1/models` includes canonical `claude-fable-5` and no longer lists raw `global.anthropic.claude-fable-5`.
- [ ] CloudWatch log line shows `Forwarding request to Bedrock` with `bedrock_model = global.anthropic.claude-fable-5`.

Evidence captured to `.claude/deploys/<sha>-evidence.md` before `/deploy --prod --release`.

## Non-goals

- Mythos 5 mappings — Glasswing-only, deferred until access lands.
- Auto-discovery code changes — `discover_model` and the cache-miss path already handle Fable 5; no touch.
- IAM updates — wildcard `*anthropic.claude*` already covers the new id.
- `SUFFIX_BETA_MAP` entries — Fable 5 has 1M context by default; no `[1m]` beta needed.