### PR TITLE
fix(pricing): skip AWS metadata preamble in price list CSV

### DIFF
--- a/src/pricing/mod.rs
+++ b/src/pricing/mod.rs
@@ -26,6 +26,37 @@ pub fn normalize_service_name(service_name: &str) -> String {
 // CSV parser
 // ---------------------------------------------------------------------------
 
+/// Drop the metadata preamble that AWS prepends to every price list CSV.
+///
+/// A price list file downloaded from `GetPriceListFileUrl` starts with five
+/// two-column metadata rows before the real 17-column header:
+///
+/// ```text
+/// "FormatVersion","v1.0"
+/// "Disclaimer","This pricing list is for informational purposes only..."
+/// "Publication Date","2026-07-03T08:58:57Z"
+/// "Version","20260703085857"
+/// "OfferCode","AmazonBedrockFoundationModels"
+/// "SKU","OfferTermCode",...          <-- header starts here
+/// ```
+///
+/// Handing the raw text to a `has_headers(true)` reader makes the csv crate
+/// treat `"FormatVersion","v1.0"` as a two-field header, after which *every*
+/// 17-field data row fails the equal-length check and is discarded. Returns
+/// the slice beginning at the header row, or the input unchanged when no
+/// header is found (the caller then parses zero rows, as before).
+fn strip_preamble(csv: &str) -> &str {
+    let mut offset = 0;
+    for line in csv.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("\"SKU\"") || trimmed.starts_with("SKU,") {
+            return &csv[offset..];
+        }
+        offset += line.len();
+    }
+    csv
+}
+
 /// Intermediate accumulator while parsing rows for a single service/model.
 #[derive(Debug, Default)]
 struct ModelAccumulator {
@@ -71,6 +102,9 @@ fn classify_description(price_description: &str) -> Option<&'static str> {
 ///
 /// `source` is always `"price_list_api"` on every returned row.
 /// `aws_sku` is the SKU from the first `Input Tokens` row seen for the model.
+///
+/// Accepts both a raw price list file (with AWS's metadata preamble) and one
+/// that already begins at the header row — see [`strip_preamble`].
 pub fn parse_price_list_csv(csv: &str) -> Result<Vec<ModelPricing>> {
     // Column indices (0-based).  The test header is:
     // SKU | OfferTermCode | RateCode | TermType | PriceDescription |
@@ -84,7 +118,7 @@ pub fn parse_price_list_csv(csv: &str) -> Result<Vec<ModelPricing>> {
 
     let mut reader = csv::ReaderBuilder::new()
         .has_headers(true)
-        .from_reader(csv.as_bytes());
+        .from_reader(strip_preamble(csv).as_bytes());
 
     // Keyed by normalized model prefix.
     let mut accumulators: HashMap<String, ModelAccumulator> = HashMap::new();

--- a/tests/integration/pricing_csv_tests.rs
+++ b/tests/integration/pricing_csv_tests.rs
@@ -14,6 +14,18 @@ use ccag::pricing::{normalize_service_name, parse_price_list_csv};
 // CSV header used by the AWS Bedrock Foundation Models price list (confirmed by live fetch).
 const CSV_HEADER: &str = r#""SKU","OfferTermCode","RateCode","TermType","PriceDescription","EffectiveDate","StartingRange","EndingRange","Unit","PricePerUnit","Currency","Location","Location Type","usageType","operation","Region Code","serviceName""#;
 
+// The metadata preamble AWS prepends to every price list file downloaded via
+// GetPriceListFileUrl. Five two-column rows, then the real 17-column header.
+// Reproduced verbatim (modulo the disclaimer text) from a live fetch of
+// arn:aws:pricing:::price-list/aws/AmazonBedrockFoundationModels/USD/.../us-east-1
+const CSV_PREAMBLE: &str = concat!(
+    "\"FormatVersion\",\"v1.0\"\n",
+    "\"Disclaimer\",\"This pricing list is for informational purposes only.\"\n",
+    "\"Publication Date\",\"2026-07-03T08:58:57Z\"\n",
+    "\"Version\",\"20260703085857\"\n",
+    "\"OfferCode\",\"AmazonBedrockFoundationModels\"\n",
+);
+
 // Build a minimal CSV string from header + rows.
 fn csv_with_rows(rows: &[&str]) -> String {
     let mut out = CSV_HEADER.to_string();
@@ -23,6 +35,12 @@ fn csv_with_rows(rows: &[&str]) -> String {
         out.push('\n');
     }
     out
+}
+
+// Same as `csv_with_rows`, but prefixed with AWS's metadata preamble — i.e.
+// byte-for-byte what `refresh_pricing` actually feeds the parser in production.
+fn csv_with_preamble_rows(rows: &[&str]) -> String {
+    format!("{CSV_PREAMBLE}{}", csv_with_rows(rows))
 }
 
 // Build a single quoted CSV row with the fields the parser cares about.
@@ -651,4 +669,95 @@ fn includes_non_anthropic_models_with_complete_global_dimensions() {
     result.sort_by(|a, b| a.model_prefix.cmp(&b.model_prefix));
     assert_eq!(result[0].model_prefix, "claude-haiku-4-5");
     assert_eq!(result[1].model_prefix, "llama-4-scout");
+}
+
+// -----------------------------------------------------------------------
+// Regression: the real price list file carries a metadata preamble
+// -----------------------------------------------------------------------
+
+/// A price list downloaded from `GetPriceListFileUrl` begins with five
+/// two-column metadata rows before the header. Feeding that to a
+/// `has_headers(true)` reader made the csv crate adopt `"FormatVersion","v1.0"`
+/// as a 2-field header, so every 17-field data row failed the equal-length
+/// check and was silently dropped — `refresh_pricing` logged
+/// `Parsed price list rows count=0` and reported "Nothing changed" forever.
+///
+/// Every other test in this file builds its fixture from `CSV_HEADER` directly,
+/// so none of them exercised the preamble. This one does.
+#[test]
+fn preamble_is_skipped_and_rows_are_parsed() {
+    let service = "Claude Opus 4.8 (Amazon Bedrock Edition)";
+    let csv = csv_with_preamble_rows(&[
+        &make_row(
+            "SKU-O48-INPUT",
+            "AWS Marketplace software usage|us-east-1|Input Tokens - Standard, Global",
+            "5.0000000000",
+            service,
+        ),
+        &make_row(
+            "SKU-O48-OUTPUT",
+            "AWS Marketplace software usage|us-east-1|Output Tokens - Standard, Global",
+            "25.0000000000",
+            service,
+        ),
+        &make_row(
+            "SKU-O48-CREAD",
+            "AWS Marketplace software usage|us-east-1|Cache Read Tokens - Standard, Global",
+            "0.5000000000",
+            service,
+        ),
+        &make_row(
+            "SKU-O48-CWRITE",
+            "AWS Marketplace software usage|us-east-1|Cache Write Tokens - Standard, Global",
+            "6.2500000000",
+            service,
+        ),
+    ]);
+
+    let result = parse_price_list_csv(&csv).expect("parse should succeed");
+
+    assert_eq!(
+        result.len(),
+        1,
+        "preamble must be skipped so the data rows parse; got {} rows",
+        result.len()
+    );
+    assert_pricing(&result[0], "claude-opus-4-8", 5.0, 25.0, 0.5, 6.25);
+}
+
+/// A CSV that already starts at the header row must keep working — the fix
+/// must not depend on a preamble being present.
+#[test]
+fn header_only_csv_still_parses_without_preamble() {
+    let service = "Claude Sonnet 5 (Amazon Bedrock Edition)";
+    let csv = csv_with_rows(&[
+        &make_row(
+            "SKU-S5-INPUT",
+            "AWS Marketplace software usage|us-east-1|Input Tokens - Standard, Global",
+            "2.0000000000",
+            service,
+        ),
+        &make_row(
+            "SKU-S5-OUTPUT",
+            "AWS Marketplace software usage|us-east-1|Output Tokens - Standard, Global",
+            "10.0000000000",
+            service,
+        ),
+        &make_row(
+            "SKU-S5-CREAD",
+            "AWS Marketplace software usage|us-east-1|Cache Read Tokens - Standard, Global",
+            "0.2000000000",
+            service,
+        ),
+        &make_row(
+            "SKU-S5-CWRITE",
+            "AWS Marketplace software usage|us-east-1|Cache Write Tokens - Standard, Global",
+            "2.5000000000",
+            service,
+        ),
+    ]);
+
+    let result = parse_price_list_csv(&csv).expect("parse should succeed");
+    assert_eq!(result.len(), 1, "header-only CSV must still parse");
+    assert_pricing(&result[0], "claude-sonnet-5", 2.0, 10.0, 0.2, 2.5);
 }


### PR DESCRIPTION
## Summary

This PR fixes #87, #95, #94 

`refresh_pricing` is not writing new rows. It fetches the price list, discards all 360 data rows, and reports success.

Every price list file from `GetPriceListFileUrl` opens with five two-column metadata rows before the real 17-column header:

```
"FormatVersion","v1.0"
"Disclaimer","This pricing list is for informational purposes only..."
"Publication Date","2026-07-03T08:58:57Z"
"Version","20260703085857"
"OfferCode","AmazonBedrockFoundationModels"
"SKU","OfferTermCode",...          <-- header
```

`parse_price_list_csv` hands that text straight to a `has_headers(true)` reader, so the csv crate adopts `"FormatVersion","v1.0"` as a 2-field header. Every 17-field data row then fails the equal-length check and hits the `Err(e) => warn!("Skipping malformed CSV record")` arm.

Observed in production (`v1.9.3`, `RUST_LOG=info`):

```
WARN ccag::pricing: Skipping malformed CSV record error=CSV error: record 360
  (line: 361, byte: 129415): found record with 17 fields, but the previous record has 2 fields
INFO ccag::pricing: Parsed price list rows count=0
INFO ccag::pricing: Price list refresh complete updated=0 skipped_manual=0 errors=0
```

## Why it's invisible

With `count=0` there's nothing to upsert, so every `RefreshReport` counter stays zero. `static/index.html` then falls through to the empty-`parts` branch and renders **"Nothing changed"** — with no error suffix, because nothing errored. Operators see a green banner.

The practical consequence: a deployment keeps whatever `migrations/010_model_pricing.sql` seeded and never picks up models released since. `estimate_cost_usd()` returns `NULL` for those, so their spend is silently excluded from all cost reporting. On our gateway that was 764 requests over 7 days against `claude-opus-4-8` and `claude-sonnet-5`.

## Fix

Add `strip_preamble()`: advance to the line beginning `"SKU"` (or a bare `SKU,`), and return the input untouched if no header row is found — so an already-trimmed CSV parses exactly as before.

## Verification

Against a live price list (`arn:aws:pricing:::price-list/aws/AmazonBedrockFoundationModels/USD/20260703085857/us-east-1`, 361 lines), through the real `parse_price_list_csv`:

| | rows |
|---|---|
| before | **0** |
| after | **4** |

```
claude-fable-5   in=10 out=50 cache_read=1   cache_write=12.5
claude-opus-4-7  in=5  out=25 cache_read=0.5 cache_write=6.25
claude-opus-4-8  in=5  out=25 cache_read=0.5 cache_write=6.25
claude-sonnet-5  in=2  out=10 cache_read=0.2 cache_write=2.5
```

## Tests

Every existing fixture in `pricing_csv_tests.rs` is built from `CSV_HEADER` directly via `csv_with_rows()`, which is exactly why the suite never caught this — the header constant is correct, the preamble above it was just never modelled.

- `preamble_is_skipped_and_rows_are_parsed` — builds its fixture the way AWS actually ships the file. Fails with `got 0 rows` on `main`, passes with this change.
- `header_only_csv_still_parses_without_preamble` — pins the no-preamble path so the fix can't regress it.

All 12 `pricing_csv` tests pass; `cargo fmt --check` clean.

## Out of scope

`classify_description()` matches only the four `... - Standard, Global` descriptions. In the current price list that naming is used solely by the newest models — Opus 4.5/4.6, Sonnet 4.5/4.6 and Haiku 4.5 use an older convention (`Million Input Tokens Global`) and are still skipped, so they keep their seeded rates indefinitely. That's a separate bug and I've left it alone here, but happy to follow up if you'd like it addressed in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code) reviewed, tested and edited by @orangewolf 