### PR TITLE
fix(infra): allowed_cidrs object format + expired filtering (1.9.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "ccag"
-version = "1.9.4"
+version = "1.9.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ccag-cli"
-version = "1.9.4"
+version = "1.9.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "ccag"
-version = "1.9.4"
+version = "1.9.5"
 edition = "2024"
 description = "Self-hosted API gateway that routes Claude Code through Amazon Bedrock"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccag-cli"
-version = "1.9.4"
+version = "1.9.5"
 edition = "2024"
 description = "CLI management tool for Claude Code AWS Gateway — manage keys, users, teams, and budgets"
 repository = "https://github.com/antkawam/claude-code-aws-gateway"

--- a/infra/app.ts
+++ b/infra/app.ts
@@ -36,5 +36,7 @@ new GatewayStack(app, stackName, {
   imageTag: app.node.tryGetContext('imageTag') || undefined,
   imageDigest: app.node.tryGetContext('imageDigest') || undefined,
   rdsIamAuth: app.node.tryGetContext('rdsIamAuth') === 'true' || envConfig.rds_iam_auth === true,
-  allowedCidrs: envConfig.allowed_cidrs || undefined,
+  allowedCidrs: (envConfig.allowed_cidrs || [])
+    .filter((e: any) => typeof e === 'string' || !e.expires || new Date(e.expires) > new Date())
+    .map((e: any) => typeof e === 'string' ? e : e.cidr),
 });


### PR DESCRIPTION
## Problem

The prod deploy of v1.9.4 (the char-boundary 502 fix) **failed at CDK** with:

\`\`\`
SecurityGroupIngress/N/CidrIp: expected type: String, found: JSONObject
\`\`\`

Prod rolled back cleanly (no outage) but the 502 fix never landed.

Root cause: \`ccag-allowlist\` now writes \`environments.json\` \`allowed_cidrs\` entries as objects (\`{ cidr, description, expires? }\`), but \`infra/app.ts\` passed them straight to the \`allowedCidrs\` stack prop, so CloudFormation received JSONObjects where it wants CIDR strings. Infra drift — no prod deploy happened between the format change (~Aug 29) and now to catch it.

## Fix

Map object entries to their \`.cidr\` string and filter out entries whose \`expires\` timestamp has passed; string entries pass through unchanged.

\`\`\`ts
allowedCidrs: (envConfig.allowed_cidrs || [])
  .filter((e: any) => typeof e === 'string' || !e.expires || new Date(e.expires) > new Date())
  .map((e: any) => typeof e === 'string' ? e : e.cidr),
\`\`\`

## Validation

\`cdk synth -c environment=prod\` — the synthesized \`SecurityGroupIngress\` now renders \`CidrIp\` as plain strings and \`FromPort\`/\`ToPort\` as integers. The CloudFormation type error will not recur. (CI does not run cdk synth, so this was validated locally.)

## New runtime I/O

None new. Changes which CIDR strings populate the existing ALB security group ingress (drops expired allowlist entries on deploy). No new AWS API calls, env vars, or dependencies.

## Note

Bundles the already-merged-but-never-deployed v1.9.4 char-boundary 502 fix; ships as 1.9.5.