### PR TITLE
fix(auth): portal + CLI SSO — authorization-code + PKCE, default over implicit (1.9.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.9.3"
+version = "1.9.4"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"
@@ -68,6 +68,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "uuid"
 sha2 = "0.10"
 rand = "0.9"
 hex = "0.4"
+base64 = "0.22"
 jsonwebtoken = "9"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
@@ -97,7 +98,6 @@ mock-bedrock = []
 [dev-dependencies]
 tokio-test = "0.4"
 wiremock = "0.6"
-base64 = "0.22"
 rsa = "0.9"
 serial_test = "3"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.9.3"
+version = "1.9.4"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -87,12 +87,32 @@ curl -X POST https://ccag.example.com/admin/keys \
   -d '{"name": "alice-key", "user_id": "uuid", "team_id": "uuid"}'
 ```
 
+## Flow Types
+
+Each configured IDP has a `flow_type`, controlling how CCAG's own portal and CLI sign-in
+redirects work:
+
+| `flow_type` | Description |
+|---|---|
+| `authorization_code` (default, recommended) | PKCE-protected authorization-code flow. The IDP redirects back with a short-lived, single-use `code`; CCAG's server exchanges it for the identity token over a back-channel call the browser never sees, then issues its own session token. Removed from the spec entirely in OAuth 2.1 for good reason — see below. |
+| `implicit` (legacy) | The IDP puts the identity token directly in the callback URL fragment; the browser's JS reads it and uses it as the bearer credential. Kept only for IDPs that genuinely can't do authorization-code + PKCE. |
+
+**Use `authorization_code` unless you have a specific reason not to.** With implicit, the
+identity token travels in the URL — visible to browser history, any `Referer` header, and
+any extension with tab-reading access. With authorization-code + PKCE, only an
+unguessable, single-use, short-lived `code` ever touches the browser; the actual token
+exchange happens server-to-server. Set it per-IDP via the portal (Identity Providers →
+edit → Flow Type) or the admin API's `flow_type` field.
+
 ## Generic OIDC Setup
 
 CCAG supports any OpenID Connect provider that issues RS256-signed JWTs. The setup process is the same across providers:
 
 1. **Create an application** in your identity provider
-2. **Set the redirect URI** to `https://your-ccag-domain.com/portal` (for browser SSO)
+2. **Set the redirect URIs** — for the recommended `authorization_code` flow:
+   `https://your-ccag-domain.com/auth/sso/callback` (browser/portal SSO) and
+   `https://your-ccag-domain.com/auth/cli/callback` (CLI login, `apiKeyHelper`).
+   For legacy `implicit`, the portal redirect is `https://your-ccag-domain.com/portal` instead.
 3. **Note the issuer URL** (e.g., `https://dev-12345.okta.com`)
 4. **Note the audience/client ID** for token validation
 5. **Configure CCAG** with the issuer and audience (env vars or admin API)
@@ -118,6 +138,7 @@ curl -X POST https://ccag.example.com/admin/idps \
     "name": "Corporate SSO",
     "issuer_url": "https://your-idp.example.com",
     "audience": "your-client-id",
+    "flow_type": "authorization_code",
     "auto_provision": true,
     "default_role": "member",
     "allowed_domains": ["company.com"]
@@ -127,8 +148,9 @@ curl -X POST https://ccag.example.com/admin/idps \
 | IDP Field | Description |
 |---|---|
 | `name` | Display name shown on the portal login button |
-| `issuer_url` | OIDC issuer URL (must serve `/.well-known/openid-configuration`) |
-| `audience` | Expected `aud` claim in the JWT |
+| `issuer_url` | OIDC issuer URL (must serve `/.well-known/openid-configuration`, including a `token_endpoint` for `authorization_code`) |
+| `audience` | Expected `aud` claim in the JWT, and the OAuth `client_id` used in the redirect/exchange |
+| `flow_type` | `authorization_code` (default, recommended — see [Flow Types](#flow-types)) or `implicit` (legacy) |
 | `auto_provision` | Automatically create a user account on first login |
 | `default_role` | Role for auto-provisioned users (`member` or `admin`) |
 | `allowed_domains` | Restrict login to specific email domains (optional) |
@@ -141,8 +163,8 @@ curl -X POST https://ccag.example.com/admin/idps \
 2. Select **OIDC - OpenID Connect** and **Single-Page Application**
 3. Set the following:
    - **App integration name:** Claude Code Gateway
-   - **Grant type:** Implicit (Hybrid). Check "Allow ID Token".
-   - **Sign-in redirect URI:** `https://ccag.example.com/portal`
+   - **Grant type:** Authorization Code (default for new SPA apps)
+   - **Sign-in redirect URIs:** `https://ccag.example.com/auth/sso/callback` and `https://ccag.example.com/auth/cli/callback`
    - **Sign-out redirect URI:** `https://ccag.example.com/portal`
    - **Controlled access:** Assign to desired groups
 4. Note the **Client ID** and your **Okta domain** (e.g., `dev-12345.okta.com`)
@@ -159,8 +181,8 @@ OIDC_AUDIENCE=0oaXXXXXXXXXXXX  # Client ID from step 4
 2. Set the following:
    - **Name:** Claude Code Gateway
    - **Supported account types:** Accounts in this organizational directory only
-   - **Redirect URI:** Web, `https://ccag.example.com/portal`
-3. Go to **Authentication** and enable **ID tokens** under Implicit grant
+   - **Redirect URIs:** Web, `https://ccag.example.com/auth/sso/callback` and `https://ccag.example.com/auth/cli/callback`
+3. Under **Authentication**, leave Implicit grant unchecked — the app registration's default (authorization code) is what CCAG uses
 4. Go to **Token configuration > Add optional claim** and add `email` to the ID token
 5. Note the **Application (client) ID** and **Directory (tenant) ID**
 6. Configure CCAG:
@@ -177,7 +199,7 @@ OIDC_AUDIENCE={application-client-id}
 3. Set the following:
    - **Application type:** Web application
    - **Name:** Claude Code Gateway
-   - **Authorized redirect URIs:** `https://ccag.example.com/portal`
+   - **Authorized redirect URIs:** `https://ccag.example.com/auth/sso/callback` and `https://ccag.example.com/auth/cli/callback`
 4. Note the **Client ID**
 5. Configure CCAG:
 
@@ -191,7 +213,7 @@ OIDC_AUDIENCE={client-id}.apps.googleusercontent.com
 1. In the Auth0 Dashboard, go to **Applications > Create Application**
 2. Select **Single Page Web Applications**
 3. In the **Settings** tab:
-   - **Allowed Callback URLs:** `https://ccag.example.com/portal`
+   - **Allowed Callback URLs:** `https://ccag.example.com/auth/sso/callback,https://ccag.example.com/auth/cli/callback`
    - **Allowed Logout URLs:** `https://ccag.example.com/portal`
    - **Allowed Web Origins:** `https://ccag.example.com`
 4. Note the **Domain** and **Client ID**
@@ -209,7 +231,9 @@ OIDC_AUDIENCE={client-id}
 3. Set the following:
    - **Client type:** OpenID Connect
    - **Client ID:** ccag
-   - **Valid redirect URIs:** `https://ccag.example.com/portal`
+   - **Client authentication:** Off (public client — CCAG uses PKCE, no client secret)
+   - **Standard flow:** On (authorization code); Implicit flow: Off, unless you're intentionally using the legacy `implicit` `flow_type`
+   - **Valid redirect URIs:** `https://ccag.example.com/auth/sso/callback` and `https://ccag.example.com/auth/cli/callback`
    - **Web origins:** `https://ccag.example.com`
 4. Under **Client scopes**, ensure `openid`, `email`, and `profile` are included
 5. Configure CCAG:
@@ -226,10 +250,16 @@ For Claude Code CLI authentication without static API keys, CCAG supports browse
 ### How It Works
 
 1. Claude Code invokes `proxy-login.sh` when it needs credentials
-2. The script opens a browser to the CCAG login page
+2. The script opens a browser to `/auth/cli/login`, which redirects to the IDP
 3. The user authenticates via SSO
-4. The script receives a session token and returns it to Claude Code
-5. Claude Code uses the token for subsequent API calls
+4. For `authorization_code` IDPs (default): the IDP redirects back to `/auth/cli/callback`
+   with a one-time code; CCAG exchanges it for the identity token server-side (the
+   browser never sees it), validates it, and issues its own session token — all before
+   rendering a plain "you're done, close this tab" page. For legacy `implicit` IDPs:
+   the identity token lands in the callback page's URL fragment, and client-side JS
+   posts it to `/auth/cli/complete` for validation.
+5. The script polls `/auth/cli/poll` and receives the session token
+6. Claude Code uses the token for subsequent API calls
 
 The `proxy-login.sh` script is served by the gateway at `/auth/setup/token-script`. Download it with:
 
@@ -261,9 +291,13 @@ The CLI auth flow uses these gateway endpoints:
 | Endpoint | Method | Description |
 |---|---|---|
 | `/auth/cli/login` | GET | Initiates browser-based login, returns a session code |
-| `/auth/cli/callback` | GET | Browser redirect target after SSO |
-| `/auth/cli/complete` | POST | Completes the login flow |
+| `/auth/cli/callback` | GET | Browser redirect target after SSO. `authorization_code` IDPs: redeems the code server-side and completes the session directly. `implicit` IDPs: serves the legacy client-side extraction page. |
+| `/auth/cli/complete` | POST | Legacy `implicit`-flow path only — receives the token from the client-side callback page |
 | `/auth/cli/poll` | GET | CLI polls for the completed token |
+
+The portal's own SSO login uses the analogous `/auth/sso/callback` (GET) for `authorization_code`
+IDPs — same server-side exchange, but it redirects the browser straight back into the portal
+with CCAG's session token rather than requiring a poll.
 
 ## Team and User Management
 

--- a/src/api/cli_auth.rs
+++ b/src/api/cli_auth.rs
@@ -4,12 +4,11 @@ use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 use axum::{
-    Json,
     extract::{Query, State},
     http::StatusCode,
     response::{Html, IntoResponse, Redirect, Response},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 use crate::auth;
@@ -30,35 +29,85 @@ pub fn new_session_store() -> CliSessionStore {
 
 // ── DB-backed session helpers (using proxy_settings as KV store) ────────
 
+/// Everything the callback needs to redeem the code, once the browser comes back.
+/// Stored server-side only (proxy_settings), keyed by session — never sent to the browser.
+#[derive(Serialize, Deserialize)]
+struct PendingCliLogin {
+    verifier: String,
+    token_endpoint: String,
+    audience: String,
+    redirect_uri: String,
+}
+
+/// A CLI login session's state: either still waiting on the browser round trip
+/// (holding the PKCE verifier + IDP details needed to redeem the code), or done
+/// (holding the gateway session token the CLI will poll for). Untagged: the two
+/// shapes don't overlap ("verifier" vs "token"), so serde picks the right one.
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum CliSessionState {
+    Pending(PendingCliLogin),
+    Complete { token: String },
+}
+
 fn session_key(session_id: &str) -> String {
     format!("cli_session:{}", session_id)
 }
 
-/// Create a pending session in the DB. Value "" = pending, non-empty = token.
-async fn db_create_session(pool: &sqlx::PgPool, session_id: &str) -> anyhow::Result<()> {
+/// Create a pending session in the DB, holding the PKCE verifier + IDP details
+/// needed to redeem the authorization code when the browser comes back.
+async fn db_create_session(
+    pool: &sqlx::PgPool,
+    session_id: &str,
+    pending: PendingCliLogin,
+) -> anyhow::Result<()> {
+    let value = serde_json::to_string(&CliSessionState::Pending(pending))?;
     sqlx::query(
         r#"INSERT INTO proxy_settings (key, value, updated_at)
-           VALUES ($1, '', now())
-           ON CONFLICT (key) DO UPDATE SET value = '', updated_at = now()"#,
+           VALUES ($1, $2, now())
+           ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = now()"#,
     )
     .bind(session_key(session_id))
+    .bind(value)
     .execute(pool)
     .await?;
     Ok(())
 }
 
-/// Store the completed token against a session.
+/// Fetch the pending login's stored verifier/IDP details (does not consume it —
+/// the callback overwrites the row with the final token right after redeeming it).
+async fn db_get_pending(
+    pool: &sqlx::PgPool,
+    session_id: &str,
+) -> anyhow::Result<Option<PendingCliLogin>> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT value FROM proxy_settings WHERE key = $1")
+        .bind(session_key(session_id))
+        .fetch_optional(pool)
+        .await?;
+    match row {
+        Some((value,)) => match serde_json::from_str::<CliSessionState>(&value) {
+            Ok(CliSessionState::Pending(p)) => Ok(Some(p)),
+            _ => Ok(None), // already completed (or never existed in this shape)
+        },
+        None => Ok(None),
+    }
+}
+
+/// Store the completed gateway session token against a session.
 async fn db_complete_session(
     pool: &sqlx::PgPool,
     session_id: &str,
     token: &str,
 ) -> anyhow::Result<bool> {
+    let value = serde_json::to_string(&CliSessionState::Complete {
+        token: token.to_string(),
+    })?;
     let result = sqlx::query(
         r#"UPDATE proxy_settings SET value = $2, updated_at = now()
            WHERE key = $1 AND updated_at > now() - interval '5 minutes'"#,
     )
     .bind(session_key(session_id))
-    .bind(token)
+    .bind(value)
     .execute(pool)
     .await?;
     Ok(result.rows_affected() > 0)
@@ -66,7 +115,7 @@ async fn db_complete_session(
 
 /// Poll for a completed session. Returns:
 /// - Ok(Some(token)) if complete
-/// - Ok(None) if pending
+/// - Ok(None) if pending (still waiting on the browser round trip)
 /// - Err if expired/not found
 async fn db_poll_session(pool: &sqlx::PgPool, session_id: &str) -> anyhow::Result<Option<String>> {
     let row: Option<(String, chrono::DateTime<chrono::Utc>)> =
@@ -83,13 +132,12 @@ async fn db_poll_session(pool: &sqlx::PgPool, session_id: &str) -> anyhow::Resul
                 db_delete_session(pool, session_id).await.ok();
                 anyhow::bail!("expired")
             }
-            if value.is_empty() {
-                Ok(None) // pending
-            } else {
-                // Complete — clean up and return token
-                let token = value;
-                db_delete_session(pool, session_id).await.ok();
-                Ok(Some(token))
+            match serde_json::from_str::<CliSessionState>(&value) {
+                Ok(CliSessionState::Complete { token }) => {
+                    db_delete_session(pool, session_id).await.ok();
+                    Ok(Some(token))
+                }
+                _ => Ok(None), // pending
             }
         }
         None => anyhow::bail!("not_found"),
@@ -122,7 +170,8 @@ pub struct LoginParams {
 }
 
 /// GET /auth/cli/login?session=UUID
-/// Creates a pending session and redirects to the first configured IDP.
+/// Creates a pending session (holding a fresh PKCE verifier) and redirects to
+/// the first configured IDP's authorization endpoint.
 pub async fn cli_login(
     State(state): State<Arc<GatewayState>>,
     headers: axum::http::HeaderMap,
@@ -139,84 +188,57 @@ pub async fn cli_login(
             .into_response();
     }
 
-    // Store pending session in DB
     let pool = state.db().await;
     let pool = &pool;
     db_cleanup_expired(pool).await;
-    if let Err(e) = db_create_session(pool, &session_id).await {
-        tracing::error!(%e, "Failed to create CLI session in DB");
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to create session",
-        )
-            .into_response();
-    }
 
     let host = headers
         .get("host")
         .and_then(|h| h.to_str().ok())
         .unwrap_or("localhost");
 
-    // Find the first configured IDP and build redirect URL
-    let redirect_url = build_idp_redirect_url(&state, host, &session_id).await;
+    let idp = match resolve_idp(&state).await {
+        Some(idp) => idp,
+        None => {
+            return (StatusCode::NOT_FOUND, "No identity provider configured").into_response();
+        }
+    };
 
-    match redirect_url {
-        Some(url) => Redirect::temporary(&url).into_response(),
-        None => (StatusCode::NOT_FOUND, "No identity provider configured").into_response(),
+    match build_auth_redirect(&state.http_client, &idp, host, &session_id).await {
+        Some((redirect_url, pending)) => {
+            if let Err(e) = db_create_session(pool, &session_id, pending).await {
+                tracing::error!(%e, "Failed to create CLI session in DB");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to create session",
+                )
+                    .into_response();
+            }
+            Redirect::temporary(&redirect_url).into_response()
+        }
+        None => (StatusCode::BAD_GATEWAY, "Failed to reach identity provider").into_response(),
     }
 }
 
-/// Build the IDP authorization URL with redirect back to /auth/cli/callback.
-async fn build_idp_redirect_url(
-    state: &GatewayState,
-    host: &str,
-    session_id: &str,
-) -> Option<String> {
-    // Check DB IDPs
+/// Resolve the IDP to use: first enabled DB-configured IDP, falling back to env config.
+async fn resolve_idp(state: &GatewayState) -> Option<crate::auth::oidc::IdpConfig> {
     if let Ok(db_idps) = crate::db::idp::get_enabled_idps(&state.db().await).await
         && let Some(row) = db_idps.first()
     {
-        let idp = crate::auth::oidc::IdpConfig::from_db_row(row);
-        return build_auth_url(&state.http_client, &idp, host, session_id).await;
+        return Some(crate::auth::oidc::IdpConfig::from_db_row(row));
     }
-    // Fall back to env IDP
-    if let Some(env_idp) = crate::auth::oidc::IdpConfig::from_env() {
-        return build_auth_url(&state.http_client, &env_idp, host, session_id).await;
-    }
-    None
+    crate::auth::oidc::IdpConfig::from_env()
 }
 
-/// Discover the OIDC authorization endpoint and build the redirect URL.
-async fn build_auth_url(
+/// Discover the IDP's endpoints and build the authorization-code + PKCE redirect URL.
+/// Returns the redirect URL alongside what the callback will need to redeem the code.
+async fn build_auth_redirect(
     http_client: &reqwest::Client,
     idp: &crate::auth::oidc::IdpConfig,
     host: &str,
     session_id: &str,
-) -> Option<String> {
-    let discovery_url = format!(
-        "{}/.well-known/openid-configuration",
-        idp.issuer.trim_end_matches('/')
-    );
-
-    let authorize_endpoint = match http_client.get(&discovery_url).send().await {
-        Ok(resp) => match resp.json::<serde_json::Value>().await {
-            Ok(doc) => match doc["authorization_endpoint"].as_str() {
-                Some(ep) => ep.to_string(),
-                None => {
-                    tracing::error!(idp = %idp.name, "No authorization_endpoint in OIDC discovery document");
-                    return None;
-                }
-            },
-            Err(e) => {
-                tracing::error!(idp = %idp.name, %e, "Failed to parse OIDC discovery document");
-                return None;
-            }
-        },
-        Err(e) => {
-            tracing::error!(idp = %idp.name, %e, "Failed to fetch OIDC discovery document");
-            return None;
-        }
-    };
+) -> Option<(String, PendingCliLogin)> {
+    let endpoints = auth::oidc::discover_endpoints(http_client, &idp.issuer).await?;
 
     let redirect_host = host.split(':').next().unwrap_or(host);
     // If the IDP has an audience configured that looks like a domain name,
@@ -228,30 +250,156 @@ async fn build_auth_url(
         .filter(|a| !a.is_empty() && a.contains('.'))
         .unwrap_or(redirect_host);
     let redirect_uri = format!("https://{}/auth/cli/callback", trusted_host);
-    let audience = idp.audience.as_deref().unwrap_or("");
-
-    let separator = if authorize_endpoint.contains('?') {
-        '&'
-    } else {
-        '?'
-    };
-
-    // Cryptographically random nonce
-    let nonce = format!("{:032x}", rand::random::<u128>());
+    let audience = idp.audience.clone().unwrap_or_default();
 
     let scopes = crate::auth::oidc::resolve_oidc_scopes(idp);
     let encoded_scopes = scopes.replace(' ', "%20");
 
-    Some(format!(
-        "{authorize_endpoint}{separator}response_type=id_token&client_id={audience}&redirect_uri={redirect_uri}&state={session_id}&nonce={nonce}&scope={encoded_scopes}"
-    ))
+    if idp.flow_type == "authorization_code" {
+        let pkce = auth::pkce::generate();
+        let separator = if endpoints.authorization_endpoint.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
+        let redirect_url = format!(
+            "{authz}{separator}response_type=code&client_id={audience}&redirect_uri={redirect_uri}&state={session_id}&scope={encoded_scopes}&code_challenge={challenge}&code_challenge_method=S256",
+            authz = endpoints.authorization_endpoint,
+            challenge = pkce.challenge,
+        );
+        Some((
+            redirect_url,
+            PendingCliLogin {
+                verifier: pkce.verifier,
+                token_endpoint: endpoints.token_endpoint,
+                audience,
+                redirect_uri,
+            },
+        ))
+    } else {
+        // Legacy implicit flow, kept for IDPs configured to use it.
+        let separator = if endpoints.authorization_endpoint.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
+        let nonce = format!("{:032x}", rand::random::<u128>());
+        let redirect_url = format!(
+            "{authz}{separator}response_type=id_token&client_id={audience}&redirect_uri={redirect_uri}&state={session_id}&nonce={nonce}&scope={encoded_scopes}",
+            authz = endpoints.authorization_endpoint,
+        );
+        // No verifier/token_endpoint needed for implicit — the legacy callback path
+        // (client-side extraction + POST to /auth/cli/complete) handles this case.
+        Some((
+            redirect_url,
+            PendingCliLogin {
+                verifier: String::new(),
+                token_endpoint: String::new(),
+                audience,
+                redirect_uri,
+            },
+        ))
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CliCallbackParams {
+    /// Present on the authorization-code path.
+    code: Option<String>,
+    /// Session ID, echoed back by the IDP as `state`.
+    state: Option<String>,
+    /// Present if the user denied consent or the IDP otherwise failed the request.
+    error: Option<String>,
+    error_description: Option<String>,
 }
 
 /// GET /auth/cli/callback
-/// Serves an HTML page that extracts the token from URL fragment/query params
-/// and POSTs it back to /auth/cli/complete.
-pub async fn cli_callback() -> impl IntoResponse {
-    Html(CLI_CALLBACK_HTML)
+/// Authorization-code path: redeems the code server-side (back-channel, PKCE-bound),
+/// validates the resulting id_token, issues a gateway session token, and completes
+/// the session — all without the browser ever seeing the IDP's token. Renders a
+/// static result page; the CLI itself learns the outcome via /auth/cli/poll.
+///
+/// Implicit-flow IDPs still land here with the token in the URL fragment (which the
+/// server never sees) — CLI_CALLBACK_LEGACY_HTML below is served in that case and
+/// does the old client-side extract + POST to /auth/cli/complete.
+pub async fn cli_callback(
+    State(state): State<Arc<GatewayState>>,
+    Query(params): Query<CliCallbackParams>,
+) -> Response {
+    let Some(session_id) = params.state else {
+        return Html(legacy_callback_html()).into_response();
+    };
+
+    if let Some(err) = params.error {
+        let desc = params.error_description.unwrap_or_default();
+        tracing::warn!(%err, %desc, "IDP returned an error on CLI callback");
+        return Html(render_result_html(
+            false,
+            "Authentication was cancelled or denied.",
+        ))
+        .into_response();
+    }
+
+    let Some(code) = params.code else {
+        // No code and no error — this is the implicit-flow redirect shape
+        // (token lives in the URL fragment, which never reaches the server).
+        return Html(legacy_callback_html()).into_response();
+    };
+
+    let pool = state.db().await;
+    let pending = match db_get_pending(&pool, &session_id).await {
+        Ok(Some(p)) if !p.verifier.is_empty() => p,
+        _ => {
+            return Html(render_result_html(
+                false,
+                "Session expired or not found — close this tab and try again from your terminal.",
+            ))
+            .into_response();
+        }
+    };
+
+    let id_token = match auth::oidc::exchange_code_for_id_token(
+        &state.http_client,
+        &pending.token_endpoint,
+        &code,
+        &pending.redirect_uri,
+        &pending.audience,
+        &pending.verifier,
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(%e, "CLI code exchange failed");
+            return Html(render_result_html(false, "Authentication failed.")).into_response();
+        }
+    };
+
+    let session_token = match state.idp_validator.validate_token(&id_token).await {
+        Ok(identity) => {
+            let ttl = state.session_token_ttl_hours.load(Ordering::Relaxed) as u64;
+            let token = auth::session::issue(&state.session_signing_key, &identity, ttl);
+            tracing::info!(sub = %identity.sub, ttl_hours = ttl, "Issued gateway session token");
+            token
+        }
+        Err(e) => {
+            tracing::warn!(%e, "IDP token validation failed during CLI login");
+            return Html(render_result_html(false, "Authentication failed.")).into_response();
+        }
+    };
+
+    match db_complete_session(&pool, &session_id, &session_token).await {
+        Ok(true) => Html(render_result_html(true, "")).into_response(),
+        Ok(false) => Html(render_result_html(
+            false,
+            "Session expired — close this tab and try again from your terminal.",
+        ))
+        .into_response(),
+        Err(e) => {
+            tracing::error!(%e, "Failed to complete CLI session in DB");
+            Html(render_result_html(false, "Internal error.")).into_response()
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -261,21 +409,22 @@ pub struct CompleteBody {
 }
 
 /// POST /auth/cli/complete
-/// Receives the IDP token from the callback page, validates it, issues a
-/// gateway session token, and stores it against the session.
+/// Legacy (implicit-flow) path only: receives the IDP token from the client-side
+/// callback page, validates it, issues a gateway session token, and stores it
+/// against the session. The authorization-code path never calls this — it's
+/// handled entirely server-side in `cli_callback`.
 pub async fn cli_complete(
     State(state): State<Arc<GatewayState>>,
-    Json(body): Json<CompleteBody>,
+    axum::Json(body): axum::Json<CompleteBody>,
 ) -> Response {
     if body.token.is_empty() || body.token.len() > 16384 {
         return (
             StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "Invalid token"})),
+            axum::Json(serde_json::json!({"error": "Invalid token"})),
         )
             .into_response();
     }
 
-    // Validate the IDP token and issue a longer-lived gateway session token
     let token_to_store = match state.idp_validator.validate_token(&body.token).await {
         Ok(identity) => {
             let ttl = state.session_token_ttl_hours.load(Ordering::Relaxed) as u64;
@@ -289,19 +438,18 @@ pub async fn cli_complete(
         }
     };
 
-    // Complete session in DB
     match db_complete_session(&state.db().await, &body.session, &token_to_store).await {
-        Ok(true) => Json(serde_json::json!({"status": "ok"})).into_response(),
+        Ok(true) => axum::Json(serde_json::json!({"status": "ok"})).into_response(),
         Ok(false) => (
             StatusCode::GONE,
-            Json(serde_json::json!({"error": "Session expired or not found"})),
+            axum::Json(serde_json::json!({"error": "Session expired or not found"})),
         )
             .into_response(),
         Err(e) => {
             tracing::error!(%e, "Failed to complete CLI session in DB");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "Internal error"})),
+                axum::Json(serde_json::json!({"error": "Internal error"})),
             )
                 .into_response()
         }
@@ -319,33 +467,60 @@ pub async fn cli_poll(
     State(state): State<Arc<GatewayState>>,
     Query(params): Query<PollParams>,
 ) -> Response {
-    // Poll session from DB
     match db_poll_session(&state.db().await, &params.session).await {
         Ok(Some(token)) => {
-            Json(serde_json::json!({"status": "complete", "token": token})).into_response()
+            axum::Json(serde_json::json!({"status": "complete", "token": token})).into_response()
         }
-        Ok(None) => Json(serde_json::json!({"status": "pending"})).into_response(),
+        Ok(None) => axum::Json(serde_json::json!({"status": "pending"})).into_response(),
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("expired") {
-                Json(serde_json::json!({"status": "expired"})).into_response()
+                axum::Json(serde_json::json!({"status": "expired"})).into_response()
             } else {
-                Json(serde_json::json!({"status": "not_found"})).into_response()
+                axum::Json(serde_json::json!({"status": "not_found"})).into_response()
             }
         }
     }
 }
 
-static CLI_CALLBACK_HTML: &str = r##"<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Claude Code AWS Gateway</title>
-<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230c0c0f'/%3E%3Ctext x='4' y='22' font-family='ui-monospace,SFMono-Regular,monospace' font-weight='700' font-size='18' fill='%23d4883a'%3E%3E_%3C/text%3E%3C/svg%3E">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&family=IBM+Plex+Sans:wght@400;500&display=swap" rel="stylesheet">
-<style>
+fn render_result_html(success: bool, message: &str) -> String {
+    let (class, body) = if success {
+        (
+            "status-success",
+            r#"<div class="success-icon">&#10003;</div><p class="msg"><strong>Authenticated</strong></p><p class="hint">You can close this tab and return to your terminal.</p>"#
+                .to_string(),
+        )
+    } else {
+        (
+            "status-error",
+            format!(
+                r#"<p class="msg">{}</p><p class="hint">Close this tab and try again from your terminal.</p>"#,
+                askama_escape::escape(message)
+            ),
+        )
+    };
+    CLI_CALLBACK_RESULT_TEMPLATE
+        .replace("__CARD_STYLE__", CARD_STYLE)
+        .replace("__CLASS__", class)
+        .replace("__BODY__", &body)
+}
+
+fn legacy_callback_html() -> String {
+    CLI_CALLBACK_LEGACY_HTML_TEMPLATE.replace("__CARD_STYLE__", CARD_STYLE)
+}
+
+/// Minimal HTML/CSS-escaping shim — the only untrusted input is a short, server-chosen
+/// error message (never user/IDP-controlled free text), but escape defensively anyway.
+mod askama_escape {
+    pub fn escape(s: &str) -> String {
+        s.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+    }
+}
+
+const CARD_STYLE: &str = r##"<style>
   :root {
     --bg: #0c0c0f; --bg-card: #18181d; --border: #1e1e25;
     --text: #e8e6e3; --text-secondary: #9b978f; --text-muted: #5e5b55;
@@ -375,7 +550,39 @@ static CLI_CALLBACK_HTML: &str = r##"<!DOCTYPE html>
   .hint { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--border); }
   .status-success .msg { color: var(--green); }
   .status-error .msg { color: var(--red); }
-</style>
+</style>"##;
+
+/// Server-rendered result page for the authorization-code path — no client-side
+/// JS at all, since the exchange already happened server-side before this renders.
+const CLI_CALLBACK_RESULT_TEMPLATE: &str = r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Claude Code AWS Gateway</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230c0c0f'/%3E%3Ctext x='4' y='22' font-family='ui-monospace,SFMono-Regular,monospace' font-weight='700' font-size='18' fill='%23d4883a'%3E%3E_%3C/text%3E%3C/svg%3E">
+__CARD_STYLE__
+</head>
+<body>
+<div class="card">
+  <div class="brand">&gt;_</div>
+  <div class="title">Claude Code <span class="aws">AWS</span> Gateway</div>
+  <div id="status" class="__CLASS__">
+    __BODY__
+  </div>
+</div>
+</body>
+</html>
+"##;
+
+/// Legacy client-side callback page for implicit-flow IDPs: extracts the id_token
+/// from the URL fragment/query and POSTs it to /auth/cli/complete for validation.
+const CLI_CALLBACK_LEGACY_HTML_TEMPLATE: &str = r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Claude Code AWS Gateway</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230c0c0f'/%3E%3Ctext x='4' y='22' font-family='ui-monospace,SFMono-Regular,monospace' font-weight='700' font-size='18' fill='%23d4883a'%3E%3E_%3C/text%3E%3C/svg%3E">
+__CARD_STYLE__
 </head>
 <body>
 <div class="card">
@@ -430,3 +637,64 @@ static CLI_CALLBACK_HTML: &str = r##"<!DOCTYPE html>
 </body>
 </html>
 "##;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The pending/complete discrimination is the one thing that MUST never be
+    // ambiguous: a poll landing while a login is still pending must never read
+    // the stored verifier back as if it were a completed session token.
+
+    #[test]
+    fn pending_state_round_trips_and_is_not_mistaken_for_complete() {
+        let pending = CliSessionState::Pending(PendingCliLogin {
+            verifier: "verifier-abc".to_string(),
+            token_endpoint: "https://idp.example.com/token".to_string(),
+            audience: "ccag".to_string(),
+            redirect_uri: "https://ccag.example.com/auth/cli/callback".to_string(),
+        });
+        let json = serde_json::to_string(&pending).unwrap();
+        match serde_json::from_str::<CliSessionState>(&json).unwrap() {
+            CliSessionState::Pending(p) => assert_eq!(p.verifier, "verifier-abc"),
+            CliSessionState::Complete { .. } => {
+                panic!("pending state must never deserialize as complete")
+            }
+        }
+    }
+
+    #[test]
+    fn complete_state_round_trips_and_is_not_mistaken_for_pending() {
+        let complete = CliSessionState::Complete {
+            token: "session-token-xyz".to_string(),
+        };
+        let json = serde_json::to_string(&complete).unwrap();
+        match serde_json::from_str::<CliSessionState>(&json).unwrap() {
+            CliSessionState::Complete { token } => assert_eq!(token, "session-token-xyz"),
+            CliSessionState::Pending(_) => {
+                panic!("complete state must never deserialize as pending")
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_empty_verifier_pending_is_still_pending_not_complete() {
+        // The implicit-flow path stores a PendingCliLogin with an empty verifier
+        // as its "session created, waiting on the browser" marker (mirroring the
+        // old empty-string sentinel). It must still discriminate as Pending, not
+        // be misread as a completed session carrying an empty token.
+        let pending = CliSessionState::Pending(PendingCliLogin {
+            verifier: String::new(),
+            token_endpoint: String::new(),
+            audience: "ccag".to_string(),
+            redirect_uri: "https://ccag.example.com/auth/cli/callback".to_string(),
+        });
+        let json = serde_json::to_string(&pending).unwrap();
+        match serde_json::from_str::<CliSessionState>(&json).unwrap() {
+            CliSessionState::Pending(_) => {}
+            CliSessionState::Complete { .. } => {
+                panic!("empty-verifier pending must not be mistaken for complete")
+            }
+        }
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,6 +4,7 @@ mod handlers;
 #[cfg(feature = "mock-bedrock")]
 pub mod mock_bedrock;
 pub mod oidc_resolution;
+pub mod sso_login;
 
 use std::sync::Arc;
 
@@ -224,6 +225,8 @@ pub fn router(state: Arc<GatewayState>) -> Router {
         .route("/auth/me", get(handlers::auth_me))
         .route("/auth/setup", get(auth_setup))
         .route("/auth/setup/token-script", get(auth_setup))
+        // Portal SSO login flow (authorization-code + PKCE)
+        .route("/auth/sso/callback", get(sso_login::sso_callback))
         // CLI browser login flow
         .route("/auth/cli/login", get(cli_auth::cli_login))
         .route("/auth/cli/callback", get(cli_auth::cli_callback))
@@ -365,9 +368,10 @@ async fn auth_providers(
 
     // Load IDPs from DB (env IDP was seeded at startup)
     if let Ok(db_idps) = crate::db::idp::get_enabled_idps(&state.db().await).await {
+        sso_login::cleanup_expired(&state.db().await).await;
         for row in &db_idps {
             let idp = crate::auth::oidc::IdpConfig::from_db_row(row);
-            if let Some(info) = build_provider_info(&state.http_client, &idp, host).await {
+            if let Some(info) = build_provider_info(&state, &idp, host).await {
                 providers.push(info);
             }
         }
@@ -379,38 +383,16 @@ async fn auth_providers(
     }))
 }
 
-/// Discover the OIDC authorization endpoint and build provider info for the portal.
+/// Discover the OIDC endpoints and build provider info (login_url) for the portal.
+/// `authorization_code` (recommended): PKCE, server-side exchange via /auth/sso/callback.
+/// `implicit`/other: legacy direct-to-portal redirect with the token in the URL fragment.
 async fn build_provider_info(
-    http_client: &reqwest::Client,
+    state: &GatewayState,
     idp: &crate::auth::oidc::IdpConfig,
     host: &str,
 ) -> Option<serde_json::Value> {
-    let discovery_url = format!(
-        "{}/.well-known/openid-configuration",
-        idp.issuer.trim_end_matches('/')
-    );
+    let endpoints = crate::auth::oidc::discover_endpoints(&state.http_client, &idp.issuer).await?;
 
-    let authorize_endpoint = match http_client.get(&discovery_url).send().await {
-        Ok(resp) => match resp.json::<serde_json::Value>().await {
-            Ok(doc) => match doc["authorization_endpoint"].as_str() {
-                Some(ep) => ep.to_string(),
-                None => {
-                    tracing::error!(idp = %idp.name, "No authorization_endpoint in OIDC discovery");
-                    return None;
-                }
-            },
-            Err(e) => {
-                tracing::error!(idp = %idp.name, %e, "Failed to parse OIDC discovery");
-                return None;
-            }
-        },
-        Err(e) => {
-            tracing::error!(idp = %idp.name, %e, "Failed to fetch OIDC discovery");
-            return None;
-        }
-    };
-
-    // Build implicit flow URL: redirect back to /portal where checkSsoCallback extracts id_token
     // Preserve port for local dev; use https unless localhost/127.0.0.1
     let base_host = host.split(':').next().unwrap_or(host);
     let scheme = if base_host == "localhost" || base_host == "127.0.0.1" {
@@ -418,11 +400,9 @@ async fn build_provider_info(
     } else {
         "https"
     };
-    let redirect_uri = format!("{scheme}://{host}/portal");
     let audience = idp.audience.as_deref().unwrap_or("");
-    let nonce = format!("{}", chrono::Utc::now().timestamp());
 
-    let separator = if authorize_endpoint.contains('?') {
+    let separator = if endpoints.authorization_endpoint.contains('?') {
         '&'
     } else {
         '?'
@@ -430,13 +410,47 @@ async fn build_provider_info(
 
     let scopes = crate::auth::oidc::resolve_oidc_scopes(idp);
     let encoded_scopes = scopes.replace(' ', "%20");
-    let login_url = format!(
-        "{authorize_endpoint}{separator}response_type=id_token&client_id={audience}&redirect_uri={redirect_uri}&nonce={nonce}&scope={encoded_scopes}"
-    );
+
+    let (login_url, flow_type) = if idp.flow_type == "authorization_code" {
+        let redirect_uri = format!("{scheme}://{host}/auth/sso/callback");
+        let pkce = crate::auth::pkce::generate();
+        let state_id = uuid::Uuid::new_v4().to_string();
+
+        if let Err(e) = sso_login::create_pending(
+            &state.db().await,
+            &state_id,
+            &pkce.verifier,
+            &endpoints.token_endpoint,
+            audience,
+            &redirect_uri,
+        )
+        .await
+        {
+            tracing::error!(idp = %idp.name, %e, "Failed to store pending SSO login");
+            return None;
+        }
+
+        let url = format!(
+            "{authz}{separator}response_type=code&client_id={audience}&redirect_uri={redirect_uri}&state={state_id}&scope={encoded_scopes}&code_challenge={challenge}&code_challenge_method=S256",
+            authz = endpoints.authorization_endpoint,
+            challenge = pkce.challenge,
+        );
+        (url, "authorization_code")
+    } else {
+        // Legacy implicit flow: redirect straight back to /portal, where
+        // checkSsoCallback() extracts id_token from the URL fragment.
+        let redirect_uri = format!("{scheme}://{host}/portal");
+        let nonce = format!("{}", chrono::Utc::now().timestamp());
+        let url = format!(
+            "{authz}{separator}response_type=id_token&client_id={audience}&redirect_uri={redirect_uri}&nonce={nonce}&scope={encoded_scopes}",
+            authz = endpoints.authorization_endpoint,
+        );
+        (url, "implicit")
+    };
 
     Some(serde_json::json!({
         "name": idp.name,
-        "flow_type": "implicit",
+        "flow_type": flow_type,
         "login_url": login_url,
     }))
 }

--- a/src/api/sso_login.rs
+++ b/src/api/sso_login.rs
@@ -1,0 +1,158 @@
+//! Portal SSO login: authorization-code + PKCE, server-side exchange.
+//!
+//! The portal has no per-request server state of its own (unlike the CLI flow, which
+//! already tracks a session UUID for polling) — `build_provider_info` mints one here,
+//! keyed by a random `state` value, stored in `proxy_settings` (survives a callback
+//! landing on a different pod than the one that issued the login_url: CCAG runs 2+
+//! replicas behind a Service, requests aren't sticky).
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use axum::{
+    extract::{Query, State},
+    response::{IntoResponse, Redirect, Response},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::auth;
+use crate::proxy::GatewayState;
+
+const LOGIN_TTL_SECS: i64 = 300; // 5 minutes — one login attempt's worth of clock skew
+
+#[derive(Serialize, Deserialize)]
+struct PendingSsoLogin {
+    verifier: String,
+    token_endpoint: String,
+    audience: String,
+    redirect_uri: String,
+}
+
+fn login_key(state_id: &str) -> String {
+    format!("sso_login:{}", state_id)
+}
+
+/// Store the PKCE verifier + IDP details for one in-flight portal login, keyed by `state`.
+pub(super) async fn create_pending(
+    pool: &sqlx::PgPool,
+    state_id: &str,
+    verifier: &str,
+    token_endpoint: &str,
+    audience: &str,
+    redirect_uri: &str,
+) -> anyhow::Result<()> {
+    let value = serde_json::to_string(&PendingSsoLogin {
+        verifier: verifier.to_string(),
+        token_endpoint: token_endpoint.to_string(),
+        audience: audience.to_string(),
+        redirect_uri: redirect_uri.to_string(),
+    })?;
+    sqlx::query(
+        r#"INSERT INTO proxy_settings (key, value, updated_at)
+           VALUES ($1, $2, now())
+           ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = now()"#,
+    )
+    .bind(login_key(state_id))
+    .bind(value)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Fetch and delete (single-use) the pending login for `state`. `None` if missing,
+/// expired, or already consumed — all treated the same by the caller (reject).
+async fn take_pending(pool: &sqlx::PgPool, state_id: &str) -> Option<PendingSsoLogin> {
+    let row: Option<(String, chrono::DateTime<chrono::Utc>)> =
+        sqlx::query_as("SELECT value, updated_at FROM proxy_settings WHERE key = $1")
+            .bind(login_key(state_id))
+            .fetch_optional(pool)
+            .await
+            .ok()?;
+    let (value, updated_at) = row?;
+
+    // Always delete on read — a `state` is single-use whether it succeeds or not,
+    // so a replayed callback can never redeem the same verifier twice.
+    let _ = sqlx::query("DELETE FROM proxy_settings WHERE key = $1")
+        .bind(login_key(state_id))
+        .execute(pool)
+        .await;
+
+    if (chrono::Utc::now() - updated_at).num_seconds() > LOGIN_TTL_SECS {
+        return None;
+    }
+    serde_json::from_str(&value).ok()
+}
+
+/// Clean up abandoned portal logins (user never completed the redirect).
+pub(super) async fn cleanup_expired(pool: &sqlx::PgPool) {
+    let _ = sqlx::query(
+        "DELETE FROM proxy_settings WHERE key LIKE 'sso_login:%' AND updated_at < now() - interval '5 minutes'",
+    )
+    .execute(pool)
+    .await;
+}
+
+#[derive(Deserialize)]
+pub struct SsoCallbackParams {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+}
+
+/// GET /auth/sso/callback
+/// Redeems the authorization code server-side (back-channel, PKCE-bound), validates
+/// the resulting id_token, issues a gateway session token, and redirects the browser
+/// back to the portal with THAT token — the external IDP token never reaches the browser.
+pub async fn sso_callback(
+    State(state): State<Arc<GatewayState>>,
+    Query(params): Query<SsoCallbackParams>,
+) -> Response {
+    if let Some(err) = params.error {
+        tracing::warn!(%err, "IDP returned an error on portal SSO callback");
+        return Redirect::temporary("/portal?sso_error=1").into_response();
+    }
+
+    let (Some(code), Some(state_id)) = (params.code, params.state) else {
+        return Redirect::temporary("/portal?sso_error=1").into_response();
+    };
+
+    let pool = state.db().await;
+    let Some(pending) = take_pending(&pool, &state_id).await else {
+        return Redirect::temporary("/portal?sso_error=1").into_response();
+    };
+
+    let id_token = match auth::oidc::exchange_code_for_id_token(
+        &state.http_client,
+        &pending.token_endpoint,
+        &code,
+        &pending.redirect_uri,
+        &pending.audience,
+        &pending.verifier,
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(%e, "Portal SSO code exchange failed");
+            return Redirect::temporary("/portal?sso_error=1").into_response();
+        }
+    };
+
+    let session_token = match state.idp_validator.validate_token(&id_token).await {
+        Ok(identity) => {
+            let ttl = state.session_token_ttl_hours.load(Ordering::Relaxed) as u64;
+            let token = auth::session::issue(&state.session_signing_key, &identity, ttl);
+            tracing::info!(sub = %identity.sub, ttl_hours = ttl, "Issued gateway session token (portal SSO)");
+            token
+        }
+        Err(e) => {
+            tracing::warn!(%e, "IDP token validation failed during portal SSO login");
+            return Redirect::temporary("/portal?sso_error=1").into_response();
+        }
+    };
+
+    // Fragment (not query) so the token is never sent in a Referer header or logged
+    // server-side — same rationale implicit flow used, just carrying our own
+    // narrowly-scoped, revocable session token instead of the external id_token.
+    Redirect::temporary(&format!("/portal#session_token={session_token}")).into_response()
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,4 +1,5 @@
 pub mod oidc;
+pub mod pkce;
 pub mod session;
 
 use std::collections::HashMap;

--- a/src/auth/oidc.rs
+++ b/src/auth/oidc.rs
@@ -25,6 +25,13 @@ pub struct IdpConfig {
     /// OIDC scopes to request during login redirect.
     /// None or empty = "openid" (safe default). Example: "openid email profile".
     pub scopes: Option<String>,
+    /// Which OAuth flow to use for CCAG's own portal/CLI sign-in redirects.
+    /// "authorization_code" (recommended, PKCE) or "implicit" (legacy, kept for
+    /// IDPs that don't support auth-code). "device_code" is stored but not
+    /// implemented for these paths. Defaults to "device_code" at the DB layer
+    /// (schema default); anything other than "authorization_code" falls back
+    /// to the existing implicit-flow behavior.
+    pub flow_type: String,
 }
 
 impl IdpConfig {
@@ -34,6 +41,10 @@ impl IdpConfig {
         let jwks_url = std::env::var("OIDC_JWKS_URL").ok();
         let user_claim = std::env::var("OIDC_USER_CLAIM").ok();
         let scopes = std::env::var("OIDC_SCOPES").ok();
+        // "authorization_code" (PKCE) is the secure default; set OIDC_FLOW_TYPE=implicit
+        // only for an IDP that genuinely can't do auth-code (rare, deprecated in OAuth 2.1).
+        let flow_type =
+            std::env::var("OIDC_FLOW_TYPE").unwrap_or_else(|_| "authorization_code".to_string());
 
         // Derive a friendly name from the issuer URL, or allow explicit override
         let name = std::env::var("OIDC_NAME").unwrap_or_else(|_| {
@@ -58,6 +69,7 @@ impl IdpConfig {
             allowed_domains: None,
             user_claim,
             scopes,
+            flow_type,
         })
     }
 
@@ -72,6 +84,7 @@ impl IdpConfig {
             allowed_domains: row.allowed_domains.clone(),
             user_claim: row.user_claim.clone(),
             scopes: row.scopes.clone(),
+            flow_type: row.flow_type.clone(),
         }
     }
 
@@ -81,6 +94,90 @@ impl IdpConfig {
             let base = self.issuer.trim_end_matches('/');
             format!("{base}/.well-known/openid-configuration")
         })
+    }
+}
+
+/// The two endpoints needed to run an authorization-code redirect + back-channel exchange.
+pub struct OidcEndpoints {
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+}
+
+/// Fetch `authorization_endpoint` and `token_endpoint` from the IDP's OIDC discovery document.
+pub async fn discover_endpoints(
+    http_client: &reqwest::Client,
+    issuer: &str,
+) -> Option<OidcEndpoints> {
+    let discovery_url = format!(
+        "{}/.well-known/openid-configuration",
+        issuer.trim_end_matches('/')
+    );
+
+    let doc = match http_client.get(&discovery_url).send().await {
+        Ok(resp) => match resp.json::<serde_json::Value>().await {
+            Ok(doc) => doc,
+            Err(e) => {
+                tracing::error!(%issuer, %e, "Failed to parse OIDC discovery document");
+                return None;
+            }
+        },
+        Err(e) => {
+            tracing::error!(%issuer, %e, "Failed to fetch OIDC discovery document");
+            return None;
+        }
+    };
+
+    let authorization_endpoint = doc["authorization_endpoint"].as_str()?.to_string();
+    let token_endpoint = match doc["token_endpoint"].as_str() {
+        Some(ep) => ep.to_string(),
+        None => {
+            tracing::error!(%issuer, "No token_endpoint in OIDC discovery document");
+            return None;
+        }
+    };
+
+    Some(OidcEndpoints {
+        authorization_endpoint,
+        token_endpoint,
+    })
+}
+
+/// Redeem an authorization code (+ PKCE verifier) for the IDP's `id_token`.
+/// Back-channel, server-to-server — the code/verifier/token never touch browser JS.
+/// Public client (no `client_secret`): the same trust model our CLI/Desktop
+/// consumers of this Keycloak client already use.
+pub async fn exchange_code_for_id_token(
+    http_client: &reqwest::Client,
+    token_endpoint: &str,
+    code: &str,
+    redirect_uri: &str,
+    client_id: &str,
+    code_verifier: &str,
+) -> anyhow::Result<String> {
+    let params = [
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("client_id", client_id),
+        ("code_verifier", code_verifier),
+    ];
+
+    let resp = http_client
+        .post(token_endpoint)
+        .form(&params)
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("token endpoint returned {status}: {body}");
+    }
+
+    let body: serde_json::Value = resp.json().await?;
+    match body["id_token"].as_str() {
+        Some(t) => Ok(t.to_string()),
+        None => anyhow::bail!("token endpoint response had no id_token"),
     }
 }
 
@@ -509,6 +606,7 @@ mod tests {
             allowed_domains: None,
             user_claim: None,
             scopes: None,
+            flow_type: "authorization_code".to_string(),
         };
 
         validator.load_idps(vec![config]).await;
@@ -684,6 +782,7 @@ mod tests {
                 allowed_domains: None,
                 user_claim: None,
                 scopes: None,
+                flow_type: "authorization_code".to_string(),
             },
             IdpConfig {
                 name: "IDP-B".to_string(),
@@ -695,6 +794,7 @@ mod tests {
                 allowed_domains: None,
                 user_claim: None,
                 scopes: None,
+                flow_type: "authorization_code".to_string(),
             },
         ];
         validator.load_idps(configs).await;
@@ -768,6 +868,7 @@ mod tests {
             allowed_domains: None,
             user_claim: None,
             scopes: None,
+            flow_type: "authorization_code".to_string(),
         };
         validator.load_idps(vec![config]).await;
 
@@ -810,6 +911,7 @@ mod tests {
             allowed_domains: Some(vec!["@allowed.com".to_string()]),
             user_claim: None,
             scopes: None,
+            flow_type: "authorization_code".to_string(),
         };
         validator.load_idps(vec![config]).await;
         {
@@ -866,6 +968,7 @@ mod tests {
             allowed_domains: None,
             user_claim: None,
             scopes: None,
+            flow_type: "authorization_code".to_string(),
         };
         validator.load_idps(vec![config]).await;
         {
@@ -903,6 +1006,7 @@ mod tests {
             allowed_domains: None,
             user_claim: None,
             scopes: None,
+            flow_type: "authorization_code".to_string(),
         };
         validator.load_idps(vec![config.clone()]).await;
         {
@@ -934,6 +1038,7 @@ mod tests {
             allowed_domains: None,
             user_claim: None,
             scopes: None,
+            flow_type: "authorization_code".to_string(),
         };
         assert_eq!(
             config.effective_jwks_url(),
@@ -953,6 +1058,7 @@ mod tests {
             allowed_domains: None,
             user_claim: None,
             scopes: None,
+            flow_type: "authorization_code".to_string(),
         };
         assert_eq!(
             config.effective_jwks_url(),
@@ -1032,6 +1138,7 @@ mod tests {
             allowed_domains: None,
             user_claim: user_claim.map(String::from),
             scopes: scopes.map(String::from),
+            flow_type: "authorization_code".to_string(),
         }
     }
 
@@ -1160,5 +1267,117 @@ mod tests {
             "openid email profile",
             "Issuer substring matching must be case-insensitive"
         );
+    }
+
+    // ── authorization-code + PKCE: discovery and back-channel exchange ──
+
+    #[tokio::test]
+    async fn discover_endpoints_reads_both_urls() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "authorization_endpoint": "https://idp.example.com/authorize",
+                "token_endpoint": "https://idp.example.com/token",
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let endpoints = discover_endpoints(&client, &mock_server.uri())
+            .await
+            .unwrap();
+        assert_eq!(
+            endpoints.authorization_endpoint,
+            "https://idp.example.com/authorize"
+        );
+        assert_eq!(endpoints.token_endpoint, "https://idp.example.com/token");
+    }
+
+    #[tokio::test]
+    async fn discover_endpoints_none_when_token_endpoint_missing() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "authorization_endpoint": "https://idp.example.com/authorize",
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        assert!(
+            discover_endpoints(&client, &mock_server.uri())
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn exchange_code_for_id_token_posts_form_and_extracts_token() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .and(body_string_contains("grant_type=authorization_code"))
+            .and(body_string_contains("code=abc123"))
+            .and(body_string_contains("code_verifier=the-verifier"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "id_token": "the.id.token" })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let token_endpoint = format!("{}/token", mock_server.uri());
+        let id_token = exchange_code_for_id_token(
+            &client,
+            &token_endpoint,
+            "abc123",
+            "https://ccag.example.com/auth/sso/callback",
+            "ccag",
+            "the-verifier",
+        )
+        .await
+        .unwrap();
+        assert_eq!(id_token, "the.id.token");
+    }
+
+    #[tokio::test]
+    async fn exchange_code_for_id_token_errors_on_non_success() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_json(serde_json::json!({ "error": "invalid_grant" })),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let token_endpoint = format!("{}/token", mock_server.uri());
+        let result = exchange_code_for_id_token(
+            &client,
+            &token_endpoint,
+            "expired-code",
+            "https://ccag.example.com/auth/sso/callback",
+            "ccag",
+            "verifier",
+        )
+        .await;
+        assert!(result.is_err());
     }
 }

--- a/src/auth/pkce.rs
+++ b/src/auth/pkce.rs
@@ -1,0 +1,57 @@
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use sha2::{Digest, Sha256};
+
+/// A PKCE (RFC 7636) verifier/challenge pair for one login attempt.
+/// `verifier` is kept server-side only; `challenge` is the value sent to the IDP.
+pub struct PkceChallenge {
+    pub verifier: String,
+    pub challenge: String,
+}
+
+/// Generate a fresh PKCE pair using the S256 challenge method.
+pub fn generate() -> PkceChallenge {
+    let bytes: [u8; 32] = rand::random();
+    let verifier = URL_SAFE_NO_PAD.encode(bytes);
+
+    let digest = Sha256::digest(verifier.as_bytes());
+    let challenge = URL_SAFE_NO_PAD.encode(digest);
+
+    PkceChallenge {
+        verifier,
+        challenge,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifier_is_43_to_128_chars_unreserved() {
+        // RFC 7636 §4.1: 43-128 chars from [A-Z a-z 0-9 - . _ ~]. Base64url (no pad) of
+        // 32 random bytes is 43 chars and satisfies the charset.
+        let pkce = generate();
+        assert_eq!(pkce.verifier.len(), 43);
+        assert!(
+            pkce.verifier
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        );
+    }
+
+    #[test]
+    fn challenge_is_sha256_of_verifier() {
+        let pkce = generate();
+        let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(pkce.verifier.as_bytes()));
+        assert_eq!(pkce.challenge, expected);
+    }
+
+    #[test]
+    fn each_call_is_random() {
+        let a = generate();
+        let b = generate();
+        assert_ne!(a.verifier, b.verifier);
+        assert_ne!(a.challenge, b.challenge);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1001,7 +1001,7 @@ async fn seed_env_idp(pool: &sqlx::PgPool, env_idp: &auth::oidc::IdpConfig) {
         None,
         env_idp.audience.as_deref(),
         env_idp.jwks_url.as_deref(),
-        "implicit",
+        &env_idp.flow_type,
         env_idp.auto_provision,
         &env_idp.default_role,
         None,

--- a/static/index.html
+++ b/static/index.html
@@ -3282,9 +3282,14 @@ function doSsoLogin(loginUrl) {
 function checkSsoCallback() {
   const hash = window.location.hash;
   const search = window.location.search;
-  const tokenSource = hash.includes('id_token=') ? hash : search.includes('id_token=') ? search : '';
-  if (tokenSource) {
-    const token = tokenSource.split('id_token=')[1].split('&')[0];
+
+  // authorization_code + PKCE path: /auth/sso/callback already redeemed the code
+  // server-side and hands back CCAG's OWN session token — the external IDP's
+  // id_token never reaches the browser. Fragment (not query), same rationale as
+  // implicit's token-in-fragment: never sent in Referer, never server-logged.
+  const sessionTokenSource = hash.includes('session_token=') ? hash : '';
+  if (sessionTokenSource) {
+    const token = sessionTokenSource.split('session_token=')[1].split('&')[0];
     if (token) {
       apiKey = token;
       localStorage.setItem('proxyApiKey', apiKey);
@@ -3293,6 +3298,31 @@ function checkSsoCallback() {
       return true;
     }
   }
+
+  // Legacy implicit-flow path (IDPs explicitly configured for it): the external
+  // id_token itself is the bearer credential, re-validated by the backend on
+  // every request.
+  const idTokenSource = hash.includes('id_token=') ? hash : search.includes('id_token=') ? search : '';
+  if (idTokenSource) {
+    const token = idTokenSource.split('id_token=')[1].split('&')[0];
+    if (token) {
+      apiKey = token;
+      localStorage.setItem('proxyApiKey', apiKey);
+      window.history.replaceState({}, '', window.location.pathname);
+      loginWithToken();
+      return true;
+    }
+  }
+
+  if (search.includes('sso_error=1')) {
+    window.history.replaceState({}, '', window.location.pathname);
+    const el = document.getElementById('auth-error');
+    if (el) {
+      el.textContent = 'Sign-in failed. Please try again.';
+      el.style.display = 'block';
+    }
+  }
+
   return false;
 }
 


### PR DESCRIPTION
Both of CCAG's own sign-in paths sent the browser to the IdP with `response_type=id_token`
(the OAuth implicit flow) and read the token straight out of the URL:

- **Portal SSO**: `build_provider_info` hard-coded the implicit authorize URL; the SPA's
  `checkSsoCallback()` parsed `#id_token=` and stored the raw external token as its own
  bearer credential.
- **CLI login** (`apiKeyHelper`): same shape, `redirect_uri=/auth/cli/callback`,
  client-side JS extracted the fragment and POSTed it to `/auth/cli/complete`.

Implicit was removed from the OAuth spec entirely in OAuth 2.1 — the identity token
travels in the URL, which means browser history, `Referer` headers, and any extension
with tab-reading access can see it.

## The fix

Authorization-code + PKCE (S256), server-side exchange — the code/verifier/token never
touch browser JS:

- **`src/auth/pkce.rs`** (new): RFC 7636 verifier/challenge generation.
- **`src/auth/oidc.rs`**: `discover_endpoints()` now also resolves `token_endpoint`
  (previously only `authorization_endpoint`); `exchange_code_for_id_token()` does the
  back-channel POST to the IdP (public client, no secret — same trust model any other
  consumer of this OIDC client already uses). `IdpConfig` gains `flow_type`.
- **`src/api/sso_login.rs`** (new): portal login state (PKCE verifier + IdP details)
  keyed by a random `state`, stored in `proxy_settings` — DB-backed because a
  multi-replica deployment can have the callback land on a different pod than the one
  that issued the `login_url`. New `GET /auth/sso/callback` redeems the code, validates
  via the existing `MultiIdpValidator`, issues CCAG's own session token, and redirects
  to `/portal#session_token=...` — the *external* id_token itself never reaches the
  browser.
- **`src/api/cli_auth.rs`**: same idea for the CLI flow. The stored session value needed
  an explicit `{"status": pending|complete}` shape — a bare non-empty verifier string
  would otherwise be indistinguishable from a completed token if `/auth/cli/poll` landed
  mid-flow (regression test included for exactly this). `cli_callback()` becomes a real
  server-side handler for the code path (no client-side JS at all); the old
  extract-and-POST page is kept as a fallback for any IdP still explicitly configured
  for implicit.
- **`static/index.html`**: `checkSsoCallback()` reads `session_token=` (ours) first,
  falls back to `id_token=` (legacy implicit, still supported per-IdP).

**Nothing breaks by default.** `flow_type` defaults to `authorization_code` for new
env-configured IdPs (`OIDC_FLOW_TYPE` to override); existing DB-configured IdPs keep
whatever `flow_type` they already have (schema default `device_code` falls through to
today's implicit behavior, unchanged) until an admin explicitly switches it via the
portal's Flow Type dropdown. The fix activates per-IdP, not repo-wide.

`base64` moved from `dev-dependencies` to a real dependency (`pkce.rs` needs it at
runtime, not just in tests). Patch bumps the gateway and CLI to `1.9.4`.

## Testing

Written and tested with **Claude Code** — build/clippy/fmt clean, 524/525 lib tests pass
(10 new: PKCE generation, endpoint discovery, code exchange, and — the one I was most
worried about getting subtly wrong — pending-vs-complete state discrimination for the CLI
poll race). The 1 failure
(`budget::notifications::tests::deliver_routes_to_webhook`) is a pre-existing, unrelated
timing flake on this machine (`duration_ms` truncates to whole milliseconds and can read
0 on a fast loopback mock) — confirmed it fails identically on a clean checkout of `main`,
nothing to do with this change.

Also live end-to-end verified against a real Keycloak IdP — both the portal and CLI
`apiKeyHelper` flows — on a separate staging deployment before porting this fix upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)