### PR TITLE
feat(mcpgov): MCP and tool governance at the gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,32 @@ curl -fsSL https://your-gateway/setup | sh   # one command, fully configured
 - Rate limiting: per-key sliding window rate limiter
 - Spend tracking: async batch writes to Postgres with per-key analytics
 
+### MCP & Tool Governance
+
+Control which MCP servers and tools developers can actually use, enforced at the gateway instead of in client-side config a developer can edit.
+
+- **Auto-discovered catalog**: MCP servers and tools are recorded as they appear in live traffic, each with an approval status (pending, approved, denied). Nothing has to be registered by hand before it shows up.
+- **Policies resolved global → team → user**: allow and deny glob patterns matched against tool names (`mcp__github__*`), plus a default action for tools the catalog has no decision on yet.
+- **Three rollout modes**: `observe` decides and logs but never modifies a request, `warn` allows and flags, `enforce` actually strips denied tools. Start in observe, read the audit log, then tighten.
+- **Scoped to MCP by default**: `mcp_only` leaves built-in tools (Read, Write, Bash) untouched. `all_tools` governs those too.
+- **Enforced in both directions**: denied tool definitions are removed from the request, denied `tool_use` blocks are refused on the way back including under streaming, and denied calls are scrubbed from the conversation history so the model does not learn to retry them.
+- **Simulator**: answer "what would this user actually see?" without sending a request.
+- **Audit trail**: every non-allow decision recorded with user, team, tool, mode, and reason.
+
+Manage it from the admin portal or the CLI:
+
+```bash
+ccag mcp status                                   # current posture and catalog counts
+ccag mcp servers                                  # discovered MCP servers
+ccag mcp set-server github --status approved
+ccag mcp set-policy --scope global --mode enforce --deny 'mcp__*__delete_*'
+ccag mcp set-policy --scope team --ref <team-uuid> --mode enforce --allow 'mcp__github__*'
+ccag mcp simulate --user dev@example.com --denied-only
+ccag mcp events --decision blocked
+```
+
+Enforcement lives in the request path, so it applies however the developer configured their client. That is deliberate: Claude Code's own MCP controls are client-side, and server-managed settings are skipped entirely for any session with a custom `ANTHROPIC_BASE_URL` — which is how CCAG is always used.
+
 ### Authentication
 
 Three-tier authentication for different use cases:
@@ -151,6 +177,7 @@ A built-in single-page application at `/portal` for:
 - Team administration
 - Identity provider configuration with SCIM provisioning setup
 - Gateway settings
+- MCP governance: server and tool catalog, policy editor, simulator, and audit log
 - Analytics dashboard with 4 tabs:
   - Spend: timeseries by team, spend by team/model/user, budget status, OLS cost forecast
   - Activity: active users over time (new vs returning), hourly request heatmap

--- a/cli/src/commands/mcp.rs
+++ b/cli/src/commands/mcp.rs
@@ -1,0 +1,523 @@
+//! `ccag mcp` — MCP / tool governance from the command line.
+//!
+//! Every subcommand talks to the `/admin/mcpgov/*` API, so scripting and GitOps use
+//! exactly the same surface the portal does.
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::config::AdminClient;
+use crate::util;
+
+#[derive(Subcommand)]
+pub enum McpCommands {
+    /// Show the current governance posture and catalog counts
+    Status,
+
+    /// List discovered MCP servers
+    Servers,
+
+    /// List discovered tools
+    Tools {
+        /// Filter by status: inherit, approved, denied
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Filter by MCP server name
+        #[arg(long)]
+        server: Option<String>,
+
+        /// Maximum rows to return
+        #[arg(long, default_value = "200")]
+        limit: i64,
+    },
+
+    /// Approve, deny, or reset an MCP server
+    SetServer {
+        /// Server name (the `<server>` in `mcp__<server>__<tool>`)
+        server: String,
+
+        /// New status: approved, denied, pending
+        #[arg(long)]
+        status: String,
+
+        /// Optional operator note
+        #[arg(long)]
+        notes: Option<String>,
+    },
+
+    /// Add a server to the catalog before it has been seen in traffic
+    AddServer {
+        /// Server name
+        server: String,
+
+        /// Initial status
+        #[arg(long, default_value = "approved")]
+        status: String,
+
+        /// Optional operator note
+        #[arg(long)]
+        notes: Option<String>,
+    },
+
+    /// Approve, deny, or reset a single tool
+    SetTool {
+        /// Full tool name, e.g. mcp__github__create_issue
+        tool: String,
+
+        /// New status: approved, denied, inherit
+        #[arg(long)]
+        status: String,
+    },
+
+    /// Set the same status on every tool of one server
+    BulkSetTools {
+        /// Server name
+        server: String,
+
+        /// New status: approved, denied, inherit
+        #[arg(long)]
+        status: String,
+    },
+
+    /// List policies
+    Policies,
+
+    /// Create or update a policy (upsert, keyed on scope + reference)
+    SetPolicy {
+        /// Scope: global, team, user
+        #[arg(long, default_value = "global")]
+        scope: String,
+
+        /// Team UUID or user email. Required unless scope is global.
+        #[arg(long = "ref")]
+        scope_ref: Option<String>,
+
+        /// Mode: observe, warn, enforce
+        #[arg(long, default_value = "observe")]
+        mode: String,
+
+        /// What to do with tools that are not in the catalog: allow, deny
+        #[arg(long, default_value = "allow")]
+        default_action: String,
+
+        /// Which tools the policy governs: mcp_only, all_tools
+        #[arg(long, default_value = "mcp_only")]
+        applies_to: String,
+
+        /// Allow glob, repeatable. Non-empty makes this an exclusive allowlist.
+        #[arg(long = "allow")]
+        allow: Vec<String>,
+
+        /// Deny glob, repeatable. Deny always wins.
+        #[arg(long = "deny")]
+        deny: Vec<String>,
+
+        /// Create the policy disabled
+        #[arg(long)]
+        disabled: bool,
+    },
+
+    /// Delete a team or user policy (the global policy cannot be deleted)
+    DeletePolicy {
+        /// Policy UUID
+        id: String,
+    },
+
+    /// Show what a given identity would actually be allowed to use
+    Simulate {
+        /// User identity (email)
+        #[arg(long)]
+        user: Option<String>,
+
+        /// Team UUID
+        #[arg(long)]
+        team: Option<String>,
+
+        /// Tool name to test, repeatable. Omit to test the whole catalog.
+        #[arg(long = "tool")]
+        tools: Vec<String>,
+
+        /// Only print denied tools
+        #[arg(long)]
+        denied_only: bool,
+    },
+
+    /// Show recent policy decisions
+    Events {
+        /// Filter by decision: blocked, would_block, warned
+        #[arg(long)]
+        decision: Option<String>,
+
+        /// Filter by user identity
+        #[arg(long)]
+        user: Option<String>,
+
+        /// Maximum rows to return
+        #[arg(long, default_value = "50")]
+        limit: i64,
+    },
+}
+
+const SERVER_STATUSES: [&str; 3] = ["approved", "denied", "pending"];
+const TOOL_STATUSES: [&str; 3] = ["approved", "denied", "inherit"];
+
+fn validate(value: &str, allowed: &[&str], what: &str) -> Result<()> {
+    if !allowed.contains(&value) {
+        anyhow::bail!(
+            "invalid {what} `{value}` — expected one of: {}",
+            allowed.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn s(v: &serde_json::Value) -> &str {
+    v.as_str().unwrap_or("-")
+}
+
+fn n(v: &serde_json::Value) -> i64 {
+    v.as_i64().unwrap_or(0)
+}
+
+pub async fn run(cmd: McpCommands, url: Option<String>, token: Option<String>) -> Result<()> {
+    let client = AdminClient::from_options(url, token).await?;
+
+    match cmd {
+        McpCommands::Status => {
+            let resp = client.get("/admin/mcpgov/summary").await?;
+            let sum = &resp["summary"];
+            let gp = &resp["global_policy"];
+
+            eprintln!("Posture");
+            eprintln!("  mode              {}", s(&gp["mode"]));
+            eprintln!("  unknown tools     {}", s(&gp["default_action"]));
+            eprintln!("  applies to        {}", s(&gp["applies_to"]));
+            eprintln!(
+                "  patterns          {} allow, {} deny",
+                gp["allow_patterns"].as_array().map_or(0, |a| a.len()),
+                gp["deny_patterns"].as_array().map_or(0, |a| a.len()),
+            );
+            eprintln!();
+            eprintln!("Catalog");
+            eprintln!(
+                "  servers           {} total ({} pending, {} approved, {} denied)",
+                n(&sum["servers_total"]),
+                n(&sum["servers_pending"]),
+                n(&sum["servers_approved"]),
+                n(&sum["servers_denied"]),
+            );
+            eprintln!(
+                "  tools             {} total ({} undecided, {} approved, {} denied)",
+                n(&sum["tools_total"]),
+                n(&sum["tools_pending"]),
+                n(&sum["tools_approved"]),
+                n(&sum["tools_denied"]),
+            );
+            eprintln!();
+            eprintln!("Last 24h");
+            eprintln!("  blocked           {}", n(&sum["events_24h_blocked"]));
+            eprintln!("  would block       {}", n(&sum["events_24h_would_block"]));
+            eprintln!("  warned            {}", n(&sum["events_24h_warned"]));
+
+            let drops = &resp["buffer_drops"];
+            if n(&drops["discovery"]) > 0 || n(&drops["events"]) > 0 {
+                util::warn(&format!(
+                    "write buffers dropped {} discovery and {} audit items under load",
+                    n(&drops["discovery"]),
+                    n(&drops["events"]),
+                ));
+            }
+
+            if s(&gp["mode"]) == "observe" {
+                util::info("observe mode: nothing is being stripped yet");
+            }
+        }
+
+        McpCommands::Servers => {
+            let resp = client.get("/admin/mcpgov/servers").await?;
+            let rows = resp["servers"].as_array().cloned().unwrap_or_default();
+            if rows.is_empty() {
+                eprintln!("No MCP servers discovered yet.");
+                return Ok(());
+            }
+            eprintln!("{:<30}  {:<10}  LAST SEEN", "SERVER", "STATUS");
+            eprintln!("{}", "-".repeat(70));
+            for r in &rows {
+                println!(
+                    "{:<30}  {:<10}  {}",
+                    s(&r["server_name"]),
+                    s(&r["status"]),
+                    s(&r["last_seen"]),
+                );
+            }
+        }
+
+        McpCommands::Tools {
+            status,
+            server,
+            limit,
+        } => {
+            let mut path = format!("/admin/mcpgov/tools?limit={limit}");
+            if let Some(st) = &status {
+                validate(st, &TOOL_STATUSES, "status")?;
+                path.push_str(&format!("&status={st}"));
+            }
+            if let Some(sv) = &server {
+                path.push_str(&format!("&server={sv}"));
+            }
+
+            let resp = client.get(&path).await?;
+            let rows = resp["tools"].as_array().cloned().unwrap_or_default();
+            if rows.is_empty() {
+                eprintln!("No tools matched.");
+                return Ok(());
+            }
+            eprintln!("{:<50}  {:<10}  {:>6}  SERVER", "TOOL", "STATUS", "SEEN");
+            eprintln!("{}", "-".repeat(90));
+            for r in &rows {
+                println!(
+                    "{:<50}  {:<10}  {:>6}  {}",
+                    s(&r["tool_name"]),
+                    s(&r["status"]),
+                    n(&r["seen_count"]),
+                    r["server_name"].as_str().unwrap_or("(builtin)"),
+                );
+            }
+        }
+
+        McpCommands::SetServer {
+            server,
+            status,
+            notes,
+        } => {
+            validate(&status, &SERVER_STATUSES, "status")?;
+            let mut body = serde_json::json!({ "server_name": server, "status": status });
+            if let Some(nt) = notes {
+                body["notes"] = serde_json::json!(nt);
+            }
+            client.put("/admin/mcpgov/servers/status", &body).await?;
+            util::success(&format!("server {server} set to {status}"));
+        }
+
+        McpCommands::AddServer {
+            server,
+            status,
+            notes,
+        } => {
+            validate(&status, &SERVER_STATUSES, "status")?;
+            let mut body = serde_json::json!({ "server_name": server, "status": status });
+            if let Some(nt) = notes {
+                body["notes"] = serde_json::json!(nt);
+            }
+            client.post("/admin/mcpgov/servers", &body).await?;
+            util::success(&format!("server {server} added as {status}"));
+        }
+
+        McpCommands::SetTool { tool, status } => {
+            validate(&status, &TOOL_STATUSES, "status")?;
+            client
+                .put(
+                    "/admin/mcpgov/tools/status",
+                    &serde_json::json!({ "tool_name": tool, "status": status }),
+                )
+                .await?;
+            util::success(&format!("tool {tool} set to {status}"));
+        }
+
+        McpCommands::BulkSetTools { server, status } => {
+            validate(&status, &TOOL_STATUSES, "status")?;
+            let resp = client
+                .put(
+                    "/admin/mcpgov/servers/bulk-status",
+                    &serde_json::json!({ "server_name": server, "status": status }),
+                )
+                .await?;
+            util::success(&format!(
+                "{} tools of {server} set to {status}",
+                n(&resp["updated"])
+            ));
+        }
+
+        McpCommands::Policies => {
+            let resp = client.get("/admin/mcpgov/policies").await?;
+            let rows = resp["policies"].as_array().cloned().unwrap_or_default();
+            if rows.is_empty() {
+                eprintln!("No policies defined.");
+                return Ok(());
+            }
+            for r in &rows {
+                let scope = s(&r["scope"]);
+                let label = if scope == "global" {
+                    "global".to_string()
+                } else {
+                    format!("{scope}:{}", s(&r["scope_ref"]))
+                };
+                println!(
+                    "{}\n  id            {}\n  mode          {}\n  unknown tools {}\n  applies to    {}\n  enabled       {}",
+                    label,
+                    s(&r["id"]),
+                    s(&r["mode"]),
+                    s(&r["default_action"]),
+                    s(&r["applies_to"]),
+                    r["enabled"].as_bool().unwrap_or(false),
+                );
+                for (field, title) in [("allow_patterns", "allow"), ("deny_patterns", "deny")] {
+                    if let Some(list) = r[field].as_array()
+                        && !list.is_empty()
+                    {
+                        let joined: Vec<&str> = list.iter().map(s).collect();
+                        println!("  {title:<13} {}", joined.join(", "));
+                    }
+                }
+                println!();
+            }
+        }
+
+        McpCommands::SetPolicy {
+            scope,
+            scope_ref,
+            mode,
+            default_action,
+            applies_to,
+            allow,
+            deny,
+            disabled,
+        } => {
+            validate(&scope, &["global", "team", "user"], "scope")?;
+            validate(&mode, &["observe", "warn", "enforce"], "mode")?;
+            validate(&default_action, &["allow", "deny"], "default action")?;
+            validate(&applies_to, &["mcp_only", "all_tools"], "applies-to")?;
+
+            if scope != "global" && scope_ref.as_deref().unwrap_or("").trim().is_empty() {
+                anyhow::bail!("--ref is required when --scope is `{scope}`");
+            }
+
+            // Guard the one combination that silently disables every built-in tool.
+            if mode == "enforce"
+                && applies_to == "all_tools"
+                && default_action == "deny"
+                && allow.is_empty()
+            {
+                anyhow::bail!(
+                    "refusing to enforce all_tools with deny-by-default and no --allow patterns: \
+                     this would strip every built-in tool (Read, Write, Bash, ...). \
+                     Add --allow patterns, or use --applies-to mcp_only."
+                );
+            }
+
+            let body = serde_json::json!({
+                "scope": scope,
+                "scope_ref": scope_ref,
+                "mode": mode,
+                "default_action": default_action,
+                "applies_to": applies_to,
+                "allow_patterns": allow,
+                "deny_patterns": deny,
+                "enabled": !disabled,
+            });
+
+            client.put("/admin/mcpgov/policies", &body).await?;
+            util::success(&format!("policy saved for scope {scope}"));
+            if mode == "enforce" {
+                util::info("enforce mode is active: denied tool definitions will be stripped");
+            }
+        }
+
+        McpCommands::DeletePolicy { id } => {
+            client
+                .delete(&format!("/admin/mcpgov/policies/{id}"))
+                .await?;
+            util::success(&format!("policy {id} deleted"));
+        }
+
+        McpCommands::Simulate {
+            user,
+            team,
+            tools,
+            denied_only,
+        } => {
+            let mut body = serde_json::json!({ "tool_names": tools });
+            if let Some(u) = user {
+                body["user_identity"] = serde_json::json!(u);
+            }
+            if let Some(t) = team {
+                body["team_id"] = serde_json::json!(t);
+            }
+
+            let resp = client.post("/admin/mcpgov/simulate", &body).await?;
+            let eff = &resp["effective_policy"];
+            let counts = &resp["counts"];
+
+            eprintln!(
+                "Effective policy: mode={} unknown={} applies_to={} (from {})",
+                s(&eff["mode"]),
+                s(&eff["default_action"]),
+                s(&eff["applies_to"]),
+                s(&eff["decided_by"]),
+            );
+            eprintln!(
+                "{} allowed, {} denied",
+                n(&counts["allowed"]),
+                n(&counts["denied"])
+            );
+            eprintln!();
+
+            let rows = resp["results"].as_array().cloned().unwrap_or_default();
+            if rows.is_empty() {
+                eprintln!("Nothing to evaluate — the catalog is empty and no --tool was given.");
+                return Ok(());
+            }
+
+            eprintln!("{:<50}  {:<8}  WHY", "TOOL", "VERDICT");
+            eprintln!("{}", "-".repeat(100));
+            for r in &rows {
+                let allowed = r["allowed"].as_bool().unwrap_or(false);
+                if denied_only && allowed {
+                    continue;
+                }
+                println!(
+                    "{:<50}  {:<8}  {}",
+                    s(&r["tool_name"]),
+                    if allowed { "allow" } else { "DENY" },
+                    s(&r["reason"]),
+                );
+            }
+        }
+
+        McpCommands::Events {
+            decision,
+            user,
+            limit,
+        } => {
+            let mut path = format!("/admin/mcpgov/events?limit={limit}");
+            if let Some(d) = &decision {
+                validate(d, &["blocked", "would_block", "warned"], "decision")?;
+                path.push_str(&format!("&decision={d}"));
+            }
+            if let Some(u) = &user {
+                path.push_str(&format!("&user={u}"));
+            }
+
+            let resp = client.get(&path).await?;
+            let rows = resp["events"].as_array().cloned().unwrap_or_default();
+            if rows.is_empty() {
+                eprintln!("No policy decisions recorded.");
+                return Ok(());
+            }
+            eprintln!("{:<26}  {:<12}  {:<40}  USER", "WHEN", "DECISION", "TOOL");
+            eprintln!("{}", "-".repeat(110));
+            for r in &rows {
+                println!(
+                    "{:<26}  {:<12}  {:<40}  {}",
+                    s(&r["created_at"]),
+                    s(&r["decision"]),
+                    s(&r["tool_name"]),
+                    r["user_identity"].as_str().unwrap_or("-"),
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod endpoints;
 pub mod idps;
 pub mod keys;
 pub mod logs;
+pub mod mcp;
 pub mod scim;
 pub mod status;
 pub mod teams;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -76,6 +76,10 @@ enum Commands {
     #[command(subcommand)]
     Betas(commands::betas::BetasCommands),
 
+    /// Govern MCP servers and tool access
+    #[command(subcommand)]
+    Mcp(commands::mcp::McpCommands),
+
     /// Check deployment status and health
     Status(commands::status::StatusArgs),
 
@@ -132,6 +136,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Idps(cmd) => commands::idps::run(cmd, cli.url, cli.token).await,
         Commands::Scim(cmd) => commands::scim::run(cmd, cli.url, cli.token).await,
         Commands::Betas(cmd) => commands::betas::run(cmd, cli.url, cli.token).await,
+        Commands::Mcp(cmd) => commands::mcp::run(cmd, cli.url, cli.token).await,
         Commands::Status(args) => commands::status::run(args, cli.url).await,
         Commands::Logs(args) => commands::logs::run(args).await,
         Commands::Update => commands::update::run().await,

--- a/migrations/900_mcp_governance.sql
+++ b/migrations/900_mcp_governance.sql
@@ -1,0 +1,134 @@
+-- MCP / tool governance overlay.
+--
+-- Numbered 900 on purpose: upstream CCAG migrations advance from 013 upward, so a
+-- high offset guarantees this file never collides with an upstream version number
+-- when rebasing. Every table is prefixed `mcpgov_` for the same reason.
+--
+-- Three concerns:
+--   1. Catalog  (mcpgov_servers, mcpgov_tools) — what MCP servers/tools exist, auto
+--      discovered from live traffic, each with an approval status.
+--   2. Policy   (mcpgov_policies) — per-scope rules resolved global -> team -> user.
+--   3. Audit    (mcpgov_events) — every non-allow decision, for rollout visibility.
+
+-- ---------------------------------------------------------------------------
+-- Catalog
+-- ---------------------------------------------------------------------------
+
+-- One row per discovered MCP server, keyed on the `<server>` segment of the
+-- `mcp__<server>__<tool>` convention Claude Code uses to namespace MCP tools.
+CREATE TABLE IF NOT EXISTS mcpgov_servers (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    server_name TEXT NOT NULL UNIQUE,
+    -- pending: discovered, no decision yet (policy default_action applies)
+    -- approved / denied: explicit operator decision
+    status      TEXT NOT NULL DEFAULT 'pending',
+    notes       TEXT,
+    first_seen  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT mcpgov_servers_status_chk
+        CHECK (status IN ('pending', 'approved', 'denied'))
+);
+
+-- One row per discovered tool. `tool_name` is the full name as it appears in the
+-- request `tools` array (e.g. "mcp__github__create_issue", or "Bash" for builtins).
+-- `server_name` is NULL for non-MCP builtin tools.
+CREATE TABLE IF NOT EXISTS mcpgov_tools (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tool_name   TEXT NOT NULL UNIQUE,
+    server_name TEXT,
+    -- inherit: defer to the server's status
+    -- approved / denied: explicit per-tool override
+    status      TEXT NOT NULL DEFAULT 'inherit',
+    first_seen  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    seen_count  BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT mcpgov_tools_status_chk
+        CHECK (status IN ('inherit', 'approved', 'denied'))
+);
+
+CREATE INDEX IF NOT EXISTS mcpgov_tools_server_idx ON mcpgov_tools (server_name);
+CREATE INDEX IF NOT EXISTS mcpgov_tools_status_idx ON mcpgov_tools (status);
+
+-- ---------------------------------------------------------------------------
+-- Policy
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS mcpgov_policies (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- global | team | user
+    scope          TEXT NOT NULL,
+    -- NULL for global; team UUID (as text) for team; user email for user
+    scope_ref      TEXT,
+    -- observe: decide + log, never modify the request
+    -- warn:    allow, but log and flag on the response
+    -- enforce: actually strip denied tool definitions
+    mode           TEXT NOT NULL DEFAULT 'observe',
+    -- What to do with a tool the catalog has no decision for (status 'pending').
+    default_action TEXT NOT NULL DEFAULT 'allow',
+    -- mcp_only: only `mcp__*` tools are subject to policy (safe default — never
+    --           touches builtins like Read/Write/Bash)
+    -- all_tools: builtins are governed too
+    applies_to     TEXT NOT NULL DEFAULT 'mcp_only',
+    -- Glob patterns matched against the full tool name, e.g. "mcp__github__*".
+    allow_patterns JSONB NOT NULL DEFAULT '[]'::jsonb,
+    deny_patterns  JSONB NOT NULL DEFAULT '[]'::jsonb,
+    enabled        BOOLEAN NOT NULL DEFAULT true,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by     TEXT,
+    CONSTRAINT mcpgov_policies_scope_chk
+        CHECK (scope IN ('global', 'team', 'user')),
+    CONSTRAINT mcpgov_policies_mode_chk
+        CHECK (mode IN ('observe', 'warn', 'enforce')),
+    CONSTRAINT mcpgov_policies_default_action_chk
+        CHECK (default_action IN ('allow', 'deny')),
+    CONSTRAINT mcpgov_policies_applies_to_chk
+        CHECK (applies_to IN ('mcp_only', 'all_tools')),
+    -- A global policy must have no ref; team/user policies must have one.
+    CONSTRAINT mcpgov_policies_ref_chk CHECK (
+        (scope = 'global' AND scope_ref IS NULL)
+        OR (scope <> 'global' AND scope_ref IS NOT NULL AND scope_ref <> '')
+    )
+);
+
+-- Postgres treats NULLs as distinct in UNIQUE constraints, which would allow
+-- several 'global' rows. COALESCE collapses that so there is exactly one policy
+-- per (scope, ref).
+CREATE UNIQUE INDEX IF NOT EXISTS mcpgov_policies_scope_uniq
+    ON mcpgov_policies (scope, COALESCE(scope_ref, ''));
+
+-- Seed a global policy in the safest possible posture: observe mode (nothing is
+-- ever stripped) and allow-by-default. Operators tighten this once the catalog
+-- has been populated from real traffic.
+INSERT INTO mcpgov_policies (scope, scope_ref, mode, default_action, applies_to)
+SELECT 'global', NULL, 'observe', 'allow', 'mcp_only'
+WHERE NOT EXISTS (SELECT 1 FROM mcpgov_policies WHERE scope = 'global');
+
+-- ---------------------------------------------------------------------------
+-- Audit
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS mcpgov_events (
+    id            BIGSERIAL PRIMARY KEY,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    tool_name     TEXT NOT NULL,
+    server_name   TEXT,
+    -- blocked: tool definition was stripped (enforce mode)
+    -- would_block: policy said deny but mode was observe (dry run)
+    -- warned: policy said deny but mode was warn (allowed + flagged)
+    decision      TEXT NOT NULL,
+    mode          TEXT NOT NULL,
+    reason        TEXT NOT NULL,
+    -- Which scope produced the decision: global | team | user | catalog
+    decided_by    TEXT,
+    user_identity TEXT,
+    team_id       UUID,
+    key_id        UUID,
+    request_id    TEXT,
+    CONSTRAINT mcpgov_events_decision_chk
+        CHECK (decision IN ('blocked', 'would_block', 'warned'))
+);
+
+CREATE INDEX IF NOT EXISTS mcpgov_events_created_idx ON mcpgov_events (created_at DESC);
+CREATE INDEX IF NOT EXISTS mcpgov_events_tool_idx ON mcpgov_events (tool_name);
+CREATE INDEX IF NOT EXISTS mcpgov_events_user_idx ON mcpgov_events (user_identity);

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -485,7 +485,7 @@ pub async fn resolve_oidc_role(
 pub async fn messages(
     State(state): State<Arc<GatewayState>>,
     headers: HeaderMap,
-    Json(body): Json<request::AnthropicRequest>,
+    Json(mut body): Json<request::AnthropicRequest>,
 ) -> Response {
     let start = Instant::now();
     let request_id = format!("req_{}", uuid::Uuid::new_v4().simple());
@@ -684,6 +684,42 @@ pub async fn messages(
         .ok()
         .flatten()
         .unwrap_or_else(|| "enabled".to_string());
+
+    // ── mcpgov overlay: apply MCP/tool governance policy ──────────────────────
+    // Runs here because this is the last point where the request still owns its
+    // Anthropic-shaped `tools` array, and identity (`identity`, `team_id`) is already
+    // resolved. In observe/warn mode this only records; in enforce mode it strips
+    // denied tool definitions so the model never sees them. It never fails a request.
+    let mcpgov_ctx = crate::mcpgov::RequestContext {
+        user_identity: identity.user_identity.clone(),
+        team_id,
+        key_id: identity.key_id,
+        request_id: Some(request_id.clone()),
+    };
+    let mcpgov_outcome = crate::mcpgov::enforce(
+        &mut body.tools,
+        &mut body.tool_choice,
+        &mut body.messages,
+        &mcpgov_ctx,
+    )
+    .await;
+    if !mcpgov_outcome.is_noop() {
+        tracing::info!(
+            request_id = %request_id,
+            removed = mcpgov_outcome.removed.len(),
+            flagged = mcpgov_outcome.flagged.len(),
+            tool_choice_reset = mcpgov_outcome.tool_choice_reset,
+            history_tool_uses = mcpgov_outcome.history.tool_uses,
+            history_tool_results = mcpgov_outcome.history.tool_results,
+            "mcpgov: tool policy applied"
+        );
+    }
+    // Request-side filtering reduces the model's appetite for a denied tool but cannot
+    // guarantee it will not ask anyway, so the response is policed too. `None` when
+    // policy is not enforcing or nothing is deniable, which is the common case.
+    let mcpgov_guard =
+        crate::mcpgov::response::guard_for(&mcpgov_ctx, &mcpgov_outcome.removed).await;
+    // ──────────────────────────────────────────────────────────────────────────
 
     let (mut bedrock_model, mut bedrock_body, web_search_ctx) = request::translate(
         body,
@@ -906,6 +942,7 @@ pub async fn messages(
             endpoint_id,
             &websearch_mode,
             beta_retry_ctx,
+            mcpgov_guard.clone(),
         )
         .await
     } else if is_streaming {
@@ -921,6 +958,7 @@ pub async fn messages(
             start,
             endpoint_id,
             beta_retry_ctx,
+            mcpgov_guard.clone(),
         )
         .await
     } else {
@@ -936,6 +974,7 @@ pub async fn messages(
             start,
             endpoint_id,
             beta_retry_ctx,
+            mcpgov_guard.clone(),
         )
         .await
     };
@@ -984,6 +1023,7 @@ pub async fn messages(
                         start,
                         fb_endpoint_id,
                         None, // no beta retry on failover — already retried on primary
+                        mcpgov_guard.clone(),
                     )
                     .await
                 } else {
@@ -999,6 +1039,7 @@ pub async fn messages(
                         start,
                         fb_endpoint_id,
                         None, // no beta retry on failover — already retried on primary
+                        mcpgov_guard.clone(),
                     )
                     .await
                 };
@@ -1280,6 +1321,27 @@ fn extract_response_metadata(resp: &Value) -> (i32, i32, i32, i32, Option<String
     (input, output, cache_read, cache_write, stop_reason)
 }
 
+/// Refuse any denied tool calls in a finished response.
+///
+/// A no-op when the guard is `None`, which is the common case: policy has to be enforcing
+/// and something has to be deniable before a guard is built at all.
+fn mcpgov_refuse(
+    guard: &mut Option<crate::mcpgov::response::ResponseGuard>,
+    resp: &mut Value,
+    request_id: &str,
+) {
+    let Some(g) = guard.as_mut() else { return };
+    g.rewrite_non_streaming(resp);
+    if g.acted() {
+        let names: Vec<&str> = g.blocked().iter().map(|d| d.tool_name.as_str()).collect();
+        tracing::info!(
+            request_id = %request_id,
+            tools = ?names,
+            "mcpgov: refused tool calls in response"
+        );
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn handle_non_streaming(
     state: &GatewayState,
@@ -1293,7 +1355,12 @@ async fn handle_non_streaming(
     start: Instant,
     endpoint_id: Option<Uuid>,
     beta_ctx: Option<BetaRetryContext>,
+    mut mcpgov_guard: Option<crate::mcpgov::response::ResponseGuard>,
 ) -> Response {
+    // `request_id` is moved into the spend log before the response is assembled, so
+    // keep a copy for the refusal pass that runs after it.
+    let request_id_for_mcpgov = request_id.clone();
+
     let result = runtime_client
         .invoke_model()
         .model_id(bedrock_model)
@@ -1398,10 +1465,15 @@ async fn handle_non_streaming(
                                             endpoint_id,
                                         })
                                         .await;
-                                    let normalized = response::normalize_response(
+                                    let mut normalized = response::normalize_response(
                                         resp,
                                         original_model,
                                         Some(&state.model_cache),
+                                    );
+                                    mcpgov_refuse(
+                                        &mut mcpgov_guard,
+                                        &mut normalized,
+                                        &request_id_for_mcpgov,
                                     );
                                     Json(normalized).into_response()
                                 }
@@ -1485,11 +1557,12 @@ async fn handle_non_streaming(
                         })
                         .await;
 
-                    let normalized = response::normalize_response(
+                    let mut normalized = response::normalize_response(
                         resp,
                         original_model,
                         Some(&state.model_cache),
                     );
+                    mcpgov_refuse(&mut mcpgov_guard, &mut normalized, &request_id_for_mcpgov);
                     Json(normalized).into_response()
                 }
                 Err(e) => {
@@ -1568,6 +1641,7 @@ async fn handle_streaming(
     start: Instant,
     endpoint_id: Option<Uuid>,
     beta_ctx: Option<BetaRetryContext>,
+    mut mcpgov_guard: Option<crate::mcpgov::response::ResponseGuard>,
 ) -> Response {
     let result = runtime_client
         .invoke_model_with_response_stream()
@@ -1704,14 +1778,39 @@ async fn handle_streaming(
                                                     _ => {}
                                                 }
 
-                                                let normalized = streaming::normalize_stream_event(
+                                                let mut normalized = streaming::normalize_stream_event(
                                                     event_json,
                                                     &original_model,
                                                     Some(&model_cache),
                                                 );
 
+                                                // Refuse denied tool calls on the way out. A
+                                                // refused block is rewritten into text, its
+                                                // argument deltas are dropped, and the turn
+                                                // ends instead of asking the client to run
+                                                // something it is not allowed to run.
+                                                let mut follow_up = None;
+                                                if let Some(g) = mcpgov_guard.as_mut() {
+                                                    match g.on_stream_event(&mut normalized) {
+                                                        crate::mcpgov::response::StreamAction::Drop => continue,
+                                                        crate::mcpgov::response::StreamAction::ForwardThen(extra) => {
+                                                            follow_up = Some(extra);
+                                                        }
+                                                        crate::mcpgov::response::StreamAction::Forward => {}
+                                                    }
+                                                }
+
                                                 let sse_text = streaming::format_sse_event(&event_type, &normalized);
                                                 yield Ok::<_, std::convert::Infallible>(sse_text);
+
+                                                if let Some(extra) = follow_up {
+                                                    let extra_type = extra
+                                                        .get("type")
+                                                        .and_then(|t| t.as_str())
+                                                        .unwrap_or("content_block_delta")
+                                                        .to_string();
+                                                    yield Ok(streaming::format_sse_event(&extra_type, &extra));
+                                                }
                                             }
                                             Err(e) => {
                                                 tracing::warn!(%e, "Failed to parse stream chunk as JSON");
@@ -1845,7 +1944,12 @@ async fn handle_with_web_search(
     endpoint_id: Option<Uuid>,
     websearch_mode: &str,
     beta_retry_ctx: Option<BetaRetryContext>,
+    mut mcpgov_guard: Option<crate::mcpgov::response::ResponseGuard>,
 ) -> Response {
+    // `request_id` is moved into the spend log before the response is assembled, so keep
+    // a copy for the refusal pass that runs after it.
+    let request_id_for_mcpgov = request_id.clone();
+
     // Resolve search provider: "global" mode uses admin-configured global provider,
     // otherwise fall back to per-user provider (which defaults to DuckDuckGo).
     let search_provider = if websearch_mode == "global" {
@@ -2158,7 +2262,7 @@ async fn handle_with_web_search(
         .record(RequestLogEntry {
             key_id: identity.key_id,
             user_identity: identity.user_identity,
-            request_id,
+            request_id: request_id_for_mcpgov.clone(),
             model: original_model.to_string(),
             streaming: is_streaming,
             duration_ms: start.elapsed().as_millis() as i32,
@@ -2199,6 +2303,15 @@ async fn handle_with_web_search(
             "cache_read_input_tokens": total_cache_read,
         }
     });
+
+    // This path builds its own response, so it needs its own refusal pass. It runs
+    // non-streaming internally even for streaming clients, so one call covers both.
+    let mut final_response = final_response;
+    mcpgov_refuse(
+        &mut mcpgov_guard,
+        &mut final_response,
+        &request_id_for_mcpgov,
+    );
 
     if is_streaming {
         // Synthesize SSE events from the non-streaming response

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -266,6 +266,8 @@ pub fn router(state: Arc<GatewayState>) -> Router {
         // Portal & Metrics
         .route("/portal", get(portal))
         .route("/metrics", get(prometheus_metrics))
+        // mcpgov overlay: MCP/tool governance admin API + portal asset.
+        .merge(crate::mcpgov::admin::routes())
         .with_state(state)
         .layer(
             CorsLayer::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod db;
 pub mod detection;
 pub mod endpoint;
+pub mod mcpgov;
 pub mod migrations;
 pub mod pricing;
 pub mod proxy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,11 @@ async fn main() -> anyhow::Result<()> {
     // Start cache version polling loop (5s interval)
     start_cache_poll_loop(Arc::clone(&state));
 
+    // mcpgov overlay: load the MCP/tool policy cache and start its background tasks.
+    // Self-contained — it runs its own poll loop and buffered writers, so nothing
+    // inside start_cache_poll_loop above needs to know about it.
+    ccag::mcpgov::start(state.db().await).await;
+
     // Self-healing startup migration: populate endpoint_aip_overrides from the
     // legacy inference_profile_arn column for endpoints that haven't been migrated yet.
     {

--- a/src/mcpgov/admin.rs
+++ b/src/mcpgov/admin.rs
@@ -1,0 +1,564 @@
+//! Admin HTTP surface for the governance overlay.
+//!
+//! Every route lives under `/admin/mcpgov/*` and is admin-gated with CCAG's existing
+//! [`check_admin_auth`] helper, called as the first statement of each handler exactly
+//! as upstream handlers do. The whole surface is exposed as one [`routes`] router so
+//! that wiring it into `src/api/mod.rs` costs a single `.merge()` line.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post, put};
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::api::admin::check_admin_auth;
+use crate::proxy::GatewayState;
+
+use super::{RequestContext, cache, sink, store};
+
+/// The portal page for this feature, served as a standalone asset and injected into
+/// the SPA at runtime. Keeping it out of `static/index.html` reduces the overlay's
+/// footprint in that 7.5k-line file to a single `<script>` tag.
+static PORTAL_EXT_JS: &str = include_str!("../../static/ext/mcp-governance.js");
+
+fn err(status: StatusCode, message: &str) -> Response {
+    (status, Json(json!({ "error": { "message": message } }))).into_response()
+}
+
+fn internal(e: impl std::fmt::Display) -> Response {
+    tracing::error!(error = %e, "mcpgov admin error");
+    err(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string())
+}
+
+const SERVER_STATUSES: [&str; 3] = ["pending", "approved", "denied"];
+const TOOL_STATUSES: [&str; 3] = ["inherit", "approved", "denied"];
+
+/// All governance routes. Merged into the main router before `.with_state()`.
+pub fn routes() -> Router<Arc<GatewayState>> {
+    Router::new()
+        .route("/admin/mcpgov/summary", get(get_summary))
+        .route(
+            "/admin/mcpgov/servers",
+            get(list_servers).post(create_server),
+        )
+        .route("/admin/mcpgov/servers/status", put(set_server_status))
+        .route("/admin/mcpgov/servers/bulk-status", put(bulk_tool_status))
+        .route("/admin/mcpgov/tools", get(list_tools))
+        .route("/admin/mcpgov/tools/status", put(set_tool_status))
+        .route(
+            "/admin/mcpgov/policies",
+            get(list_policies).put(upsert_policy),
+        )
+        .route(
+            "/admin/mcpgov/policies/{id}",
+            axum::routing::delete(delete_policy),
+        )
+        .route("/admin/mcpgov/simulate", post(simulate))
+        .route("/admin/mcpgov/events", get(list_events))
+        // Portal asset. Not admin-gated: it is static JavaScript containing no data,
+        // and the SPA loads it before the user authenticates. Every API call it makes
+        // is individually authorized.
+        .route("/portal/ext/mcp-governance.js", get(portal_ext))
+}
+
+async fn portal_ext() -> impl IntoResponse {
+    (
+        [("content-type", "application/javascript; charset=utf-8")],
+        PORTAL_EXT_JS,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+async fn get_summary(State(state): State<Arc<GatewayState>>, headers: HeaderMap) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+
+    let summary = match store::summary(&pool).await {
+        Ok(s) => s,
+        Err(e) => return internal(e),
+    };
+    let (dropped_tools, dropped_events) = sink::dropped_counts();
+
+    // The globally effective policy, so the portal can show the current posture
+    // without the operator having to open the policy editor.
+    let global = cache::effective_policy(&RequestContext::default()).await;
+
+    Json(json!({
+        "summary": summary,
+        "global_policy": global,
+        "buffer_drops": { "discovery": dropped_tools, "events": dropped_events },
+    }))
+    .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Catalog: servers
+// ---------------------------------------------------------------------------
+
+async fn list_servers(State(state): State<Arc<GatewayState>>, headers: HeaderMap) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+    match store::load_servers(&pool).await {
+        Ok(rows) => Json(json!({ "servers": rows })).into_response(),
+        Err(e) => internal(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateServerRequest {
+    server_name: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+async fn create_server(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Json(body): Json<CreateServerRequest>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+
+    let name = body.server_name.trim();
+    if name.is_empty() {
+        return err(StatusCode::BAD_REQUEST, "server_name is required");
+    }
+    let status = body.status.as_deref().unwrap_or("approved");
+    if !SERVER_STATUSES.contains(&status) {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "status must be one of: pending, approved, denied",
+        );
+    }
+
+    let pool = state.db().await;
+    match store::create_server(&pool, name, status, body.notes.as_deref()).await {
+        Ok(row) => {
+            cache::invalidate_now(&pool).await;
+            tracing::info!(
+                server = name,
+                status,
+                "mcpgov: server catalog entry upserted"
+            );
+            Json(json!({ "server": row })).into_response()
+        }
+        Err(e) => internal(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SetServerStatusRequest {
+    server_name: String,
+    status: String,
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+async fn set_server_status(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Json(body): Json<SetServerStatusRequest>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    if !SERVER_STATUSES.contains(&body.status.as_str()) {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "status must be one of: pending, approved, denied",
+        );
+    }
+
+    let pool = state.db().await;
+    match store::set_server_status(
+        &pool,
+        &body.server_name,
+        &body.status,
+        body.notes.as_deref(),
+    )
+    .await
+    {
+        Ok(true) => {
+            cache::invalidate_now(&pool).await;
+            tracing::info!(
+                server = %body.server_name,
+                status = %body.status,
+                "mcpgov: server status changed"
+            );
+            Json(json!({ "updated": true })).into_response()
+        }
+        Ok(false) => err(StatusCode::NOT_FOUND, "server not found"),
+        Err(e) => internal(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BulkToolStatusRequest {
+    server_name: String,
+    status: String,
+}
+
+/// Set the same status on every tool of one server — the bulk triage action.
+async fn bulk_tool_status(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Json(body): Json<BulkToolStatusRequest>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    if !TOOL_STATUSES.contains(&body.status.as_str()) {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "status must be one of: inherit, approved, denied",
+        );
+    }
+
+    let pool = state.db().await;
+    match store::set_status_for_server_tools(&pool, &body.server_name, &body.status).await {
+        Ok(n) => {
+            cache::invalidate_now(&pool).await;
+            tracing::info!(
+                server = %body.server_name,
+                status = %body.status,
+                count = n,
+                "mcpgov: bulk tool status change"
+            );
+            Json(json!({ "updated": n })).into_response()
+        }
+        Err(e) => internal(e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Catalog: tools
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct ListToolsQuery {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    server: Option<String>,
+    #[serde(default)]
+    limit: Option<i64>,
+}
+
+async fn list_tools(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Query(q): Query<ListToolsQuery>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let limit = q.limit.unwrap_or(500).clamp(1, 5000);
+
+    let pool = state.db().await;
+    match store::list_tools_filtered(&pool, q.status.as_deref(), q.server.as_deref(), limit).await {
+        Ok(rows) => Json(json!({ "tools": rows })).into_response(),
+        Err(e) => internal(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SetToolStatusRequest {
+    tool_name: String,
+    status: String,
+}
+
+/// Tool status is set through a body rather than a path segment because tool names
+/// contain `__` separators and arbitrary vendor characters that are awkward to encode.
+async fn set_tool_status(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Json(body): Json<SetToolStatusRequest>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    if !TOOL_STATUSES.contains(&body.status.as_str()) {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "status must be one of: inherit, approved, denied",
+        );
+    }
+
+    let pool = state.db().await;
+    match store::set_tool_status(&pool, &body.tool_name, &body.status).await {
+        Ok(true) => {
+            cache::invalidate_now(&pool).await;
+            tracing::info!(
+                tool = %body.tool_name,
+                status = %body.status,
+                "mcpgov: tool status changed"
+            );
+            Json(json!({ "updated": true })).into_response()
+        }
+        Ok(false) => err(StatusCode::NOT_FOUND, "tool not found"),
+        Err(e) => internal(e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Policies
+// ---------------------------------------------------------------------------
+
+async fn list_policies(State(state): State<Arc<GatewayState>>, headers: HeaderMap) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+    match store::load_policies(&pool).await {
+        Ok(rows) => Json(json!({ "policies": rows })).into_response(),
+        Err(e) => internal(e),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct UpsertPolicyRequest {
+    scope: String,
+    #[serde(default)]
+    scope_ref: Option<String>,
+    mode: String,
+    default_action: String,
+    #[serde(default)]
+    applies_to: Option<String>,
+    #[serde(default)]
+    allow_patterns: Vec<String>,
+    #[serde(default)]
+    deny_patterns: Vec<String>,
+    #[serde(default = "default_true")]
+    enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+async fn upsert_policy(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Json(body): Json<UpsertPolicyRequest>,
+) -> Response {
+    let admin = match crate::api::admin::check_admin_auth_identity(&headers, &state).await {
+        Ok(sub) => sub,
+        Err(resp) => return resp,
+    };
+
+    if !["global", "team", "user"].contains(&body.scope.as_str()) {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "scope must be one of: global, team, user",
+        );
+    }
+    if !["observe", "warn", "enforce"].contains(&body.mode.as_str()) {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "mode must be one of: observe, warn, enforce",
+        );
+    }
+    if !["allow", "deny"].contains(&body.default_action.as_str()) {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "default_action must be one of: allow, deny",
+        );
+    }
+    let applies_to = body.applies_to.as_deref().unwrap_or("mcp_only");
+    if !["mcp_only", "all_tools"].contains(&applies_to) {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "applies_to must be one of: mcp_only, all_tools",
+        );
+    }
+
+    // Mirror the database CHECK constraint here so the caller gets a 400 with a clear
+    // message instead of a 500 from a constraint violation.
+    let scope_ref = match body.scope.as_str() {
+        "global" => None,
+        _ => {
+            let r = body.scope_ref.as_deref().unwrap_or("").trim().to_string();
+            if r.is_empty() {
+                return err(
+                    StatusCode::BAD_REQUEST,
+                    "scope_ref is required for team and user policies",
+                );
+            }
+            if body.scope == "team" && Uuid::parse_str(&r).is_err() {
+                return err(
+                    StatusCode::BAD_REQUEST,
+                    "scope_ref must be a team UUID for team policies",
+                );
+            }
+            Some(r)
+        }
+    };
+
+    // A pattern that is only `*` in an allowlist means "allow everything", which is
+    // almost certainly not what an operator wants to type; it silently disables the
+    // allowlist's exclusivity. Reject it rather than quietly accepting a no-op.
+    if body.allow_patterns.iter().any(|p| p.trim() == "*") {
+        return err(
+            StatusCode::BAD_REQUEST,
+            "an allow pattern of `*` allows everything — leave allow_patterns empty instead",
+        );
+    }
+
+    let pool = state.db().await;
+    match store::upsert_policy(
+        &pool,
+        &body.scope,
+        scope_ref.as_deref(),
+        &body.mode,
+        &body.default_action,
+        applies_to,
+        &body.allow_patterns,
+        &body.deny_patterns,
+        body.enabled,
+        Some(&admin),
+    )
+    .await
+    {
+        Ok(row) => {
+            cache::invalidate_now(&pool).await;
+            tracing::info!(
+                scope = %body.scope,
+                scope_ref = ?scope_ref,
+                mode = %body.mode,
+                by = %admin,
+                "mcpgov: policy upserted"
+            );
+            Json(json!({ "policy": row })).into_response()
+        }
+        Err(e) => internal(e),
+    }
+}
+
+async fn delete_policy(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Path(id): Path<Uuid>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let pool = state.db().await;
+    match store::delete_policy(&pool, id).await {
+        Ok(true) => {
+            cache::invalidate_now(&pool).await;
+            tracing::info!(%id, "mcpgov: policy deleted");
+            Json(json!({ "deleted": true })).into_response()
+        }
+        Ok(false) => err(
+            StatusCode::NOT_FOUND,
+            "policy not found, or it is the global policy (which cannot be deleted)",
+        ),
+        Err(e) => internal(e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Simulator
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct SimulateRequest {
+    #[serde(default)]
+    user_identity: Option<String>,
+    #[serde(default)]
+    team_id: Option<Uuid>,
+    /// Tool names to test. Empty means "everything in the catalog".
+    #[serde(default)]
+    tool_names: Vec<String>,
+}
+
+/// Answer "what would this user actually see?" without sending a request.
+async fn simulate(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Json(body): Json<SimulateRequest>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+
+    let ctx = RequestContext {
+        user_identity: body.user_identity.clone(),
+        team_id: body.team_id,
+        key_id: None,
+        request_id: None,
+    };
+
+    let (eff, decisions) = super::simulate(&ctx, &body.tool_names).await;
+
+    let results: Vec<_> = decisions
+        .into_iter()
+        .map(|(name, d)| {
+            json!({
+                "tool_name": name,
+                "allowed": d.allowed,
+                "reason": d.reason,
+                "decided_by": d.decided_by.as_str(),
+            })
+        })
+        .collect();
+
+    let allowed = results
+        .iter()
+        .filter(|r| r["allowed"].as_bool().unwrap_or(false))
+        .count();
+    let denied = results.len() - allowed;
+
+    Json(json!({
+        "effective_policy": eff,
+        "counts": { "allowed": allowed, "denied": denied },
+        "results": results,
+    }))
+    .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Audit
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct ListEventsQuery {
+    #[serde(default)]
+    decision: Option<String>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
+    limit: Option<i64>,
+}
+
+async fn list_events(
+    State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
+    Query(q): Query<ListEventsQuery>,
+) -> Response {
+    if let Err(resp) = check_admin_auth(&headers, &state).await {
+        return resp;
+    }
+    let limit = q.limit.unwrap_or(200).clamp(1, 2000);
+
+    let pool = state.db().await;
+    match store::list_events(&pool, q.decision.as_deref(), q.user.as_deref(), limit).await {
+        Ok(rows) => Json(json!({ "events": rows })).into_response(),
+        Err(e) => internal(e),
+    }
+}

--- a/src/mcpgov/cache.rs
+++ b/src/mcpgov/cache.rs
@@ -1,0 +1,291 @@
+//! In-memory policy and catalog cache.
+//!
+//! Deliberately a module-level singleton rather than a field on `GatewayState`. That
+//! keeps the overlay self-contained: adding it requires no change to the shared state
+//! struct or to the state construction in `main.rs`, which are exactly the kind of
+//! densely-edited upstream lines that make rebases painful.
+//!
+//! Propagation across replicas reuses CCAG's existing `cache_version` counter. Any
+//! operator write bumps it, and every gateway notices within 5 seconds.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use sqlx::PgPool;
+use tokio::sync::RwLock;
+
+use super::{CatalogStatus, EffectivePolicy, PolicyRow, RequestContext, policy, store};
+
+/// Poll interval, matched to CCAG's own cache poll loop.
+const POLL_INTERVAL_SECS: u64 = 5;
+
+#[derive(Default)]
+struct Inner {
+    /// The single `global` policy row, if present.
+    global: Option<PolicyRow>,
+    /// Team policies keyed by team UUID rendered as a string.
+    by_team: HashMap<String, PolicyRow>,
+    /// User policies keyed by user identity (email).
+    by_user: HashMap<String, PolicyRow>,
+    /// Resolved catalog status per full tool name.
+    tools: HashMap<String, CatalogStatus>,
+    /// Resolved catalog status per MCP server name.
+    servers: HashMap<String, CatalogStatus>,
+    /// Tool names already present in the catalog, used to avoid re-queueing every
+    /// known tool on every single request.
+    known_tools: HashSet<String>,
+}
+
+struct Cache {
+    inner: RwLock<Inner>,
+    version: AtomicI64,
+}
+
+static CACHE: LazyLock<Cache> = LazyLock::new(|| Cache {
+    inner: RwLock::new(Inner::default()),
+    version: AtomicI64::new(-1),
+});
+
+/// Load the cache from the database. Errors are logged, not propagated: a governance
+/// overlay that cannot read its own tables must leave the gateway running (and, since
+/// an empty cache resolves to the inert default policy, running unmodified).
+pub async fn init(pool: &PgPool) {
+    if let Err(e) = reload(pool).await {
+        tracing::warn!(%e, "mcpgov: initial cache load failed — overlay inert until next poll");
+    }
+}
+
+pub async fn reload(pool: &PgPool) -> anyhow::Result<()> {
+    let policies = store::load_policies(pool).await?;
+    let servers = store::load_servers(pool).await?;
+    let tools = store::load_tools(pool).await?;
+
+    let mut next = Inner::default();
+
+    for row in &policies {
+        let p = row.to_policy();
+        match row.scope.as_str() {
+            "global" => next.global = Some(p),
+            "team" => {
+                if let Some(r) = &row.scope_ref {
+                    next.by_team.insert(r.clone(), p);
+                }
+            }
+            "user" => {
+                if let Some(r) = &row.scope_ref {
+                    // User identities are emails; compare case-insensitively.
+                    next.by_user.insert(r.to_lowercase(), p);
+                }
+            }
+            other => tracing::warn!(scope = other, "mcpgov: ignoring policy with unknown scope"),
+        }
+    }
+
+    for s in &servers {
+        next.servers.insert(
+            s.server_name.clone(),
+            CatalogStatus::parse_server(&s.status),
+        );
+    }
+    for t in &tools {
+        next.tools
+            .insert(t.tool_name.clone(), CatalogStatus::parse_tool(&t.status));
+        next.known_tools.insert(t.tool_name.clone());
+    }
+
+    let counts = (policies.len(), next.servers.len(), next.tools.len());
+    *CACHE.inner.write().await = next;
+    tracing::debug!(
+        policies = counts.0,
+        servers = counts.1,
+        tools = counts.2,
+        "mcpgov: cache reloaded"
+    );
+    Ok(())
+}
+
+/// Poll `cache_version` and reload when an operator write bumps it.
+///
+/// This runs as its own task rather than hooking CCAG's `start_cache_poll_loop`, so
+/// the overlay adds no line inside that function's body.
+pub fn start_poll_loop(pool: PgPool) {
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(POLL_INTERVAL_SECS));
+        loop {
+            interval.tick().await;
+
+            let observed = match crate::db::settings::get_cache_version(&pool).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::debug!(%e, "mcpgov: cache version poll failed");
+                    continue;
+                }
+            };
+
+            let current = CACHE.version.load(Ordering::Relaxed);
+            if observed != current {
+                if let Err(e) = reload(&pool).await {
+                    tracing::warn!(%e, "mcpgov: cache reload failed");
+                    continue;
+                }
+                CACHE.version.store(observed, Ordering::Relaxed);
+            }
+        }
+    });
+}
+
+/// Force an immediate reload, used by admin handlers so an operator sees their own
+/// change take effect without waiting out the poll interval on this replica.
+pub async fn invalidate_now(pool: &PgPool) {
+    if let Err(e) = reload(pool).await {
+        tracing::warn!(%e, "mcpgov: immediate reload after admin write failed");
+    }
+}
+
+/// Merge the policies that apply to this identity.
+pub async fn effective_policy(ctx: &RequestContext) -> EffectivePolicy {
+    let inner = CACHE.inner.read().await;
+
+    let team = ctx
+        .team_id
+        .and_then(|id| inner.by_team.get(&id.to_string()));
+    let user = ctx
+        .user_identity
+        .as_ref()
+        .and_then(|u| inner.by_user.get(&u.to_lowercase()));
+
+    policy::resolve(inner.global.as_ref(), team, user)
+}
+
+/// Snapshot the catalog maps for a decision pass.
+pub async fn catalog_snapshot() -> (
+    HashMap<String, CatalogStatus>,
+    HashMap<String, CatalogStatus>,
+) {
+    let inner = CACHE.inner.read().await;
+    (inner.tools.clone(), inner.servers.clone())
+}
+
+/// Partition tool names into those the catalog has never seen (which need an upsert)
+/// and mark them known so repeat requests do not re-queue them.
+///
+/// Returning early for the common "everything already known" case keeps discovery off
+/// the hot path: after warm-up this is a single read lock and no allocation.
+pub async fn take_unknown(names: &[String]) -> Vec<String> {
+    {
+        let inner = CACHE.inner.read().await;
+        if names.iter().all(|n| inner.known_tools.contains(n)) {
+            return Vec::new();
+        }
+    }
+
+    let mut inner = CACHE.inner.write().await;
+    let mut fresh = Vec::new();
+    for n in names {
+        if inner.known_tools.insert(n.clone()) {
+            fresh.push(n.clone());
+        }
+    }
+    fresh
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcpgov::{Action, AppliesTo, Mode};
+
+    fn row(scope: &str, scope_ref: Option<&str>, mode: Mode) -> PolicyRow {
+        PolicyRow {
+            scope: scope.to_string(),
+            scope_ref: scope_ref.map(String::from),
+            mode,
+            default_action: Action::Allow,
+            applies_to: AppliesTo::McpOnly,
+            allow_patterns: vec![],
+            deny_patterns: vec![],
+            enabled: true,
+        }
+    }
+
+    /// Serialises the tests in this module.
+    ///
+    /// They all replace the same process-wide cache, and cargo runs tests in parallel by
+    /// default, so without this each test can observe another's seed. That showed up as
+    /// intermittent failures rather than consistent ones, which is the worst kind.
+    /// Every test holds the guard for its whole body, not just across [`seed`].
+    static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    async fn seed(inner: Inner) {
+        *CACHE.inner.write().await = inner;
+    }
+
+    #[tokio::test]
+    async fn user_policy_beats_team_and_global() {
+        let _guard = TEST_LOCK.lock().await;
+        let mut inner = Inner {
+            global: Some(row("global", None, Mode::Observe)),
+            ..Default::default()
+        };
+        let team_id = uuid::Uuid::nil();
+        inner
+            .by_team
+            .insert(team_id.to_string(), row("team", Some("t"), Mode::Warn));
+        inner.by_user.insert(
+            "dev@example.com".into(),
+            row("user", Some("u"), Mode::Enforce),
+        );
+        seed(inner).await;
+
+        let ctx = RequestContext {
+            user_identity: Some("dev@example.com".into()),
+            team_id: Some(team_id),
+            ..Default::default()
+        };
+        assert_eq!(effective_policy(&ctx).await.mode, Mode::Enforce);
+
+        // Same team, a user with no policy of their own -> team policy applies.
+        let ctx2 = RequestContext {
+            user_identity: Some("other@example.com".into()),
+            team_id: Some(team_id),
+            ..Default::default()
+        };
+        assert_eq!(effective_policy(&ctx2).await.mode, Mode::Warn);
+    }
+
+    #[tokio::test]
+    async fn user_identity_matches_case_insensitively() {
+        let _guard = TEST_LOCK.lock().await;
+        let mut inner = Inner::default();
+        inner.by_user.insert(
+            "dev@example.com".into(),
+            row("user", Some("u"), Mode::Enforce),
+        );
+        seed(inner).await;
+
+        let ctx = RequestContext {
+            user_identity: Some("DEV@Example.COM".into()),
+            ..Default::default()
+        };
+        assert_eq!(effective_policy(&ctx).await.mode, Mode::Enforce);
+    }
+
+    #[tokio::test]
+    async fn take_unknown_returns_each_name_once() {
+        let _guard = TEST_LOCK.lock().await;
+        seed(Inner::default()).await;
+
+        let names = vec!["mcp__a__x".to_string(), "mcp__b__y".to_string()];
+        let first = take_unknown(&names).await;
+        assert_eq!(first.len(), 2);
+
+        // Second call sees them as known.
+        let second = take_unknown(&names).await;
+        assert!(second.is_empty());
+
+        // A new name still comes through.
+        let third = take_unknown(&["mcp__c__z".to_string()]).await;
+        assert_eq!(third, vec!["mcp__c__z".to_string()]);
+    }
+}

--- a/src/mcpgov/mod.rs
+++ b/src/mcpgov/mod.rs
@@ -1,0 +1,1175 @@
+//! MCP / tool governance.
+//!
+//! This module is an **additive extension** to CCAG: all of its logic lives under
+//! `src/mcpgov/`, its tables are prefixed `mcpgov_`, its migration is numbered 900,
+//! and its portal UI is a separate self-injecting asset. Contact with pre-existing
+//! files is deliberately minimal — one hook in `src/api/handlers.rs`, one `.merge()`
+//! in `src/api/mod.rs`, a module declaration, two background tasks in `main.rs`, and a
+//! single `<script>` tag in `static/index.html`.
+//!
+//! What it does
+//! ------------
+//! Claude Code's own MCP controls (`managed-mcp.json`, `allowedMcpServers`) are
+//! client-side, and Anthropic's server-managed settings are skipped entirely for any
+//! session with a custom `ANTHROPIC_BASE_URL` — which is exactly how CCAG is used. So
+//! policy is enforced here instead, on the request path, where it needs no client
+//! configuration and cannot be bypassed by editing local files.
+//!
+//! Two halves:
+//!
+//! * **Discovery** — every request carries the full `tools` array, which is a complete
+//!   inventory of what the caller has connected. Observed tools are upserted into a
+//!   catalog so operators approve from a real list instead of guessing.
+//! * **Enforcement** — denied tool *definitions* are stripped before the request
+//!   reaches Bedrock. Filtering definitions rather than invocations means the model
+//!   never sees a forbidden tool, so there is nothing to intercept later and the
+//!   behaviour is identical in streaming and non-streaming mode.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+pub mod admin;
+pub mod cache;
+pub mod policy;
+pub mod response;
+pub mod sink;
+pub mod store;
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// How aggressively policy is applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Mode {
+    /// Decide and record, but never modify the request. The dry-run posture used to
+    /// build up the catalog before turning enforcement on.
+    Observe,
+    /// Allow the tool through, but record the decision as a `warned` audit event and
+    /// log it. The request itself is left untouched.
+    Warn,
+    /// Actually strip denied tool definitions.
+    Enforce,
+}
+
+impl Mode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Mode::Observe => "observe",
+            Mode::Warn => "warn",
+            Mode::Enforce => "enforce",
+        }
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "enforce" => Mode::Enforce,
+            "warn" => Mode::Warn,
+            _ => Mode::Observe,
+        }
+    }
+}
+
+/// What to do with a tool the catalog has no decision for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Action {
+    Allow,
+    Deny,
+}
+
+impl Action {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Action::Allow => "allow",
+            Action::Deny => "deny",
+        }
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "deny" => Action::Deny,
+            _ => Action::Allow,
+        }
+    }
+}
+
+/// Which tools a policy governs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppliesTo {
+    /// Only `mcp__*` tools. The safe default: builtins like Read/Write/Bash are
+    /// never touched, so a misconfigured policy cannot break basic Claude Code use.
+    McpOnly,
+    /// Builtins are governed too.
+    AllTools,
+}
+
+impl AppliesTo {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AppliesTo::McpOnly => "mcp_only",
+            AppliesTo::AllTools => "all_tools",
+        }
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "all_tools" => AppliesTo::AllTools,
+            _ => AppliesTo::McpOnly,
+        }
+    }
+}
+
+/// Approval state of a catalog entry. For tools, `Pending` also represents the
+/// `inherit` state stored in the database (defer to the server's status).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogStatus {
+    Pending,
+    Approved,
+    Denied,
+}
+
+impl CatalogStatus {
+    pub fn parse_server(s: &str) -> Self {
+        match s {
+            "approved" => CatalogStatus::Approved,
+            "denied" => CatalogStatus::Denied,
+            _ => CatalogStatus::Pending,
+        }
+    }
+
+    /// Tool rows use `inherit` where servers use `pending`; both mean "undecided
+    /// here, look further up".
+    pub fn parse_tool(s: &str) -> Self {
+        match s {
+            "approved" => CatalogStatus::Approved,
+            "denied" => CatalogStatus::Denied,
+            _ => CatalogStatus::Pending,
+        }
+    }
+}
+
+/// Servers use the same three states as tools.
+pub type ServerStatus = CatalogStatus;
+
+/// Which layer produced a decision, recorded for auditing and shown in the portal's
+/// simulator so operators can see *why* a tool was allowed or denied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecidedBy {
+    Global,
+    Team,
+    User,
+    /// An explicit approve/deny in the catalog.
+    Catalog,
+    /// No specific attribution: out of policy scope, or a fallback default.
+    Unscoped,
+}
+
+impl DecidedBy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DecidedBy::Global => "global",
+            DecidedBy::Team => "team",
+            DecidedBy::User => "user",
+            DecidedBy::Catalog => "catalog",
+            DecidedBy::Unscoped => "unscoped",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Structs
+// ---------------------------------------------------------------------------
+
+/// A tool name split into its MCP server and tool segments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolRef<'a> {
+    /// The full name as it appeared in the request.
+    pub full: &'a str,
+    /// The MCP server segment, or `None` for builtins and malformed MCP names.
+    pub server: Option<&'a str>,
+    /// The tool segment (equals `full` for builtins).
+    pub tool: &'a str,
+    pub is_mcp: bool,
+}
+
+/// One row of `mcpgov_policies`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyRow {
+    pub scope: String,
+    pub scope_ref: Option<String>,
+    pub mode: Mode,
+    pub default_action: Action,
+    pub applies_to: AppliesTo,
+    pub allow_patterns: Vec<String>,
+    pub deny_patterns: Vec<String>,
+    pub enabled: bool,
+}
+
+impl PolicyRow {
+    pub fn scope_kind(&self) -> DecidedBy {
+        match self.scope.as_str() {
+            "team" => DecidedBy::Team,
+            "user" => DecidedBy::User,
+            "global" => DecidedBy::Global,
+            _ => DecidedBy::Unscoped,
+        }
+    }
+}
+
+/// The merged policy that applies to one identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EffectivePolicy {
+    pub mode: Mode,
+    pub default_action: Action,
+    pub applies_to: AppliesTo,
+    pub allow_patterns: Vec<String>,
+    pub deny_patterns: Vec<String>,
+    /// The most specific scope that contributed scalars.
+    pub decided_by: DecidedBy,
+}
+
+impl Default for EffectivePolicy {
+    /// With no policy rows at all the overlay is inert: observe mode, allow
+    /// everything, MCP-only scope. Installing the extension therefore changes no
+    /// behaviour until an operator configures something.
+    fn default() -> Self {
+        Self {
+            mode: Mode::Observe,
+            default_action: Action::Allow,
+            applies_to: AppliesTo::McpOnly,
+            allow_patterns: Vec::new(),
+            deny_patterns: Vec::new(),
+            decided_by: DecidedBy::Unscoped,
+        }
+    }
+}
+
+/// The verdict for a single tool, before `mode` is taken into account.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Decision {
+    pub allowed: bool,
+    pub reason: String,
+    pub decided_by: DecidedBy,
+}
+
+impl Decision {
+    pub fn allow(reason: &str, decided_by: DecidedBy) -> Self {
+        Self {
+            allowed: true,
+            reason: reason.to_string(),
+            decided_by,
+        }
+    }
+
+    pub fn allow_owned(reason: String, decided_by: DecidedBy) -> Self {
+        Self {
+            allowed: true,
+            reason,
+            decided_by,
+        }
+    }
+
+    pub fn deny(reason: String, decided_by: DecidedBy) -> Self {
+        Self {
+            allowed: false,
+            reason,
+            decided_by,
+        }
+    }
+}
+
+/// Identity and request metadata needed to resolve policy and write audit rows.
+#[derive(Debug, Clone, Default)]
+pub struct RequestContext {
+    /// OIDC email or virtual-key user identity.
+    pub user_identity: Option<String>,
+    pub team_id: Option<Uuid>,
+    pub key_id: Option<Uuid>,
+    pub request_id: Option<String>,
+}
+
+/// How many history blocks were scrubbed, and what that implies for the caller.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct HistoryScrub {
+    /// `tool_use` blocks removed from assistant turns.
+    pub tool_uses: usize,
+    /// `tool_result` blocks removed from user turns to keep pairing valid.
+    pub tool_results: usize,
+    /// Messages left with no content, which had to get a placeholder block.
+    pub placeholders: usize,
+}
+
+impl HistoryScrub {
+    pub fn is_empty(&self) -> bool {
+        self.tool_uses == 0 && self.tool_results == 0
+    }
+}
+
+/// A tool that policy did not permit.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeniedTool {
+    pub tool_name: String,
+    pub server_name: Option<String>,
+    pub reason: String,
+    pub decided_by: String,
+}
+
+/// What enforcement did to a request.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct EnforcementOutcome {
+    /// Tools whose definitions were actually removed (enforce mode only).
+    pub removed: Vec<DeniedTool>,
+    /// Tools that policy denied but mode let through (observe / warn).
+    pub flagged: Vec<DeniedTool>,
+    /// True when `tool_choice` had to be relaxed because it named a removed tool.
+    pub tool_choice_reset: bool,
+    /// Denied tool traffic erased from the conversation transcript.
+    pub history: HistoryScrub,
+}
+
+impl EnforcementOutcome {
+    pub fn is_noop(&self) -> bool {
+        self.removed.is_empty()
+            && self.flagged.is_empty()
+            && !self.tool_choice_reset
+            && self.history.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// Initialise the overlay: load the cache and start the background poll and
+/// buffered-writer tasks. Safe to call once at startup; failures are logged and
+/// leave the overlay inert rather than blocking gateway boot.
+pub async fn start(pool: sqlx::PgPool) {
+    cache::init(&pool).await;
+    cache::start_poll_loop(pool.clone());
+    sink::start(pool);
+}
+
+/// Extract the tool names declared in an Anthropic `tools` array.
+///
+/// Tool definitions carry their name in `name`; Anthropic server-side tools (such as
+/// `web_search`) instead carry only a `type`, which we skip — those are handled by
+/// CCAG's own web-search interception, not by MCP policy.
+fn tool_names_of(tools: &[Value]) -> Vec<String> {
+    tools
+        .iter()
+        .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(String::from))
+        .collect()
+}
+
+/// Extract the distinct tool names the transcript shows the client has actually called.
+///
+/// Only assistant `tool_use` blocks count. `tool_result` blocks carry an id rather than
+/// a name, so they are matched back to their call during the scrub instead.
+///
+/// Order is preserved and duplicates collapsed, so a long session with many repeats of
+/// the same tool costs one policy decision, not one per turn.
+fn tool_names_in_history(messages: &[Value]) -> Vec<String> {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut names: Vec<String> = Vec::new();
+
+    for msg in messages {
+        if msg.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+            continue;
+        }
+        // Content is a plain string on turns with no tool calls; nothing to collect.
+        let Some(blocks) = msg.get("content").and_then(|c| c.as_array()) else {
+            continue;
+        };
+        for block in blocks {
+            if block.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+                continue;
+            }
+            if let Some(name) = block.get("name").and_then(|n| n.as_str())
+                && seen.insert(name)
+            {
+                names.push(name.to_string());
+            }
+        }
+    }
+
+    names
+}
+
+/// Apply MCP/tool policy to an outbound request.
+///
+/// Mutates `tools` (removing denied definitions) and `tool_choice` (relaxing it if it
+/// named a removed tool) **only** in `enforce` mode. In `observe` and `warn` mode the
+/// request is left byte-for-byte untouched and the decisions are only recorded.
+///
+/// This never fails the request: on any internal error it logs and allows, because a
+/// governance overlay must not be able to take the gateway down.
+pub async fn enforce(
+    tools: &mut Option<Vec<Value>>,
+    tool_choice: &mut Option<Value>,
+    messages: &mut [Value],
+    ctx: &RequestContext,
+) -> EnforcementOutcome {
+    let noop = EnforcementOutcome::default();
+
+    // What the client declared this turn.
+    let declared = tools.as_deref().map(tool_names_of).unwrap_or_default();
+
+    // What the transcript proves the client can still reach. These two sets are not the
+    // same, and the difference is the whole reason enforcement leaked: once the gateway
+    // strips a definition, the client stops re-declaring the tool, but its history still
+    // carries the earlier `tool_use` / `tool_result` pair — and the model keeps calling
+    // the tool from that memory. Judging only the declarations means a continuing session
+    // is never re-examined, so it keeps working forever. Both sets must be policed.
+    let historical = tool_names_in_history(messages);
+
+    if declared.is_empty() && historical.is_empty() {
+        return noop;
+    }
+
+    // Only declared names feed the catalog. A name in the transcript is evidence of a
+    // past call, not of a currently connected server, so recording it would resurrect
+    // catalog entries for tools a developer has since removed.
+    if !declared.is_empty() {
+        sink::observe_tools(&declared).await;
+    }
+
+    let eff = cache::effective_policy(ctx).await;
+    let (catalog_tools, catalog_servers) = cache::catalog_snapshot().await;
+
+    let mut denied: Vec<DeniedTool> = Vec::new();
+    let mut judged: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for name in declared.iter().chain(historical.iter()) {
+        if !judged.insert(name.as_str()) {
+            continue; // Declared and used in the same request: decide once.
+        }
+        let d = policy::decide(name, &eff, &catalog_tools, &catalog_servers);
+        if !d.allowed {
+            let parsed = policy::parse_tool_name(name);
+            denied.push(DeniedTool {
+                tool_name: name.clone(),
+                server_name: parsed.server.map(String::from),
+                reason: d.reason,
+                decided_by: d.decided_by.as_str().to_string(),
+            });
+        }
+    }
+
+    if denied.is_empty() {
+        return noop;
+    }
+
+    let decision_label = match eff.mode {
+        Mode::Enforce => "blocked",
+        Mode::Warn => "warned",
+        Mode::Observe => "would_block",
+    };
+    sink::record_events(&denied, decision_label, eff.mode, ctx);
+
+    apply(tools, tool_choice, messages, denied, eff.mode)
+}
+
+/// Erase every trace of the denied tools from the conversation transcript.
+///
+/// Stripping tool *definitions* alone is not enough. Once a session's history contains
+/// a successful `tool_use` / `tool_result` pair, the model will keep emitting `tool_use`
+/// blocks for that name from memory, even though the tool is no longer declared — and
+/// the Anthropic API accepts those blocks rather than rejecting them. The client then
+/// executes the call locally, because its MCP server is still connected. Verified
+/// against a live gateway: definition-stripping protects fresh sessions but not
+/// sessions that already used the tool.
+///
+/// So the transcript has to be scrubbed too. Doing it request-side keeps enforcement
+/// identical for streaming and non-streaming, and avoids having to reassemble
+/// `partial_json` deltas to intercept tool calls on the way back.
+///
+/// The API requires every `tool_use` to be answered by a `tool_result` with a matching
+/// id, so both halves are removed together. A message emptied by that removal gets a
+/// placeholder text block, since empty content is rejected.
+fn scrub_history(messages: &mut [Value], denied: &std::collections::HashSet<&str>) -> HistoryScrub {
+    let mut stats = HistoryScrub::default();
+    let mut orphaned_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Pass 1 — drop the assistant's calls to denied tools, remembering their ids.
+    for msg in messages.iter_mut() {
+        if msg.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+            continue;
+        }
+        let Some(content) = msg.get_mut("content").and_then(|c| c.as_array_mut()) else {
+            continue;
+        };
+        content.retain(|block| {
+            let is_denied_tool_use = block.get("type").and_then(|t| t.as_str()) == Some("tool_use")
+                && block
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .is_some_and(|n| denied.contains(n));
+            if is_denied_tool_use {
+                if let Some(id) = block.get("id").and_then(|i| i.as_str()) {
+                    orphaned_ids.insert(id.to_string());
+                }
+                return false;
+            }
+            true
+        });
+    }
+    stats.tool_uses = orphaned_ids.len();
+
+    if orphaned_ids.is_empty() {
+        return stats;
+    }
+
+    // Pass 2 — drop the results that answered them, or the request becomes invalid.
+    for msg in messages.iter_mut() {
+        if msg.get("role").and_then(|r| r.as_str()) != Some("user") {
+            continue;
+        }
+        let Some(content) = msg.get_mut("content").and_then(|c| c.as_array_mut()) else {
+            continue;
+        };
+        let before = content.len();
+        content.retain(|block| {
+            if block.get("type").and_then(|t| t.as_str()) == Some("tool_result") {
+                return block
+                    .get("tool_use_id")
+                    .and_then(|i| i.as_str())
+                    .is_none_or(|id| !orphaned_ids.contains(id));
+            }
+            true
+        });
+        stats.tool_results += before - content.len();
+    }
+
+    // Pass 3 — an empty content array is rejected by the API, so backfill.
+    for msg in messages.iter_mut() {
+        if let Some(content) = msg.get_mut("content").and_then(|c| c.as_array_mut())
+            && content.is_empty()
+        {
+            content.push(serde_json::json!({ "type": "text", "text": "(omitted)" }));
+            stats.placeholders += 1;
+        }
+    }
+
+    stats
+}
+
+/// Apply a set of denials to the request, honouring `mode`.
+///
+/// Split out from [`enforce`] as a pure function so the mutation semantics — which are
+/// the part that can actually break a request — are unit testable without a database
+/// or the policy cache.
+pub(crate) fn apply(
+    tools: &mut Option<Vec<Value>>,
+    tool_choice: &mut Option<Value>,
+    messages: &mut [Value],
+    denied: Vec<DeniedTool>,
+    mode: Mode,
+) -> EnforcementOutcome {
+    let mut outcome = EnforcementOutcome::default();
+
+    match mode {
+        // Dry run and warn-only: record, but do not touch the request.
+        Mode::Observe | Mode::Warn => {
+            outcome.flagged = denied;
+            return outcome;
+        }
+        Mode::Enforce => {}
+    }
+
+    let removed_names: std::collections::HashSet<&str> =
+        denied.iter().map(|d| d.tool_name.as_str()).collect();
+
+    // Remove the tool from the transcript as well as from the declarations, so the
+    // model cannot re-invoke it from memory of an earlier turn.
+    outcome.history = scrub_history(messages, &removed_names);
+
+    // Strip the denied definitions.
+    let kept: Vec<Value> = tools
+        .as_ref()
+        .map(|list| {
+            list.iter()
+                .filter(|t| {
+                    t.get("name")
+                        .and_then(|n| n.as_str())
+                        .is_none_or(|n| !removed_names.contains(n))
+                })
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // An empty `tools` array is not the same as an absent one — Bedrock rejects the
+    // former on some model builds, so drop the field entirely instead.
+    *tools = if kept.is_empty() { None } else { Some(kept) };
+
+    // A `tool_choice` that names a stripped tool would make Bedrock 400. Relax it to
+    // `auto`, or drop it if there are no tools left at all.
+    if let Some(tc) = tool_choice.as_ref() {
+        let names_a_removed_tool = tc
+            .get("name")
+            .and_then(|n| n.as_str())
+            .is_some_and(|n| removed_names.contains(n));
+        if names_a_removed_tool {
+            *tool_choice = if tools.is_some() {
+                Some(serde_json::json!({ "type": "auto" }))
+            } else {
+                None
+            };
+            outcome.tool_choice_reset = true;
+        } else if tools.is_none() {
+            // No tools survive, so any tool_choice is meaningless.
+            *tool_choice = None;
+            outcome.tool_choice_reset = true;
+        }
+    }
+
+    outcome.removed = denied;
+    outcome
+}
+
+/// Resolve the effective policy and per-tool decisions for an arbitrary identity,
+/// without touching a request. Backs the portal's "what would user X see?" simulator.
+pub async fn simulate(
+    ctx: &RequestContext,
+    tool_names: &[String],
+) -> (EffectivePolicy, Vec<(String, Decision)>) {
+    let eff = cache::effective_policy(ctx).await;
+    let (catalog_tools, catalog_servers) = cache::catalog_snapshot().await;
+
+    let names: Vec<String> = if tool_names.is_empty() {
+        // Default to the whole known catalog, so the simulator is useful with no input.
+        catalog_tools.keys().cloned().collect()
+    } else {
+        tool_names.to_vec()
+    };
+
+    let mut out: Vec<(String, Decision)> = names
+        .into_iter()
+        .map(|n| {
+            let d = policy::decide(&n, &eff, &catalog_tools, &catalog_servers);
+            (n, d)
+        })
+        .collect();
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+
+    (eff, out)
+}
+
+/// Convenience re-export so callers can build a catalog map without depending on the
+/// internal cache representation.
+pub type CatalogMap = HashMap<String, CatalogStatus>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn tool_names_skips_server_side_tools_without_a_name() {
+        let tools = vec![
+            json!({ "name": "mcp__github__create_issue", "input_schema": {} }),
+            // Anthropic server-side tool: type only, no name.
+            json!({ "type": "web_search_20250305" }),
+            json!({ "name": "Bash", "input_schema": {} }),
+        ];
+        assert_eq!(
+            tool_names_of(&tools),
+            vec!["mcp__github__create_issue".to_string(), "Bash".to_string()]
+        );
+    }
+
+    #[test]
+    fn mode_and_action_round_trip() {
+        for m in [Mode::Observe, Mode::Warn, Mode::Enforce] {
+            assert_eq!(Mode::parse(m.as_str()), m);
+        }
+        for a in [Action::Allow, Action::Deny] {
+            assert_eq!(Action::parse(a.as_str()), a);
+        }
+        for s in [AppliesTo::McpOnly, AppliesTo::AllTools] {
+            assert_eq!(AppliesTo::parse(s.as_str()), s);
+        }
+    }
+
+    #[test]
+    fn unknown_enum_strings_fall_back_to_safe_defaults() {
+        // A value written by a newer version of the extension must not escalate
+        // enforcement on an older gateway.
+        assert_eq!(Mode::parse("something_new"), Mode::Observe);
+        assert_eq!(Action::parse("something_new"), Action::Allow);
+        assert_eq!(AppliesTo::parse("something_new"), AppliesTo::McpOnly);
+        assert_eq!(CatalogStatus::parse_server("weird"), CatalogStatus::Pending);
+        assert_eq!(CatalogStatus::parse_tool("inherit"), CatalogStatus::Pending);
+    }
+
+    #[test]
+    fn default_effective_policy_is_inert() {
+        let eff = EffectivePolicy::default();
+        assert_eq!(eff.mode, Mode::Observe);
+        assert_eq!(eff.default_action, Action::Allow);
+        assert_eq!(eff.applies_to, AppliesTo::McpOnly);
+    }
+
+    #[test]
+    fn outcome_noop_detection() {
+        assert!(EnforcementOutcome::default().is_noop());
+        let with_flag = EnforcementOutcome {
+            flagged: vec![DeniedTool {
+                tool_name: "x".into(),
+                server_name: None,
+                reason: "r".into(),
+                decided_by: "global".into(),
+            }],
+            ..Default::default()
+        };
+        assert!(!with_flag.is_noop());
+    }
+
+    // ---- apply(): the request mutation semantics -------------------------
+
+    fn tool(name: &str) -> Value {
+        json!({ "name": name, "input_schema": { "type": "object" } })
+    }
+
+    fn denial(name: &str) -> DeniedTool {
+        DeniedTool {
+            tool_name: name.to_string(),
+            server_name: None,
+            reason: "test".into(),
+            decided_by: "global".into(),
+        }
+    }
+
+    fn names_in(tools: &Option<Vec<Value>>) -> Vec<String> {
+        tools
+            .as_ref()
+            .map(|l| {
+                l.iter()
+                    .filter_map(|t| t.get("name").and_then(|n| n.as_str()).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn observe_mode_leaves_the_request_byte_identical() {
+        let original = vec![tool("mcp__a__x"), tool("Bash")];
+        let mut tools = Some(original.clone());
+        let mut tc = Some(json!({ "type": "tool", "name": "mcp__a__x" }));
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut [],
+            vec![denial("mcp__a__x")],
+            Mode::Observe,
+        );
+
+        assert_eq!(tools, Some(original));
+        assert_eq!(tc, Some(json!({ "type": "tool", "name": "mcp__a__x" })));
+        assert_eq!(out.flagged.len(), 1);
+        assert!(out.removed.is_empty());
+        assert!(!out.tool_choice_reset);
+    }
+
+    #[test]
+    fn warn_mode_leaves_the_request_byte_identical() {
+        let original = vec![tool("mcp__a__x")];
+        let mut tools = Some(original.clone());
+        let mut tc = None;
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut [],
+            vec![denial("mcp__a__x")],
+            Mode::Warn,
+        );
+
+        assert_eq!(tools, Some(original));
+        assert_eq!(out.flagged.len(), 1);
+        assert!(out.removed.is_empty());
+    }
+
+    #[test]
+    fn enforce_mode_strips_only_the_denied_definitions() {
+        let mut tools = Some(vec![
+            tool("mcp__github__create_issue"),
+            tool("mcp__github__delete_repo"),
+            tool("mcp__evil__exfiltrate"),
+            tool("Bash"),
+        ]);
+        let mut tc = None;
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut [],
+            vec![
+                denial("mcp__github__delete_repo"),
+                denial("mcp__evil__exfiltrate"),
+            ],
+            Mode::Enforce,
+        );
+
+        assert_eq!(
+            names_in(&tools),
+            vec!["mcp__github__create_issue".to_string(), "Bash".to_string()]
+        );
+        assert_eq!(out.removed.len(), 2);
+        assert!(out.flagged.is_empty());
+    }
+
+    #[test]
+    fn stripping_every_tool_drops_the_field_instead_of_sending_an_empty_array() {
+        // Bedrock rejects `"tools": []` on some model builds, so the field must go.
+        let mut tools = Some(vec![tool("mcp__a__x"), tool("mcp__b__y")]);
+        let mut tc = None;
+
+        apply(
+            &mut tools,
+            &mut tc,
+            &mut [],
+            vec![denial("mcp__a__x"), denial("mcp__b__y")],
+            Mode::Enforce,
+        );
+
+        assert!(
+            tools.is_none(),
+            "expected tools to be absent, got {tools:?}"
+        );
+    }
+
+    #[test]
+    fn tool_choice_naming_a_stripped_tool_is_relaxed_to_auto() {
+        let mut tools = Some(vec![tool("mcp__a__x"), tool("Bash")]);
+        let mut tc = Some(json!({ "type": "tool", "name": "mcp__a__x" }));
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut [],
+            vec![denial("mcp__a__x")],
+            Mode::Enforce,
+        );
+
+        assert_eq!(tc, Some(json!({ "type": "auto" })));
+        assert!(out.tool_choice_reset);
+    }
+
+    #[test]
+    fn tool_choice_is_dropped_when_no_tools_survive() {
+        let mut tools = Some(vec![tool("mcp__a__x")]);
+        let mut tc = Some(json!({ "type": "tool", "name": "mcp__a__x" }));
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut [],
+            vec![denial("mcp__a__x")],
+            Mode::Enforce,
+        );
+
+        assert!(tools.is_none());
+        assert!(tc.is_none());
+        assert!(out.tool_choice_reset);
+    }
+
+    #[test]
+    fn unrelated_tool_choice_is_left_alone() {
+        let mut tools = Some(vec![tool("mcp__a__x"), tool("Bash")]);
+        let mut tc = Some(json!({ "type": "auto" }));
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut [],
+            vec![denial("mcp__a__x")],
+            Mode::Enforce,
+        );
+
+        assert_eq!(tc, Some(json!({ "type": "auto" })));
+        assert!(!out.tool_choice_reset);
+    }
+
+    // ---- tool_names_in_history() -----------------------------------------
+
+    #[test]
+    fn history_names_come_only_from_assistant_tool_use_blocks() {
+        let msgs = vec![
+            json!({ "role": "user", "content": "hi" }),
+            json!({ "role": "assistant", "content": [
+                { "type": "text", "text": "ok" },
+                { "type": "tool_use", "id": "a", "name": "mcp__x__one", "input": {} },
+                { "type": "tool_use", "id": "b", "name": "mcp__y__two", "input": {} }
+            ]}),
+            // tool_result carries an id, not a name: it must not contribute a name.
+            json!({ "role": "user", "content": [
+                { "type": "tool_result", "tool_use_id": "a", "content": "1" }
+            ]}),
+            // Repeat of an earlier tool: one decision, not two.
+            json!({ "role": "assistant", "content": [
+                { "type": "tool_use", "id": "c", "name": "mcp__x__one", "input": {} }
+            ]}),
+            // String content and a missing content field must not panic.
+            json!({ "role": "assistant", "content": "plain text" }),
+            json!({ "role": "assistant" }),
+        ];
+
+        assert_eq!(
+            tool_names_in_history(&msgs),
+            vec!["mcp__x__one".to_string(), "mcp__y__two".to_string()]
+        );
+    }
+
+    #[test]
+    fn history_of_a_fresh_session_is_empty() {
+        let msgs = vec![json!({ "role": "user", "content": "hola" })];
+        assert!(tool_names_in_history(&msgs).is_empty());
+    }
+
+    // ---- scrub_history() -------------------------------------------------
+    //
+    // Regression cover for the gap that made enforcement leak: stripping the tool
+    // definition is not enough, because the model re-invokes the tool from its memory
+    // of an earlier turn and the client then executes it locally.
+
+    fn denied_set<'a>(names: &'a [&'a str]) -> std::collections::HashSet<&'a str> {
+        names.iter().copied().collect()
+    }
+
+    /// A transcript that already used a tool successfully, as a live session would have.
+    fn transcript_with_tool_use() -> Vec<Value> {
+        vec![
+            json!({ "role": "user", "content": "resolve react" }),
+            json!({
+                "role": "assistant",
+                "content": [
+                    { "type": "text", "text": "Looking that up." },
+                    { "type": "tool_use", "id": "tu_1",
+                      "name": "mcp__context7__resolve-library-id",
+                      "input": { "libraryName": "React" } }
+                ]
+            }),
+            json!({
+                "role": "user",
+                "content": [
+                    { "type": "tool_result", "tool_use_id": "tu_1", "content": "/facebook/react" }
+                ]
+            }),
+            json!({ "role": "assistant", "content": "It is /facebook/react." }),
+        ]
+    }
+
+    fn block_types(msg: &Value) -> Vec<String> {
+        msg.get("content")
+            .and_then(|c| c.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|b| b.get("type").and_then(|t| t.as_str()).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn scrub_removes_tool_use_and_its_paired_result() {
+        let mut msgs = transcript_with_tool_use();
+        let stats = scrub_history(
+            &mut msgs,
+            &denied_set(&["mcp__context7__resolve-library-id"]),
+        );
+
+        assert_eq!(stats.tool_uses, 1);
+        assert_eq!(stats.tool_results, 1);
+
+        // The assistant turn keeps its text but loses the call.
+        assert_eq!(block_types(&msgs[1]), vec!["text".to_string()]);
+        // The user turn that only held the result is backfilled, never left empty.
+        assert_eq!(block_types(&msgs[2]), vec!["text".to_string()]);
+    }
+
+    #[test]
+    fn scrub_leaves_allowed_tools_untouched() {
+        let mut msgs = transcript_with_tool_use();
+        let before = msgs.clone();
+        let stats = scrub_history(&mut msgs, &denied_set(&["mcp__other__thing"]));
+
+        assert!(stats.is_empty());
+        assert_eq!(msgs, before);
+    }
+
+    #[test]
+    fn scrub_never_leaves_content_empty() {
+        // An assistant turn whose only block is the denied call.
+        let mut msgs = vec![
+            json!({
+                "role": "assistant",
+                "content": [
+                    { "type": "tool_use", "id": "tu_1", "name": "mcp__bad__x", "input": {} }
+                ]
+            }),
+            json!({
+                "role": "user",
+                "content": [
+                    { "type": "tool_result", "tool_use_id": "tu_1", "content": "ok" }
+                ]
+            }),
+        ];
+        let stats = scrub_history(&mut msgs, &denied_set(&["mcp__bad__x"]));
+
+        assert_eq!(stats.placeholders, 2);
+        for m in &msgs {
+            let types = block_types(m);
+            assert!(!types.is_empty(), "empty content is rejected by the API");
+        }
+    }
+
+    #[test]
+    fn scrub_keeps_pairing_valid_when_a_turn_mixes_tools() {
+        // One assistant turn calling two tools, only one denied. The surviving
+        // tool_use must keep its result, and the denied one must lose its own.
+        let mut msgs = vec![
+            json!({
+                "role": "assistant",
+                "content": [
+                    { "type": "tool_use", "id": "keep", "name": "mcp__ok__a", "input": {} },
+                    { "type": "tool_use", "id": "drop", "name": "mcp__bad__b", "input": {} }
+                ]
+            }),
+            json!({
+                "role": "user",
+                "content": [
+                    { "type": "tool_result", "tool_use_id": "keep", "content": "1" },
+                    { "type": "tool_result", "tool_use_id": "drop", "content": "2" }
+                ]
+            }),
+        ];
+        let stats = scrub_history(&mut msgs, &denied_set(&["mcp__bad__b"]));
+
+        assert_eq!(stats.tool_uses, 1);
+        assert_eq!(stats.tool_results, 1);
+
+        let uses: Vec<&str> = msgs[0]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("id").and_then(|i| i.as_str()))
+            .collect();
+        let results: Vec<&str> = msgs[1]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|b| b.get("tool_use_id").and_then(|i| i.as_str()))
+            .collect();
+        assert_eq!(uses, vec!["keep"]);
+        assert_eq!(results, vec!["keep"]);
+    }
+
+    #[test]
+    fn scrub_tolerates_string_content_and_missing_fields() {
+        // Plain-string content and malformed blocks must not panic.
+        let mut msgs = vec![
+            json!({ "role": "user", "content": "hola" }),
+            json!({ "role": "assistant", "content": "hola" }),
+            json!({ "role": "assistant", "content": [ { "type": "tool_use" } ] }),
+            json!({ "role": "user" }),
+        ];
+        let stats = scrub_history(&mut msgs, &denied_set(&["mcp__bad__x"]));
+        assert!(stats.is_empty());
+    }
+
+    #[test]
+    fn observe_mode_does_not_scrub_history() {
+        let mut tools = Some(vec![tool("mcp__context7__resolve-library-id")]);
+        let mut tc = None;
+        let mut msgs = transcript_with_tool_use();
+        let before = msgs.clone();
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut msgs,
+            vec![denial("mcp__context7__resolve-library-id")],
+            Mode::Observe,
+        );
+
+        assert!(out.history.is_empty());
+        assert_eq!(msgs, before, "observe mode must not touch the transcript");
+    }
+
+    #[test]
+    fn enforce_mode_strips_definition_and_history_together() {
+        let mut tools = Some(vec![
+            tool("mcp__context7__resolve-library-id"),
+            tool("mcp__everything__echo"),
+        ]);
+        let mut tc = None;
+        let mut msgs = transcript_with_tool_use();
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut msgs,
+            vec![denial("mcp__context7__resolve-library-id")],
+            Mode::Enforce,
+        );
+
+        assert_eq!(names_in(&tools), vec!["mcp__everything__echo".to_string()]);
+        assert_eq!(out.history.tool_uses, 1);
+        // No trace of the tool name is left anywhere in the request.
+        let rendered = serde_json::to_string(&msgs).unwrap();
+        assert!(!rendered.contains("mcp__context7__resolve-library-id"));
+    }
+
+    #[test]
+    fn a_tool_present_only_in_history_is_still_scrubbed() {
+        // The shape of a *continuing* session, and the exact case that leaked: the client
+        // stopped declaring the tool because a previous turn already had it stripped, so
+        // judging `tools` alone finds nothing to do and the transcript sails through.
+        let mut tools = Some(vec![tool("mcp__everything__echo")]);
+        let mut tc = None;
+        let mut msgs = transcript_with_tool_use();
+
+        let out = apply(
+            &mut tools,
+            &mut tc,
+            &mut msgs,
+            vec![denial("mcp__context7__resolve-library-id")],
+            Mode::Enforce,
+        );
+
+        assert_eq!(out.history.tool_uses, 1);
+        assert_eq!(out.history.tool_results, 1);
+        // The declarations were already clean and must be left exactly as they were.
+        assert_eq!(names_in(&tools), vec!["mcp__everything__echo".to_string()]);
+        let rendered = serde_json::to_string(&msgs).unwrap();
+        assert!(!rendered.contains("mcp__context7__resolve-library-id"));
+    }
+
+    #[test]
+    fn server_side_tools_without_a_name_are_never_stripped() {
+        // Anthropic's web_search tool has a `type` but no `name`. CCAG's own
+        // interception owns it; MCP policy must leave it in place.
+        let web_search = json!({ "type": "web_search_20250305", "name_ignored": true });
+        let mut tools = Some(vec![tool("mcp__a__x"), web_search.clone()]);
+        let mut tc = None;
+
+        apply(
+            &mut tools,
+            &mut tc,
+            &mut [],
+            vec![denial("mcp__a__x")],
+            Mode::Enforce,
+        );
+
+        assert_eq!(tools, Some(vec![web_search]));
+    }
+}

--- a/src/mcpgov/policy.rs
+++ b/src/mcpgov/policy.rs
@@ -1,0 +1,570 @@
+//! Pure policy engine: tool-name parsing, glob matching, scope resolution, and the
+//! allow/deny decision.
+//!
+//! Everything here is synchronous and side-effect free so it can be unit tested
+//! without a database. The DB-backed pieces live in [`super::store`] and
+//! [`super::cache`].
+
+use std::collections::HashMap;
+
+use super::{
+    Action, AppliesTo, CatalogStatus, DecidedBy, Decision, EffectivePolicy, PolicyRow,
+    ServerStatus, ToolRef,
+};
+
+/// The prefix Claude Code uses to namespace MCP tools: `mcp__<server>__<tool>`.
+const MCP_PREFIX: &str = "mcp__";
+
+/// Split a tool name into its MCP server and tool parts.
+///
+/// Claude Code namespaces MCP tools as `mcp__<server>__<tool>`. Server names cannot
+/// contain `__` (it is the delimiter), but tool names can — AgentCore Gateway, for
+/// instance, names its tools `Target___tool` with three underscores. So we split on
+/// the *first* `__` after the prefix and treat the remainder as the tool segment.
+///
+/// Non-MCP builtin tools (`Read`, `Bash`, ...) yield `server: None`.
+pub fn parse_tool_name(tool_name: &str) -> ToolRef<'_> {
+    match tool_name.strip_prefix(MCP_PREFIX) {
+        Some(rest) => {
+            let mut parts = rest.splitn(2, "__");
+            let server = parts.next().unwrap_or_default();
+            let tool = parts.next();
+            match tool {
+                // `mcp__github__create_issue` -> ("github", "create_issue")
+                Some(t) if !server.is_empty() => ToolRef {
+                    full: tool_name,
+                    server: Some(server),
+                    tool: t,
+                    is_mcp: true,
+                },
+                // Malformed (`mcp__github`, `mcp____x`): still MCP-ish, but we cannot
+                // attribute it to a server. Treated as MCP with no server so that
+                // `mcp_only` policies still cover it.
+                _ => ToolRef {
+                    full: tool_name,
+                    server: None,
+                    tool: rest,
+                    is_mcp: true,
+                },
+            }
+        }
+        None => ToolRef {
+            full: tool_name,
+            server: None,
+            tool: tool_name,
+            is_mcp: false,
+        },
+    }
+}
+
+/// Match a tool name against a glob pattern supporting `*` wildcards anywhere.
+///
+/// `*` matches any run of characters including none. Matching is case-sensitive,
+/// because tool names are. A bare `*` matches everything.
+pub fn glob_match(pattern: &str, value: &str) -> bool {
+    // Fast paths for the overwhelmingly common shapes.
+    if pattern == "*" {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == value;
+    }
+
+    // Split on '*' and walk the literal segments left to right. A leading or
+    // trailing empty segment means the pattern was anchored with a wildcard there.
+    let segments: Vec<&str> = pattern.split('*').collect();
+    let last = segments.len() - 1;
+    let mut cursor = 0usize;
+
+    for (i, seg) in segments.iter().enumerate() {
+        if seg.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // Pattern does not start with '*': the first segment must be a prefix.
+            if !value[cursor..].starts_with(seg) {
+                return false;
+            }
+            cursor += seg.len();
+        } else if i == last {
+            // Pattern does not end with '*': the last segment must be a suffix,
+            // and must not overlap what we have already consumed.
+            if !value[cursor..].ends_with(seg) {
+                return false;
+            }
+        } else {
+            match value[cursor..].find(seg) {
+                Some(pos) => cursor += pos + seg.len(),
+                None => return false,
+            }
+        }
+    }
+
+    true
+}
+
+fn matches_any(patterns: &[String], value: &str) -> Option<String> {
+    patterns.iter().find(|p| glob_match(p, value)).cloned()
+}
+
+/// Merge the policy rows that apply to one identity into a single effective policy.
+///
+/// Rows are supplied most-general first (`global`, then `team`, then `user`); any of
+/// them may be absent. Merge semantics deliberately mirror the Claude apps gateway's
+/// managed-policy rules, so that a policy authored here can later be emitted as
+/// client-side managed settings without changing meaning:
+///
+/// * **Scalars** (`mode`, `default_action`, `applies_to`) — most specific scope wins.
+/// * **Deny lists** — union of every scope. An org-wide deny can never be dropped by
+///   a narrower override.
+/// * **Allow lists** — the most specific *non-empty* list replaces broader ones,
+///   rather than unioning, so a team allowlist genuinely narrows rather than widens.
+///
+/// Disabled rows are ignored entirely.
+pub fn resolve(
+    global: Option<&PolicyRow>,
+    team: Option<&PolicyRow>,
+    user: Option<&PolicyRow>,
+) -> EffectivePolicy {
+    let mut eff = EffectivePolicy::default();
+    let mut deny: Vec<String> = Vec::new();
+
+    // Ordered general -> specific, so later assignments win for scalars.
+    for row in [global, team, user].into_iter().flatten() {
+        if !row.enabled {
+            continue;
+        }
+        eff.mode = row.mode;
+        eff.default_action = row.default_action;
+        eff.applies_to = row.applies_to;
+        eff.decided_by = row.scope_kind();
+
+        for p in &row.deny_patterns {
+            if !deny.contains(p) {
+                deny.push(p.clone());
+            }
+        }
+        if !row.allow_patterns.is_empty() {
+            eff.allow_patterns = row.allow_patterns.clone();
+        }
+    }
+
+    eff.deny_patterns = deny;
+    eff
+}
+
+/// The catalog decision for a single tool: an explicit per-tool status if one exists,
+/// otherwise the status inherited from its MCP server.
+pub fn catalog_status(
+    tool: &ToolRef<'_>,
+    tools: &HashMap<String, CatalogStatus>,
+    servers: &HashMap<String, ServerStatus>,
+) -> CatalogStatus {
+    match tools.get(tool.full) {
+        Some(CatalogStatus::Approved) => return CatalogStatus::Approved,
+        Some(CatalogStatus::Denied) => return CatalogStatus::Denied,
+        // 'inherit' or absent: fall through to the server.
+        _ => {}
+    }
+
+    match tool.server.and_then(|s| servers.get(s)) {
+        Some(ServerStatus::Approved) => CatalogStatus::Approved,
+        Some(ServerStatus::Denied) => CatalogStatus::Denied,
+        _ => CatalogStatus::Pending,
+    }
+}
+
+/// Decide whether a single tool is permitted.
+///
+/// Precedence, highest first. Deny always wins, matching Cedar's
+/// forbid-overrides-permit model and Claude Code's own denylist semantics:
+///
+/// 1. A deny pattern matches -> DENY.
+/// 2. The catalog marks the tool (or its server) denied -> DENY.
+/// 3. An allow list is set and the tool matches -> ALLOW.
+/// 4. An allow list is set and the tool does not match -> DENY (allowlists are exclusive).
+/// 5. The catalog marks the tool (or its server) approved -> ALLOW.
+/// 6. Nothing decided -> the policy's `default_action`.
+///
+/// Note this returns the *policy* verdict. It does not consider `mode`; converting a
+/// verdict into an action (strip / flag / ignore) is [`Decision::apply_mode`].
+pub fn decide(
+    tool_name: &str,
+    eff: &EffectivePolicy,
+    tools: &HashMap<String, CatalogStatus>,
+    servers: &HashMap<String, ServerStatus>,
+) -> Decision {
+    let tool = parse_tool_name(tool_name);
+
+    // Builtin tools are out of scope unless the policy opts into governing them.
+    if eff.applies_to == AppliesTo::McpOnly && !tool.is_mcp {
+        return Decision::allow(
+            "not an MCP tool (policy scope is mcp_only)",
+            DecidedBy::Unscoped,
+        );
+    }
+
+    if let Some(p) = matches_any(&eff.deny_patterns, tool_name) {
+        return Decision::deny(format!("matched deny pattern `{p}`"), eff.decided_by);
+    }
+
+    let cat = catalog_status(&tool, tools, servers);
+    if cat == CatalogStatus::Denied {
+        return Decision::deny("denied in catalog".to_string(), DecidedBy::Catalog);
+    }
+
+    if !eff.allow_patterns.is_empty() {
+        return match matches_any(&eff.allow_patterns, tool_name) {
+            Some(p) => {
+                Decision::allow_owned(format!("matched allow pattern `{p}`"), eff.decided_by)
+            }
+            None => Decision::deny("not on the allowlist".to_string(), eff.decided_by),
+        };
+    }
+
+    if cat == CatalogStatus::Approved {
+        return Decision::allow("approved in catalog", DecidedBy::Catalog);
+    }
+
+    match eff.default_action {
+        Action::Allow => Decision::allow("not in catalog; default action is allow", eff.decided_by),
+        Action::Deny => Decision::deny(
+            "not in catalog; default action is deny".to_string(),
+            eff.decided_by,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcpgov::Mode;
+
+    fn pol(
+        scope: &str,
+        mode: Mode,
+        default_action: Action,
+        allow: &[&str],
+        deny: &[&str],
+    ) -> PolicyRow {
+        PolicyRow {
+            scope: scope.to_string(),
+            scope_ref: if scope == "global" {
+                None
+            } else {
+                Some("ref".to_string())
+            },
+            mode,
+            default_action,
+            applies_to: AppliesTo::McpOnly,
+            allow_patterns: allow.iter().map(|s| s.to_string()).collect(),
+            deny_patterns: deny.iter().map(|s| s.to_string()).collect(),
+            enabled: true,
+        }
+    }
+
+    fn empty_catalog() -> (
+        HashMap<String, CatalogStatus>,
+        HashMap<String, ServerStatus>,
+    ) {
+        (HashMap::new(), HashMap::new())
+    }
+
+    // ---- parse_tool_name -------------------------------------------------
+
+    #[test]
+    fn parses_standard_mcp_tool_name() {
+        let t = parse_tool_name("mcp__github__create_issue");
+        assert!(t.is_mcp);
+        assert_eq!(t.server, Some("github"));
+        assert_eq!(t.tool, "create_issue");
+    }
+
+    #[test]
+    fn parses_builtin_tool_name() {
+        let t = parse_tool_name("Bash");
+        assert!(!t.is_mcp);
+        assert_eq!(t.server, None);
+        assert_eq!(t.tool, "Bash");
+    }
+
+    #[test]
+    fn tool_segment_may_contain_double_underscores() {
+        // AgentCore Gateway names tools `Target___tool` (three underscores); the
+        // extra delimiters belong to the tool segment, not the server.
+        let t = parse_tool_name("mcp__awsgw__RefundTool___process_refund");
+        assert_eq!(t.server, Some("awsgw"));
+        assert_eq!(t.tool, "RefundTool___process_refund");
+    }
+
+    #[test]
+    fn malformed_mcp_name_has_no_server_but_is_still_mcp() {
+        let t = parse_tool_name("mcp__github");
+        assert!(t.is_mcp);
+        assert_eq!(t.server, None);
+    }
+
+    // ---- glob_match ------------------------------------------------------
+
+    #[test]
+    fn glob_star_matches_everything() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("*", ""));
+    }
+
+    #[test]
+    fn glob_exact_match_without_wildcard() {
+        assert!(glob_match("mcp__github__x", "mcp__github__x"));
+        assert!(!glob_match("mcp__github__x", "mcp__github__y"));
+    }
+
+    #[test]
+    fn glob_prefix_wildcard() {
+        assert!(glob_match("mcp__github__*", "mcp__github__create_issue"));
+        assert!(!glob_match("mcp__github__*", "mcp__gitlab__create_issue"));
+    }
+
+    #[test]
+    fn glob_suffix_wildcard() {
+        assert!(glob_match("*__delete_repo", "mcp__github__delete_repo"));
+        assert!(!glob_match("*__delete_repo", "mcp__github__create_repo"));
+    }
+
+    #[test]
+    fn glob_middle_wildcard() {
+        assert!(glob_match("mcp__*__delete_*", "mcp__github__delete_repo"));
+        assert!(!glob_match("mcp__*__delete_*", "mcp__github__create_repo"));
+    }
+
+    #[test]
+    fn glob_does_not_match_partial_prefix() {
+        assert!(!glob_match("mcp__github__*", "mcp__github"));
+    }
+
+    // ---- resolve ---------------------------------------------------------
+
+    #[test]
+    fn deny_patterns_union_across_scopes() {
+        let g = pol(
+            "global",
+            Mode::Enforce,
+            Action::Allow,
+            &[],
+            &["mcp__evil__*"],
+        );
+        let t = pol(
+            "team",
+            Mode::Enforce,
+            Action::Allow,
+            &[],
+            &["mcp__risky__*"],
+        );
+        let eff = resolve(Some(&g), Some(&t), None);
+        assert!(eff.deny_patterns.contains(&"mcp__evil__*".to_string()));
+        assert!(eff.deny_patterns.contains(&"mcp__risky__*".to_string()));
+    }
+
+    #[test]
+    fn allow_patterns_replace_rather_than_union() {
+        let g = pol(
+            "global",
+            Mode::Enforce,
+            Action::Allow,
+            &["mcp__a__*", "mcp__b__*"],
+            &[],
+        );
+        let t = pol("team", Mode::Enforce, Action::Allow, &["mcp__a__*"], &[]);
+        let eff = resolve(Some(&g), Some(&t), None);
+        assert_eq!(eff.allow_patterns, vec!["mcp__a__*".to_string()]);
+    }
+
+    #[test]
+    fn empty_allow_list_does_not_clobber_broader_scope() {
+        let g = pol("global", Mode::Enforce, Action::Allow, &["mcp__a__*"], &[]);
+        let t = pol("team", Mode::Enforce, Action::Allow, &[], &[]);
+        let eff = resolve(Some(&g), Some(&t), None);
+        assert_eq!(eff.allow_patterns, vec!["mcp__a__*".to_string()]);
+    }
+
+    #[test]
+    fn most_specific_scope_wins_for_mode() {
+        let g = pol("global", Mode::Observe, Action::Allow, &[], &[]);
+        let u = pol("user", Mode::Enforce, Action::Deny, &[], &[]);
+        let eff = resolve(Some(&g), None, Some(&u));
+        assert_eq!(eff.mode, Mode::Enforce);
+        assert_eq!(eff.default_action, Action::Deny);
+        assert_eq!(eff.decided_by, DecidedBy::User);
+    }
+
+    #[test]
+    fn disabled_rows_are_ignored() {
+        let g = pol("global", Mode::Observe, Action::Allow, &[], &[]);
+        let mut t = pol("team", Mode::Enforce, Action::Deny, &[], &["mcp__x__*"]);
+        t.enabled = false;
+        let eff = resolve(Some(&g), Some(&t), None);
+        assert_eq!(eff.mode, Mode::Observe);
+        assert!(eff.deny_patterns.is_empty());
+    }
+
+    // ---- decide ----------------------------------------------------------
+
+    #[test]
+    fn builtin_tools_untouched_when_scope_is_mcp_only() {
+        let (tools, servers) = empty_catalog();
+        let eff = resolve(
+            Some(&pol("global", Mode::Enforce, Action::Deny, &[], &["*"])),
+            None,
+            None,
+        );
+        // Even a deny-everything policy must not touch builtins in mcp_only scope.
+        assert!(decide("Bash", &eff, &tools, &servers).allowed);
+        assert!(decide("Read", &eff, &tools, &servers).allowed);
+        // ...but MCP tools are denied.
+        assert!(!decide("mcp__github__x", &eff, &tools, &servers).allowed);
+    }
+
+    #[test]
+    fn all_tools_scope_governs_builtins() {
+        let (tools, servers) = empty_catalog();
+        let mut row = pol("global", Mode::Enforce, Action::Deny, &[], &[]);
+        row.applies_to = AppliesTo::AllTools;
+        let eff = resolve(Some(&row), None, None);
+        assert!(!decide("Bash", &eff, &tools, &servers).allowed);
+    }
+
+    #[test]
+    fn deny_pattern_beats_allow_pattern() {
+        let (tools, servers) = empty_catalog();
+        let eff = resolve(
+            Some(&pol(
+                "global",
+                Mode::Enforce,
+                Action::Allow,
+                &["mcp__github__*"],
+                &["mcp__github__delete_*"],
+            )),
+            None,
+            None,
+        );
+        assert!(decide("mcp__github__create_issue", &eff, &tools, &servers).allowed);
+        assert!(!decide("mcp__github__delete_repo", &eff, &tools, &servers).allowed);
+    }
+
+    #[test]
+    fn deny_pattern_beats_catalog_approval() {
+        let mut servers = HashMap::new();
+        servers.insert("github".to_string(), ServerStatus::Approved);
+        let tools = HashMap::new();
+        let eff = resolve(
+            Some(&pol(
+                "global",
+                Mode::Enforce,
+                Action::Allow,
+                &[],
+                &["mcp__github__*"],
+            )),
+            None,
+            None,
+        );
+        assert!(!decide("mcp__github__create_issue", &eff, &tools, &servers).allowed);
+    }
+
+    #[test]
+    fn catalog_denial_beats_allow_pattern() {
+        let mut servers = HashMap::new();
+        servers.insert("github".to_string(), ServerStatus::Denied);
+        let tools = HashMap::new();
+        let eff = resolve(
+            Some(&pol(
+                "global",
+                Mode::Enforce,
+                Action::Allow,
+                &["mcp__github__*"],
+                &[],
+            )),
+            None,
+            None,
+        );
+        let d = decide("mcp__github__x", &eff, &tools, &servers);
+        assert!(!d.allowed);
+        assert_eq!(d.decided_by, DecidedBy::Catalog);
+    }
+
+    #[test]
+    fn per_tool_status_overrides_server_status() {
+        let mut servers = HashMap::new();
+        servers.insert("github".to_string(), ServerStatus::Approved);
+        let mut tools = HashMap::new();
+        tools.insert(
+            "mcp__github__delete_repo".to_string(),
+            CatalogStatus::Denied,
+        );
+
+        let eff = resolve(
+            Some(&pol("global", Mode::Enforce, Action::Deny, &[], &[])),
+            None,
+            None,
+        );
+        assert!(decide("mcp__github__create_issue", &eff, &tools, &servers).allowed);
+        assert!(!decide("mcp__github__delete_repo", &eff, &tools, &servers).allowed);
+    }
+
+    #[test]
+    fn exclusive_allowlist_denies_unlisted_tools() {
+        let (tools, servers) = empty_catalog();
+        let eff = resolve(
+            Some(&pol(
+                "global",
+                Mode::Enforce,
+                Action::Allow,
+                &["mcp__github__*"],
+                &[],
+            )),
+            None,
+            None,
+        );
+        // default_action is Allow, but a non-empty allowlist is exclusive.
+        assert!(!decide("mcp__slack__post", &eff, &tools, &servers).allowed);
+    }
+
+    #[test]
+    fn default_action_governs_unknown_tools() {
+        let (tools, servers) = empty_catalog();
+
+        let allow_eff = resolve(
+            Some(&pol("global", Mode::Enforce, Action::Allow, &[], &[])),
+            None,
+            None,
+        );
+        assert!(decide("mcp__brand_new__x", &allow_eff, &tools, &servers).allowed);
+
+        let deny_eff = resolve(
+            Some(&pol("global", Mode::Enforce, Action::Deny, &[], &[])),
+            None,
+            None,
+        );
+        assert!(!decide("mcp__brand_new__x", &deny_eff, &tools, &servers).allowed);
+    }
+
+    #[test]
+    fn catalog_approval_satisfies_deny_by_default() {
+        let mut servers = HashMap::new();
+        servers.insert("github".to_string(), ServerStatus::Approved);
+        let tools = HashMap::new();
+        let eff = resolve(
+            Some(&pol("global", Mode::Enforce, Action::Deny, &[], &[])),
+            None,
+            None,
+        );
+        assert!(decide("mcp__github__x", &eff, &tools, &servers).allowed);
+        assert!(!decide("mcp__unknown__x", &eff, &tools, &servers).allowed);
+    }
+
+    #[test]
+    fn no_policy_rows_defaults_to_permissive_observe() {
+        let (tools, servers) = empty_catalog();
+        let eff = resolve(None, None, None);
+        assert_eq!(eff.mode, Mode::Observe);
+        assert!(decide("mcp__anything__x", &eff, &tools, &servers).allowed);
+    }
+}

--- a/src/mcpgov/response.rs
+++ b/src/mcpgov/response.rs
@@ -1,0 +1,559 @@
+//! Response-side refusal of denied tool calls.
+//!
+//! # Why this exists
+//!
+//! Request-side filtering cannot be made airtight, and it took three attempts to accept
+//! that. The overlay first stripped denied definitions from `tools[]`; a continuing
+//! session kept working, because the model re-invoked the tool from the `tool_use` blocks
+//! still in its transcript. The overlay then also scrubbed the transcript; a real session
+//! *still* executed the tool. The reason is simple once seen: a model will emit a
+//! `tool_use` block for any name it has reason to believe exists, and the client executes
+//! whatever it is asked for. Merely mentioning the tool in the system prompt — which
+//! Claude Code does when it enumerates connected MCP servers — is enough. Verified
+//! against the live gateway: with `tools[]` clean and no history at all, a system prompt
+//! naming `mcp__context7__resolve-library-id` produced a `tool_use` for exactly that.
+//!
+//! There is no finite set of inputs to sanitise, because the leak is the model's
+//! generative capacity, not any one field. So enforcement has to happen at the only point
+//! where the tool name is a fact rather than a possibility: the response.
+//!
+//! Request-side stripping is still worth keeping — it stops the model wanting the tool in
+//! the first place, which avoids a wasted turn — but this module is what actually
+//! guarantees the call never reaches the client.
+//!
+//! # Why this is cheaper than it looks
+//!
+//! The original design note claimed response interception needed a `partial_json`
+//! accumulator. It does not. A tool call's name arrives in `content_block_start`, before
+//! any `input_json_delta`, so the verdict is available immediately and the argument
+//! deltas can simply be discarded. Only the *arguments* need reassembly, and policy does
+//! not look at arguments.
+//!
+//! # What a refusal looks like on the wire
+//!
+//! A denied `tool_use` block becomes a `text` block explaining the block, and if it was
+//! the only tool call in the turn `stop_reason` is relaxed from `tool_use` to `end_turn`.
+//! Rewriting rather than deleting matters: dropping the block would leave a
+//! `stop_reason: tool_use` with nothing to execute, and would open a gap in the streamed
+//! block indices. A turn that also called permitted tools keeps `stop_reason: tool_use`,
+//! so those still run.
+
+use std::collections::{HashMap, HashSet};
+
+use serde_json::{Value, json};
+
+use super::{
+    CatalogStatus, DeniedTool, EffectivePolicy, Mode, RequestContext, cache, policy, sink,
+};
+
+/// What the caller should emit for a stream event it just handed to the guard.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StreamAction {
+    /// Emit the event as it now stands. It may have been mutated in place.
+    Forward,
+    /// Emit nothing: this event belonged to a refused tool call.
+    Drop,
+    /// Emit the event, then this synthetic follow-up.
+    ForwardThen(Value),
+}
+
+/// Per-request policy snapshot plus the streaming state machine.
+///
+/// Owned and `Send + 'static` on purpose: `handle_streaming` moves its generator into a
+/// spawned task, so the guard cannot borrow from `GatewayState`.
+///
+/// `Clone` because endpoint failover retries the whole call and each attempt needs its own
+/// state machine. Cloning copies two catalog maps, which is affordable on a path that only
+/// runs after an upstream throttle or 5xx.
+#[derive(Clone)]
+pub struct ResponseGuard {
+    eff: EffectivePolicy,
+    tools: HashMap<String, CatalogStatus>,
+    servers: HashMap<String, CatalogStatus>,
+    ctx: RequestContext,
+
+    /// Names the request side already wrote an audit row for. Without this, denying a
+    /// declared tool would log the same block twice for one request.
+    already_audited: HashSet<String>,
+
+    /// Memoised verdicts. A turn commonly retries the same tool, and a decision walks
+    /// the pattern lists and both catalog maps.
+    verdicts: HashMap<String, bool>,
+
+    /// Streamed block indices whose `tool_use` was refused, so their argument deltas can
+    /// be dropped.
+    suppressed: HashSet<i64>,
+
+    /// Distinct tools actually refused, for the audit trail and the log line.
+    blocked: Vec<DeniedTool>,
+
+    /// Every `tool_use` seen this response. Compared against `suppressed` to decide
+    /// whether `stop_reason` may be relaxed.
+    tool_uses_seen: usize,
+}
+
+/// Build a guard for this request, or `None` when there is nothing it could ever do.
+///
+/// Returning `None` is the common case and keeps the response path untouched: policy has
+/// to be in `enforce`, and something has to be deniable at all. `observe` and `warn` are
+/// recorded on the request side and must not alter a response.
+///
+/// `already_audited` should be the tool names the request side just logged.
+pub async fn guard_for(
+    ctx: &RequestContext,
+    already_audited: &[DeniedTool],
+) -> Option<ResponseGuard> {
+    let eff = cache::effective_policy(ctx).await;
+    if eff.mode != Mode::Enforce {
+        return None;
+    }
+
+    let (tools, servers) = cache::catalog_snapshot().await;
+
+    // A policy that denies nothing cannot refuse anything, so skip the whole machinery
+    // rather than paying for a decision on every block of every response.
+    let can_deny = !eff.deny_patterns.is_empty()
+        || !eff.allow_patterns.is_empty()
+        || eff.default_action == super::Action::Deny
+        || tools.values().any(|s| *s == CatalogStatus::Denied)
+        || servers.values().any(|s| *s == CatalogStatus::Denied);
+    if !can_deny {
+        return None;
+    }
+
+    Some(ResponseGuard {
+        eff,
+        tools,
+        servers,
+        ctx: ctx.clone(),
+        already_audited: already_audited
+            .iter()
+            .map(|d| d.tool_name.clone())
+            .collect(),
+        verdicts: HashMap::new(),
+        suppressed: HashSet::new(),
+        blocked: Vec::new(),
+        tool_uses_seen: 0,
+    })
+}
+
+/// The text that replaces a refused call. Addressed to the developer reading the
+/// transcript, since this lands in the assistant's visible output.
+fn refusal_text(tool_name: &str) -> String {
+    format!(
+        "[MCP policy] `{tool_name}` is not permitted for your account, so the call was not executed."
+    )
+}
+
+impl ResponseGuard {
+    /// Distinct tools this response refused.
+    pub fn blocked(&self) -> &[DeniedTool] {
+        &self.blocked
+    }
+
+    /// Whether the guard changed anything, for the caller's log line.
+    pub fn acted(&self) -> bool {
+        !self.blocked.is_empty()
+    }
+
+    /// Decide a name, memoising and auditing the first refusal of each tool.
+    fn refuse(&mut self, name: &str) -> bool {
+        if let Some(known) = self.verdicts.get(name) {
+            return *known;
+        }
+
+        let d = policy::decide(name, &self.eff, &self.tools, &self.servers);
+        let denied = !d.allowed;
+        self.verdicts.insert(name.to_string(), denied);
+
+        if denied {
+            let parsed = policy::parse_tool_name(name);
+            let record = DeniedTool {
+                tool_name: name.to_string(),
+                server_name: parsed.server.map(String::from),
+                reason: d.reason,
+                decided_by: d.decided_by.as_str().to_string(),
+            };
+            // Only audit a name the request side did not already cover, so one refusal
+            // is one row.
+            if !self.already_audited.contains(name) {
+                sink::record_events(
+                    std::slice::from_ref(&record),
+                    "blocked",
+                    Mode::Enforce,
+                    &self.ctx,
+                );
+            }
+            self.blocked.push(record);
+        }
+
+        denied
+    }
+
+    /// True once every tool call in this response has been refused, meaning the client
+    /// has nothing left to execute and `stop_reason: tool_use` would strand it.
+    fn all_calls_refused(&self) -> bool {
+        self.tool_uses_seen > 0 && self.suppressed.len() == self.tool_uses_seen
+    }
+
+    /// Refuse denied calls in a complete (non-streaming) response.
+    pub fn rewrite_non_streaming(&mut self, resp: &mut Value) {
+        let Some(content) = resp.get_mut("content").and_then(|c| c.as_array_mut()) else {
+            return;
+        };
+
+        let mut refused = 0usize;
+        let mut calls = 0usize;
+        for block in content.iter_mut() {
+            if block.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+                continue;
+            }
+            calls += 1;
+            let Some(name) = block.get("name").and_then(|n| n.as_str()).map(String::from) else {
+                continue;
+            };
+            if self.refuse(&name) {
+                *block = json!({ "type": "text", "text": refusal_text(&name) });
+                refused += 1;
+            }
+        }
+
+        self.tool_uses_seen += calls;
+        if refused == 0 {
+            return;
+        }
+
+        // Mirror the streaming bookkeeping so `all_calls_refused` is meaningful for both
+        // paths. Indices are synthetic here; only the count is used.
+        for i in 0..refused {
+            self.suppressed.insert(-(i as i64) - 1);
+        }
+
+        if refused == calls
+            && let Some(obj) = resp.as_object_mut()
+        {
+            obj.insert("stop_reason".to_string(), json!("end_turn"));
+        }
+    }
+
+    /// Handle one outbound SSE event.
+    ///
+    /// Call this after the event has been normalised and immediately before it is
+    /// written to the client.
+    pub fn on_stream_event(&mut self, event: &mut Value) -> StreamAction {
+        let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        match event_type {
+            "content_block_start" => {
+                let is_tool_use = event
+                    .pointer("/content_block/type")
+                    .and_then(|t| t.as_str())
+                    == Some("tool_use");
+                if !is_tool_use {
+                    return StreamAction::Forward;
+                }
+                self.tool_uses_seen += 1;
+
+                let Some(name) = event
+                    .pointer("/content_block/name")
+                    .and_then(|n| n.as_str())
+                    .map(String::from)
+                else {
+                    return StreamAction::Forward;
+                };
+                if !self.refuse(&name) {
+                    return StreamAction::Forward;
+                }
+
+                let index = event.get("index").and_then(|i| i.as_i64()).unwrap_or(-1);
+                self.suppressed.insert(index);
+
+                // Become an empty text block, then carry the explanation in a delta.
+                // Anthropic's own text blocks open empty and accumulate, so a client that
+                // renders from deltas and one that reads the opening block agree.
+                if let Some(obj) = event.as_object_mut() {
+                    obj.insert(
+                        "content_block".to_string(),
+                        json!({ "type": "text", "text": "" }),
+                    );
+                }
+                StreamAction::ForwardThen(json!({
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": { "type": "text_delta", "text": refusal_text(&name) }
+                }))
+            }
+
+            // Argument deltas for a refused call. Dropping them is safe precisely because
+            // policy never inspects arguments.
+            "content_block_delta" => {
+                let index = event.get("index").and_then(|i| i.as_i64()).unwrap_or(-1);
+                if self.suppressed.contains(&index) {
+                    StreamAction::Drop
+                } else {
+                    StreamAction::Forward
+                }
+            }
+
+            // Forwarded unchanged: the rewritten text block still has to close.
+            "content_block_stop" => StreamAction::Forward,
+
+            "message_delta" => {
+                if self.all_calls_refused()
+                    && let Some(delta) = event.get_mut("delta").and_then(|d| d.as_object_mut())
+                    && delta.get("stop_reason").and_then(|s| s.as_str()) == Some("tool_use")
+                {
+                    delta.insert("stop_reason".to_string(), json!("end_turn"));
+                }
+                StreamAction::Forward
+            }
+
+            _ => StreamAction::Forward,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcpgov::{Action, AppliesTo, DecidedBy};
+
+    /// A guard that denies exactly the given names, without touching the cache.
+    fn guard(denied: &[&str]) -> ResponseGuard {
+        ResponseGuard {
+            eff: EffectivePolicy {
+                mode: Mode::Enforce,
+                default_action: Action::Allow,
+                applies_to: AppliesTo::McpOnly,
+                allow_patterns: Vec::new(),
+                deny_patterns: denied.iter().map(|s| s.to_string()).collect(),
+                decided_by: DecidedBy::Global,
+            },
+            tools: HashMap::new(),
+            servers: HashMap::new(),
+            ctx: RequestContext::default(),
+            already_audited: HashSet::new(),
+            verdicts: HashMap::new(),
+            suppressed: HashSet::new(),
+            blocked: Vec::new(),
+            tool_uses_seen: 0,
+        }
+    }
+
+    fn start_event(index: i64, name: &str) -> Value {
+        json!({
+            "type": "content_block_start",
+            "index": index,
+            "content_block": { "type": "tool_use", "id": "toolu_1", "name": name, "input": {} }
+        })
+    }
+
+    // ---- non-streaming ---------------------------------------------------
+
+    #[test]
+    fn refused_call_becomes_text_and_relaxes_stop_reason() {
+        let mut g = guard(&["mcp__context7__*"]);
+        let mut resp = json!({
+            "content": [
+                { "type": "text", "text": "Looking that up." },
+                { "type": "tool_use", "id": "t1",
+                  "name": "mcp__context7__resolve-library-id", "input": { "libraryName": "React" } }
+            ],
+            "stop_reason": "tool_use"
+        });
+
+        g.rewrite_non_streaming(&mut resp);
+
+        assert_eq!(resp["stop_reason"], "end_turn");
+        assert_eq!(resp["content"][1]["type"], "text");
+        assert_eq!(g.blocked().len(), 1);
+        // The name survives only inside the explanation, never as a callable block.
+        assert!(
+            resp["content"][1]["text"]
+                .as_str()
+                .unwrap()
+                .contains("not permitted")
+        );
+    }
+
+    #[test]
+    fn a_permitted_call_alongside_a_refused_one_keeps_stop_reason() {
+        // The client must still execute the tool it is allowed to use.
+        let mut g = guard(&["mcp__context7__*"]);
+        let mut resp = json!({
+            "content": [
+                { "type": "tool_use", "id": "t1", "name": "mcp__context7__x", "input": {} },
+                { "type": "tool_use", "id": "t2", "name": "mcp__everything__echo", "input": {} }
+            ],
+            "stop_reason": "tool_use"
+        });
+
+        g.rewrite_non_streaming(&mut resp);
+
+        assert_eq!(
+            resp["stop_reason"], "tool_use",
+            "the allowed call still needs running"
+        );
+        assert_eq!(resp["content"][0]["type"], "text");
+        assert_eq!(resp["content"][1]["type"], "tool_use");
+    }
+
+    #[test]
+    fn a_response_with_no_denied_calls_is_untouched() {
+        let mut g = guard(&["mcp__context7__*"]);
+        let mut resp = json!({
+            "content": [ { "type": "tool_use", "id": "t1", "name": "mcp__everything__echo", "input": {} } ],
+            "stop_reason": "tool_use"
+        });
+        let before = resp.clone();
+
+        g.rewrite_non_streaming(&mut resp);
+
+        assert_eq!(resp, before);
+        assert!(!g.acted());
+    }
+
+    #[test]
+    fn missing_or_malformed_content_does_not_panic() {
+        let mut g = guard(&["mcp__a__*"]);
+        let mut no_content = json!({ "stop_reason": "end_turn" });
+        g.rewrite_non_streaming(&mut no_content);
+
+        let mut junk = json!({ "content": [ { "type": "tool_use" }, 42, "str" ] });
+        g.rewrite_non_streaming(&mut junk);
+        assert!(!g.acted());
+    }
+
+    // ---- streaming -------------------------------------------------------
+
+    #[test]
+    fn refused_stream_block_is_rewritten_and_its_deltas_dropped() {
+        let mut g = guard(&["mcp__context7__*"]);
+
+        let mut start = start_event(1, "mcp__context7__resolve-library-id");
+        let action = g.on_stream_event(&mut start);
+
+        // The block is no longer a tool call.
+        assert_eq!(start["content_block"]["type"], "text");
+        assert_eq!(start["content_block"]["text"], "");
+        // ... and the explanation follows as a delta.
+        match action {
+            StreamAction::ForwardThen(extra) => {
+                assert_eq!(extra["index"], 1);
+                assert_eq!(extra["delta"]["type"], "text_delta");
+                assert!(
+                    extra["delta"]["text"]
+                        .as_str()
+                        .unwrap()
+                        .contains("not permitted")
+                );
+            }
+            other => panic!("expected ForwardThen, got {other:?}"),
+        }
+
+        // Argument deltas for that index are discarded.
+        let mut delta = json!({
+            "type": "content_block_delta", "index": 1,
+            "delta": { "type": "input_json_delta", "partial_json": "{\"libraryName\":" }
+        });
+        assert_eq!(g.on_stream_event(&mut delta), StreamAction::Drop);
+
+        // The block still closes, or the client waits forever.
+        let mut stop = json!({ "type": "content_block_stop", "index": 1 });
+        assert_eq!(g.on_stream_event(&mut stop), StreamAction::Forward);
+
+        // Nothing is left to run, so the turn ends.
+        let mut md = json!({
+            "type": "message_delta",
+            "delta": { "stop_reason": "tool_use", "stop_sequence": null }
+        });
+        assert_eq!(g.on_stream_event(&mut md), StreamAction::Forward);
+        assert_eq!(md["delta"]["stop_reason"], "end_turn");
+    }
+
+    #[test]
+    fn deltas_of_a_permitted_block_are_forwarded() {
+        let mut g = guard(&["mcp__context7__*"]);
+
+        let mut start = start_event(0, "mcp__everything__echo");
+        assert_eq!(g.on_stream_event(&mut start), StreamAction::Forward);
+        assert_eq!(
+            start["content_block"]["type"], "tool_use",
+            "must stay callable"
+        );
+
+        let mut delta = json!({
+            "type": "content_block_delta", "index": 0,
+            "delta": { "type": "input_json_delta", "partial_json": "{}" }
+        });
+        assert_eq!(g.on_stream_event(&mut delta), StreamAction::Forward);
+
+        let mut md = json!({ "type": "message_delta", "delta": { "stop_reason": "tool_use" } });
+        g.on_stream_event(&mut md);
+        assert_eq!(
+            md["delta"]["stop_reason"], "tool_use",
+            "the allowed call must survive"
+        );
+    }
+
+    #[test]
+    fn a_mixed_turn_keeps_stop_reason_and_only_drops_the_refused_index() {
+        let mut g = guard(&["mcp__context7__*"]);
+
+        let mut allowed = start_event(0, "mcp__everything__echo");
+        g.on_stream_event(&mut allowed);
+        let mut refused = start_event(1, "mcp__context7__x");
+        g.on_stream_event(&mut refused);
+
+        let mut d0 = json!({ "type": "content_block_delta", "index": 0, "delta": {} });
+        let mut d1 = json!({ "type": "content_block_delta", "index": 1, "delta": {} });
+        assert_eq!(g.on_stream_event(&mut d0), StreamAction::Forward);
+        assert_eq!(g.on_stream_event(&mut d1), StreamAction::Drop);
+
+        let mut md = json!({ "type": "message_delta", "delta": { "stop_reason": "tool_use" } });
+        g.on_stream_event(&mut md);
+        assert_eq!(md["delta"]["stop_reason"], "tool_use");
+    }
+
+    #[test]
+    fn text_blocks_and_unrelated_events_pass_through_untouched() {
+        let mut g = guard(&["mcp__a__*"]);
+        for mut ev in [
+            json!({ "type": "message_start", "message": { "id": "m1" } }),
+            json!({ "type": "content_block_start", "index": 0,
+                    "content_block": { "type": "text", "text": "" } }),
+            json!({ "type": "ping" }),
+            json!({ "type": "message_stop" }),
+        ] {
+            let before = ev.clone();
+            assert_eq!(g.on_stream_event(&mut ev), StreamAction::Forward);
+            assert_eq!(ev, before);
+        }
+        assert!(!g.acted());
+    }
+
+    #[test]
+    fn a_repeated_name_is_decided_and_audited_once() {
+        // Three calls to the same tool in one turn must all be refused, but they are one
+        // policy decision and one audit row -- otherwise a model that retries in a loop
+        // would flood the audit log.
+        let mut g = guard(&["mcp__context7__*"]);
+        for i in 0..3 {
+            let mut ev = start_event(i, "mcp__context7__x");
+            g.on_stream_event(&mut ev);
+            assert!(g.suppressed.contains(&i), "every call is still suppressed");
+        }
+        assert_eq!(g.verdicts.len(), 1, "judged once");
+        assert_eq!(g.blocked().len(), 1, "audited once");
+        assert_eq!(g.tool_uses_seen, 3);
+        assert!(g.all_calls_refused());
+    }
+
+    #[test]
+    fn stop_reason_is_left_alone_when_no_call_was_refused() {
+        let mut g = guard(&["mcp__nothing__*"]);
+        let mut md = json!({ "type": "message_delta", "delta": { "stop_reason": "max_tokens" } });
+        g.on_stream_event(&mut md);
+        assert_eq!(md["delta"]["stop_reason"], "max_tokens");
+    }
+}

--- a/src/mcpgov/sink.rs
+++ b/src/mcpgov/sink.rs
@@ -1,0 +1,177 @@
+//! Buffered background writers for catalog discovery and audit events.
+//!
+//! Both are strictly fire-and-forget. Nothing here may block, slow, or fail a
+//! `/v1/messages` request: the channels are bounded and overflow is dropped with a
+//! counter rather than applying backpressure to the request path. Losing a few audit
+//! rows under extreme load is an acceptable trade for never adding latency.
+
+use std::sync::LazyLock;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use sqlx::PgPool;
+use tokio::sync::mpsc;
+
+use super::{DeniedTool, Mode, RequestContext, cache, policy, store};
+
+/// Bounded so a pathological workload cannot grow memory without limit.
+const CHANNEL_CAPACITY: usize = 1024;
+/// Maximum rows coalesced into a single INSERT.
+const BATCH_SIZE: usize = 256;
+/// How often the audit log is trimmed.
+const PRUNE_INTERVAL_SECS: u64 = 3600;
+/// Default audit retention, overridable with the `mcpgov_event_retention_days` setting.
+const DEFAULT_RETENTION_DAYS: i64 = 30;
+
+type EventItem = (DeniedTool, String, Mode, RequestContext);
+
+struct Channels {
+    tools_tx: mpsc::Sender<Vec<String>>,
+    tools_rx: Mutex<Option<mpsc::Receiver<Vec<String>>>>,
+    events_tx: mpsc::Sender<EventItem>,
+    events_rx: Mutex<Option<mpsc::Receiver<EventItem>>>,
+}
+
+static CHANNELS: LazyLock<Channels> = LazyLock::new(|| {
+    let (tools_tx, tools_rx) = mpsc::channel(CHANNEL_CAPACITY);
+    let (events_tx, events_rx) = mpsc::channel(CHANNEL_CAPACITY);
+    Channels {
+        tools_tx,
+        tools_rx: Mutex::new(Some(tools_rx)),
+        events_tx,
+        events_rx: Mutex::new(Some(events_rx)),
+    }
+});
+
+static DROPPED_TOOLS: AtomicU64 = AtomicU64::new(0);
+static DROPPED_EVENTS: AtomicU64 = AtomicU64::new(0);
+
+/// Number of discovery / audit items dropped because a buffer was full. Surfaced in
+/// the admin summary so a silent loss is at least visible.
+pub fn dropped_counts() -> (u64, u64) {
+    (
+        DROPPED_TOOLS.load(Ordering::Relaxed),
+        DROPPED_EVENTS.load(Ordering::Relaxed),
+    )
+}
+
+/// Spawn the drain and maintenance tasks. Idempotent: the receivers can only be taken
+/// once, so a second call is a no-op.
+pub fn start(pool: PgPool) {
+    if let Some(rx) = CHANNELS.tools_rx.lock().ok().and_then(|mut g| g.take()) {
+        spawn_tools_drain(pool.clone(), rx);
+    }
+    if let Some(rx) = CHANNELS.events_rx.lock().ok().and_then(|mut g| g.take()) {
+        spawn_events_drain(pool.clone(), rx);
+    }
+    spawn_prune(pool);
+}
+
+/// Queue any tool names the catalog has not seen before.
+///
+/// The cache filters known names first, so in steady state this is a single read lock
+/// and an early return — no channel traffic, no database work.
+pub async fn observe_tools(names: &[String]) {
+    let fresh = cache::take_unknown(names).await;
+    if fresh.is_empty() {
+        return;
+    }
+    if CHANNELS.tools_tx.try_send(fresh).is_err() {
+        DROPPED_TOOLS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Queue audit rows for tools that policy denied.
+pub fn record_events(denied: &[DeniedTool], decision: &str, mode: Mode, ctx: &RequestContext) {
+    for d in denied {
+        let item = (d.clone(), decision.to_string(), mode, ctx.clone());
+        if CHANNELS.events_tx.try_send(item).is_err() {
+            DROPPED_EVENTS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+fn spawn_tools_drain(pool: PgPool, mut rx: mpsc::Receiver<Vec<String>>) {
+    tokio::spawn(async move {
+        let mut pending: Vec<Vec<String>> = Vec::new();
+        while let Some(first) = rx.recv().await {
+            pending.push(first);
+            // Coalesce whatever else is already queued.
+            while pending.len() < BATCH_SIZE {
+                match rx.try_recv() {
+                    Ok(more) => pending.push(more),
+                    Err(_) => break,
+                }
+            }
+
+            let mut names: Vec<String> = Vec::new();
+            for group in pending.drain(..) {
+                for n in group {
+                    if !names.contains(&n) {
+                        names.push(n);
+                    }
+                }
+            }
+
+            let servers: Vec<Option<String>> = names
+                .iter()
+                .map(|n| policy::parse_tool_name(n).server.map(String::from))
+                .collect();
+
+            if let Err(e) = store::upsert_observed(&pool, &names, &servers).await {
+                tracing::warn!(%e, count = names.len(), "mcpgov: catalog upsert failed");
+            } else {
+                tracing::debug!(count = names.len(), "mcpgov: discovered new tools");
+            }
+        }
+    });
+}
+
+fn spawn_events_drain(pool: PgPool, mut rx: mpsc::Receiver<EventItem>) {
+    tokio::spawn(async move {
+        let mut batch: Vec<EventItem> = Vec::new();
+        while let Some(first) = rx.recv().await {
+            batch.push(first);
+            while batch.len() < BATCH_SIZE {
+                match rx.try_recv() {
+                    Ok(more) => batch.push(more),
+                    Err(_) => break,
+                }
+            }
+
+            if let Err(e) = store::insert_events(&pool, &batch).await {
+                tracing::warn!(%e, count = batch.len(), "mcpgov: audit insert failed");
+            }
+            batch.clear();
+        }
+    });
+}
+
+fn spawn_prune(pool: PgPool) {
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(PRUNE_INTERVAL_SECS));
+        // The first tick fires immediately; skip it so boot does not do maintenance.
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+
+            let days = crate::db::settings::get_setting(&pool, "mcpgov_event_retention_days")
+                .await
+                .ok()
+                .flatten()
+                .and_then(|v| v.parse::<i64>().ok())
+                .filter(|d| *d > 0)
+                .unwrap_or(DEFAULT_RETENTION_DAYS);
+
+            match store::prune_events(&pool, days).await {
+                Ok(n) if n > 0 => {
+                    tracing::info!(pruned = n, keep_days = days, "mcpgov: trimmed audit log")
+                }
+                Ok(_) => {}
+                Err(e) => tracing::warn!(%e, "mcpgov: audit prune failed"),
+            }
+        }
+    });
+}

--- a/src/mcpgov/store.rs
+++ b/src/mcpgov/store.rs
@@ -1,0 +1,527 @@
+//! Database access for the governance overlay.
+//!
+//! Deliberately uses sqlx's **runtime** query API (`sqlx::query_as::<_, T>("...")`)
+//! rather than the `query!` macros, so the extension needs no entries in `.sqlx/` and
+//! `cargo build` works offline without regenerating the upstream query cache.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::{Action, AppliesTo, DeniedTool, Mode, PolicyRow, RequestContext};
+
+// ---------------------------------------------------------------------------
+// Row types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ServerRow {
+    pub id: Uuid,
+    pub server_name: String,
+    pub status: String,
+    pub notes: Option<String>,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct ToolRow {
+    pub id: Uuid,
+    pub tool_name: String,
+    pub server_name: Option<String>,
+    pub status: String,
+    pub first_seen: DateTime<Utc>,
+    pub last_seen: DateTime<Utc>,
+    pub seen_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct PolicyDbRow {
+    pub id: Uuid,
+    pub scope: String,
+    pub scope_ref: Option<String>,
+    pub mode: String,
+    pub default_action: String,
+    pub applies_to: String,
+    pub allow_patterns: serde_json::Value,
+    pub deny_patterns: serde_json::Value,
+    pub enabled: bool,
+    pub updated_at: DateTime<Utc>,
+    pub updated_by: Option<String>,
+}
+
+fn json_to_patterns(v: &serde_json::Value) -> Vec<String> {
+    v.as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+impl PolicyDbRow {
+    /// Convert to the engine's representation, tolerating unknown enum strings by
+    /// falling back to the safe (least restrictive) variant.
+    pub fn to_policy(&self) -> PolicyRow {
+        PolicyRow {
+            scope: self.scope.clone(),
+            scope_ref: self.scope_ref.clone(),
+            mode: Mode::parse(&self.mode),
+            default_action: Action::parse(&self.default_action),
+            applies_to: AppliesTo::parse(&self.applies_to),
+            allow_patterns: json_to_patterns(&self.allow_patterns),
+            deny_patterns: json_to_patterns(&self.deny_patterns),
+            enabled: self.enabled,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct EventRow {
+    pub id: i64,
+    pub created_at: DateTime<Utc>,
+    pub tool_name: String,
+    pub server_name: Option<String>,
+    pub decision: String,
+    pub mode: String,
+    pub reason: String,
+    pub decided_by: Option<String>,
+    pub user_identity: Option<String>,
+    pub team_id: Option<Uuid>,
+    pub key_id: Option<Uuid>,
+    pub request_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+pub async fn load_policies(pool: &PgPool) -> anyhow::Result<Vec<PolicyDbRow>> {
+    let rows = sqlx::query_as::<_, PolicyDbRow>(
+        "SELECT * FROM mcpgov_policies ORDER BY scope, COALESCE(scope_ref, '')",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+pub async fn load_servers(pool: &PgPool) -> anyhow::Result<Vec<ServerRow>> {
+    let rows = sqlx::query_as::<_, ServerRow>("SELECT * FROM mcpgov_servers ORDER BY server_name")
+        .fetch_all(pool)
+        .await?;
+    Ok(rows)
+}
+
+pub async fn load_tools(pool: &PgPool) -> anyhow::Result<Vec<ToolRow>> {
+    let rows = sqlx::query_as::<_, ToolRow>("SELECT * FROM mcpgov_tools ORDER BY tool_name")
+        .fetch_all(pool)
+        .await?;
+    Ok(rows)
+}
+
+/// Tools filtered for the approval queue, newest-seen first.
+pub async fn list_tools_filtered(
+    pool: &PgPool,
+    status: Option<&str>,
+    server: Option<&str>,
+    limit: i64,
+) -> anyhow::Result<Vec<ToolRow>> {
+    let rows = sqlx::query_as::<_, ToolRow>(
+        r#"SELECT * FROM mcpgov_tools
+           WHERE ($1::text IS NULL OR status = $1)
+             AND ($2::text IS NULL OR server_name = $2)
+           ORDER BY last_seen DESC, tool_name
+           LIMIT $3"#,
+    )
+    .bind(status)
+    .bind(server)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+pub async fn list_events(
+    pool: &PgPool,
+    decision: Option<&str>,
+    user_identity: Option<&str>,
+    limit: i64,
+) -> anyhow::Result<Vec<EventRow>> {
+    let rows = sqlx::query_as::<_, EventRow>(
+        r#"SELECT * FROM mcpgov_events
+           WHERE ($1::text IS NULL OR decision = $1)
+             AND ($2::text IS NULL OR user_identity = $2)
+           ORDER BY created_at DESC, id DESC
+           LIMIT $3"#,
+    )
+    .bind(decision)
+    .bind(user_identity)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Summary {
+    pub servers_total: i64,
+    pub servers_pending: i64,
+    pub servers_approved: i64,
+    pub servers_denied: i64,
+    pub tools_total: i64,
+    pub tools_pending: i64,
+    pub tools_approved: i64,
+    pub tools_denied: i64,
+    pub events_24h_blocked: i64,
+    pub events_24h_would_block: i64,
+    pub events_24h_warned: i64,
+}
+
+pub async fn summary(pool: &PgPool) -> anyhow::Result<Summary> {
+    let (s_total, s_pending, s_approved, s_denied): (i64, i64, i64, i64) = sqlx::query_as(
+        r#"SELECT count(*),
+                  count(*) FILTER (WHERE status = 'pending'),
+                  count(*) FILTER (WHERE status = 'approved'),
+                  count(*) FILTER (WHERE status = 'denied')
+           FROM mcpgov_servers"#,
+    )
+    .fetch_one(pool)
+    .await?;
+
+    // Tool 'pending' is spelled `inherit` in the tools table.
+    let (t_total, t_pending, t_approved, t_denied): (i64, i64, i64, i64) = sqlx::query_as(
+        r#"SELECT count(*),
+                  count(*) FILTER (WHERE status = 'inherit'),
+                  count(*) FILTER (WHERE status = 'approved'),
+                  count(*) FILTER (WHERE status = 'denied')
+           FROM mcpgov_tools"#,
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let (blocked, would_block, warned): (i64, i64, i64) = sqlx::query_as(
+        r#"SELECT count(*) FILTER (WHERE decision = 'blocked'),
+                  count(*) FILTER (WHERE decision = 'would_block'),
+                  count(*) FILTER (WHERE decision = 'warned')
+           FROM mcpgov_events
+           WHERE created_at > now() - interval '24 hours'"#,
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(Summary {
+        servers_total: s_total,
+        servers_pending: s_pending,
+        servers_approved: s_approved,
+        servers_denied: s_denied,
+        tools_total: t_total,
+        tools_pending: t_pending,
+        tools_approved: t_approved,
+        tools_denied: t_denied,
+        events_24h_blocked: blocked,
+        events_24h_would_block: would_block,
+        events_24h_warned: warned,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Discovery writes (must NOT bump cache_version)
+// ---------------------------------------------------------------------------
+
+/// Upsert observed tool names into the catalog.
+///
+/// This runs off the hot path from a buffered writer and intentionally does **not**
+/// call `bump_cache_version`: discovery happens continuously, and bumping the shared
+/// version counter would invalidate every unrelated cache (keys, endpoints, model
+/// mappings) on every replica each time a new tool name appeared.
+pub async fn upsert_observed(
+    pool: &PgPool,
+    names: &[String],
+    servers: &[Option<String>],
+) -> anyhow::Result<()> {
+    if names.is_empty() {
+        return Ok(());
+    }
+
+    // Servers first, so the tools rows always have a catalog parent to inherit from.
+    sqlx::query(
+        r#"INSERT INTO mcpgov_servers (server_name)
+           SELECT DISTINCT s FROM UNNEST($1::text[]) AS s WHERE s IS NOT NULL
+           ON CONFLICT (server_name) DO UPDATE SET last_seen = now()"#,
+    )
+    .bind(servers)
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        r#"INSERT INTO mcpgov_tools (tool_name, server_name, seen_count)
+           SELECT t.name, t.server, 1
+           FROM UNNEST($1::text[], $2::text[]) AS t(name, server)
+           ON CONFLICT (tool_name) DO UPDATE
+             SET last_seen = now(),
+                 seen_count = mcpgov_tools.seen_count + 1,
+                 server_name = COALESCE(mcpgov_tools.server_name, EXCLUDED.server_name)"#,
+    )
+    .bind(names)
+    .bind(servers)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Bulk-insert audit events. Also off the hot path, also no cache bump.
+pub async fn insert_events(
+    pool: &PgPool,
+    batch: &[(DeniedTool, String, Mode, RequestContext)],
+) -> anyhow::Result<()> {
+    if batch.is_empty() {
+        return Ok(());
+    }
+
+    let tool_names: Vec<String> = batch.iter().map(|(d, ..)| d.tool_name.clone()).collect();
+    let server_names: Vec<Option<String>> =
+        batch.iter().map(|(d, ..)| d.server_name.clone()).collect();
+    let decisions: Vec<String> = batch.iter().map(|(_, dec, ..)| dec.clone()).collect();
+    let modes: Vec<String> = batch
+        .iter()
+        .map(|(_, _, m, _)| m.as_str().to_string())
+        .collect();
+    let reasons: Vec<String> = batch.iter().map(|(d, ..)| d.reason.clone()).collect();
+    let decided_by: Vec<Option<String>> = batch
+        .iter()
+        .map(|(d, ..)| Some(d.decided_by.clone()))
+        .collect();
+    let users: Vec<Option<String>> = batch
+        .iter()
+        .map(|(_, _, _, c)| c.user_identity.clone())
+        .collect();
+    let teams: Vec<Option<Uuid>> = batch.iter().map(|(_, _, _, c)| c.team_id).collect();
+    let keys: Vec<Option<Uuid>> = batch.iter().map(|(_, _, _, c)| c.key_id).collect();
+    let request_ids: Vec<Option<String>> = batch
+        .iter()
+        .map(|(_, _, _, c)| c.request_id.clone())
+        .collect();
+
+    sqlx::query(
+        r#"INSERT INTO mcpgov_events
+             (tool_name, server_name, decision, mode, reason, decided_by,
+              user_identity, team_id, key_id, request_id)
+           SELECT * FROM UNNEST(
+             $1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[],
+             $7::text[], $8::uuid[], $9::uuid[], $10::text[]
+           )"#,
+    )
+    .bind(&tool_names)
+    .bind(&server_names)
+    .bind(&decisions)
+    .bind(&modes)
+    .bind(&reasons)
+    .bind(&decided_by)
+    .bind(&users)
+    .bind(&teams)
+    .bind(&keys)
+    .bind(&request_ids)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Trim the audit log. Called by the sink's periodic maintenance so the table cannot
+/// grow without bound in observe mode, where every request may log a would_block.
+pub async fn prune_events(pool: &PgPool, keep_days: i64) -> anyhow::Result<u64> {
+    let res = sqlx::query(
+        "DELETE FROM mcpgov_events WHERE created_at < now() - ($1 || ' days')::interval",
+    )
+    .bind(keep_days.to_string())
+    .execute(pool)
+    .await?;
+    Ok(res.rows_affected())
+}
+
+// ---------------------------------------------------------------------------
+// Operator writes (these DO bump cache_version so all replicas converge in <=5s)
+// ---------------------------------------------------------------------------
+
+pub async fn set_server_status(
+    pool: &PgPool,
+    server_name: &str,
+    status: &str,
+    notes: Option<&str>,
+) -> anyhow::Result<bool> {
+    let res = sqlx::query(
+        r#"UPDATE mcpgov_servers
+           SET status = $2, notes = COALESCE($3, notes), updated_at = now()
+           WHERE server_name = $1"#,
+    )
+    .bind(server_name)
+    .bind(status)
+    .bind(notes)
+    .execute(pool)
+    .await?;
+
+    if res.rows_affected() > 0 {
+        crate::db::settings::bump_cache_version(pool).await?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+pub async fn set_tool_status(pool: &PgPool, tool_name: &str, status: &str) -> anyhow::Result<bool> {
+    let res = sqlx::query("UPDATE mcpgov_tools SET status = $2 WHERE tool_name = $1")
+        .bind(tool_name)
+        .bind(status)
+        .execute(pool)
+        .await?;
+
+    if res.rows_affected() > 0 {
+        crate::db::settings::bump_cache_version(pool).await?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+/// Approve or deny every tool belonging to a server in one shot, for bulk triage.
+pub async fn set_status_for_server_tools(
+    pool: &PgPool,
+    server_name: &str,
+    status: &str,
+) -> anyhow::Result<u64> {
+    let res = sqlx::query("UPDATE mcpgov_tools SET status = $2 WHERE server_name = $1")
+        .bind(server_name)
+        .bind(status)
+        .execute(pool)
+        .await?;
+    crate::db::settings::bump_cache_version(pool).await?;
+    Ok(res.rows_affected())
+}
+
+/// Create a server row ahead of discovery, so operators can pre-approve a catalog.
+pub async fn create_server(
+    pool: &PgPool,
+    server_name: &str,
+    status: &str,
+    notes: Option<&str>,
+) -> anyhow::Result<ServerRow> {
+    let row = sqlx::query_as::<_, ServerRow>(
+        r#"INSERT INTO mcpgov_servers (server_name, status, notes)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (server_name) DO UPDATE
+             SET status = $2, notes = COALESCE($3, mcpgov_servers.notes), updated_at = now()
+           RETURNING *"#,
+    )
+    .bind(server_name)
+    .bind(status)
+    .bind(notes)
+    .fetch_one(pool)
+    .await?;
+
+    crate::db::settings::bump_cache_version(pool).await?;
+    Ok(row)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn upsert_policy(
+    pool: &PgPool,
+    scope: &str,
+    scope_ref: Option<&str>,
+    mode: &str,
+    default_action: &str,
+    applies_to: &str,
+    allow_patterns: &[String],
+    deny_patterns: &[String],
+    enabled: bool,
+    updated_by: Option<&str>,
+) -> anyhow::Result<PolicyDbRow> {
+    let allow = serde_json::to_value(allow_patterns)?;
+    let deny = serde_json::to_value(deny_patterns)?;
+
+    let row = sqlx::query_as::<_, PolicyDbRow>(
+        r#"INSERT INTO mcpgov_policies
+             (scope, scope_ref, mode, default_action, applies_to,
+              allow_patterns, deny_patterns, enabled, updated_by, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now())
+           ON CONFLICT (scope, COALESCE(scope_ref, '')) DO UPDATE
+             SET mode = $3, default_action = $4, applies_to = $5,
+                 allow_patterns = $6, deny_patterns = $7, enabled = $8,
+                 updated_by = $9, updated_at = now()
+           RETURNING *"#,
+    )
+    .bind(scope)
+    .bind(scope_ref)
+    .bind(mode)
+    .bind(default_action)
+    .bind(applies_to)
+    .bind(&allow)
+    .bind(&deny)
+    .bind(enabled)
+    .bind(updated_by)
+    .fetch_one(pool)
+    .await?;
+
+    crate::db::settings::bump_cache_version(pool).await?;
+    Ok(row)
+}
+
+pub async fn delete_policy(pool: &PgPool, id: Uuid) -> anyhow::Result<bool> {
+    // The global policy is the base layer every other scope inherits from; deleting
+    // it would silently change the meaning of every team and user policy.
+    let res = sqlx::query("DELETE FROM mcpgov_policies WHERE id = $1 AND scope <> 'global'")
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+    if res.rows_affected() > 0 {
+        crate::db::settings::bump_cache_version(pool).await?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_patterns_parse_string_arrays() {
+        let v = serde_json::json!(["a", "b"]);
+        assert_eq!(json_to_patterns(&v), vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn json_patterns_tolerate_junk() {
+        // Non-arrays and non-string members must not panic or poison the policy.
+        assert!(json_to_patterns(&serde_json::json!(null)).is_empty());
+        assert!(json_to_patterns(&serde_json::json!({"a": 1})).is_empty());
+        assert_eq!(
+            json_to_patterns(&serde_json::json!(["ok", 5, null])),
+            vec!["ok".to_string()]
+        );
+    }
+
+    #[test]
+    fn policy_row_conversion_falls_back_safely() {
+        let row = PolicyDbRow {
+            id: Uuid::nil(),
+            scope: "global".into(),
+            scope_ref: None,
+            mode: "bogus".into(),
+            default_action: "bogus".into(),
+            applies_to: "bogus".into(),
+            allow_patterns: serde_json::json!([]),
+            deny_patterns: serde_json::json!(["mcp__x__*"]),
+            enabled: true,
+            updated_at: Utc::now(),
+            updated_by: None,
+        };
+        let p = row.to_policy();
+        assert_eq!(p.mode, Mode::Observe);
+        assert_eq!(p.default_action, Action::Allow);
+        assert_eq!(p.applies_to, AppliesTo::McpOnly);
+        assert_eq!(p.deny_patterns, vec!["mcp__x__*".to_string()]);
+    }
+}

--- a/static/ext/mcp-governance.js
+++ b/static/ext/mcp-governance.js
@@ -1,0 +1,935 @@
+/*
+ * MCP / tool governance — portal extension.
+ *
+ * This file is a self-injecting overlay for the CCAG admin SPA. It adds its own nav
+ * entry, page, and modal at runtime instead of being written into static/index.html,
+ * so the upstream portal file needs exactly one line (the <script> tag that loads
+ * this) and rebasing onto a new CCAG release stays trivial.
+ *
+ * It reuses the SPA's existing globals rather than shipping its own: api(), toast(),
+ * esc(), showModal(), closeModal(), fmtDate(), and navigate().
+ */
+(function () {
+  'use strict';
+
+  var PAGE = 'mcpgov';
+  var state = {
+    tab: 'summary',
+    summary: null,
+    servers: [],
+    tools: [],
+    policies: [],
+    events: [],
+    expanded: {},      // server_name -> bool
+    editing: null,     // policy being edited
+    sim: null,         // last simulation result
+    loaded: false
+  };
+
+  // ---------------------------------------------------------------------------
+  // Small helpers. Defined defensively: if the host SPA ever renames one of its
+  // globals, the extension degrades instead of throwing.
+  // ---------------------------------------------------------------------------
+
+  function esc(s) {
+    if (window.esc) return window.esc(s);
+    var d = document.createElement('div');
+    d.textContent = s == null ? '' : String(s);
+    return d.innerHTML;
+  }
+
+  /**
+   * Attribute-safe escaping.
+   *
+   * The host SPA's esc() goes through textContent -> innerHTML, which escapes &, <
+   * and > but NOT quotes, because quotes need no escaping in element content. That
+   * makes it unsafe for attribute values: a name containing a double quote would end
+   * the attribute early and could inject markup. Since MCP server and tool names
+   * arrive from client-supplied tool definitions, they are untrusted input.
+   */
+  function attr(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function toast(msg, type) {
+    if (window.toast) return window.toast(msg, type);
+    console.log('[mcpgov]', type || 'info', msg);
+  }
+
+  function api(method, path, body) {
+    if (!window.api) return Promise.resolve({ error: 'portal api() unavailable' });
+    return window.api(method, path, body);
+  }
+
+  function fmtDate(s) {
+    if (!s) return '-';
+    if (window.fmtDate) return window.fmtDate(s);
+    try { return new Date(s).toLocaleString(); } catch (e) { return String(s); }
+  }
+
+  function fmtNum(n) {
+    if (n == null) return '0';
+    if (window.fmtNum) return window.fmtNum(n);
+    return String(n);
+  }
+
+  function statusBadge(status) {
+    var cls = 'badge-muted';
+    if (status === 'approved') cls = 'badge-green';
+    else if (status === 'denied') cls = 'badge-red';
+    else if (status === 'pending' || status === 'inherit') cls = 'badge-yellow';
+    return '<span class="badge ' + cls + '">' + esc(status) + '</span>';
+  }
+
+  function modeBadge(mode) {
+    var cls = mode === 'enforce' ? 'badge-red' : (mode === 'warn' ? 'badge-yellow' : 'badge-blue');
+    return '<span class="badge ' + cls + '">' + esc(mode) + '</span>';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Markup injection
+  // ---------------------------------------------------------------------------
+
+  var NAV_HTML =
+    '<div class="nav-item" data-page="' + PAGE + '" onclick="navigate(\'' + PAGE + '\')">' +
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+        '<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>' +
+        '<path d="M9 12l2 2 4-4"></path>' +
+      '</svg>' +
+      ' MCP &amp; Tools' +
+    '</div>';
+
+  var PAGE_HTML =
+    '<div id="page-' + PAGE + '" class="page">' +
+      '<div class="main-header">' +
+        '<h2>MCP &amp; Tools Governance</h2>' +
+        '<div style="display:flex;gap:8px">' +
+          '<button class="btn btn-secondary btn-sm" onclick="mcpgovRefresh()">Refresh</button>' +
+          '<button class="btn btn-primary btn-sm" onclick="mcpgovNewPolicy()">New Policy</button>' +
+        '</div>' +
+      '</div>' +
+      '<div class="main-content">' +
+        '<div class="info-callout" style="margin-bottom:16px">' +
+          '<div class="info-callout-body">' +
+            "<strong>How this works.</strong> Claude Code's own MCP controls are client-side, and " +
+            'Anthropic\u2019s server-managed settings are skipped for any session using a custom ' +
+            '<code>ANTHROPIC_BASE_URL</code> \u2014 which is how CCAG is used. So policy is applied here, ' +
+            'on the request path: denied tool definitions are stripped before the request reaches ' +
+            'Bedrock, with no client configuration and no way to bypass it locally.' +
+            '<br><br>' +
+            'Start in <strong>observe</strong> mode to build the catalog from real traffic, ' +
+            'approve what belongs, then switch to <strong>enforce</strong>.' +
+          '</div>' +
+        '</div>' +
+
+        '<div class="oa-tab-bar" id="mcpgov-tabs">' +
+          '<button class="oa-tab-btn" data-tab="summary" onclick="mcpgovTab(\'summary\')">Overview</button>' +
+          '<button class="oa-tab-btn" data-tab="catalog" onclick="mcpgovTab(\'catalog\')">Catalog</button>' +
+          '<button class="oa-tab-btn" data-tab="policies" onclick="mcpgovTab(\'policies\')">Policies</button>' +
+          '<button class="oa-tab-btn" data-tab="simulate" onclick="mcpgovTab(\'simulate\')">Simulator</button>' +
+          '<button class="oa-tab-btn" data-tab="audit" onclick="mcpgovTab(\'audit\')">Audit</button>' +
+        '</div>' +
+
+        '<div id="mcpgov-body" style="margin-top:16px"><div class="oa-loading">Loading\u2026</div></div>' +
+      '</div>' +
+    '</div>';
+
+  var MODAL_HTML =
+    '<div id="modal-mcpgov-policy" class="modal-overlay" style="display:none" onclick="if(event.target===this)closeModal()">' +
+      '<div class="modal">' +
+        '<div class="modal-header"><h3 id="mcpgov-modal-title">New Policy</h3></div>' +
+        '<div class="modal-body">' +
+          '<div class="form-row">' +
+            '<div class="form-group">' +
+              '<label class="form-label">Scope</label>' +
+              '<select class="form-input" id="mcpgov-p-scope" onchange="mcpgovScopeChanged()">' +
+                '<option value="global">Global (applies to everyone)</option>' +
+                '<option value="team">Team</option>' +
+                '<option value="user">User</option>' +
+              '</select>' +
+            '</div>' +
+            '<div class="form-group" id="mcpgov-p-ref-group" style="display:none">' +
+              '<label class="form-label" id="mcpgov-p-ref-label">Team</label>' +
+              '<input class="form-input" id="mcpgov-p-ref" placeholder="team UUID or user email">' +
+              '<div class="form-hint" id="mcpgov-p-ref-hint"></div>' +
+            '</div>' +
+          '</div>' +
+
+          '<div class="form-row">' +
+            '<div class="form-group">' +
+              '<label class="form-label">Mode</label>' +
+              '<select class="form-input" id="mcpgov-p-mode">' +
+                '<option value="observe">observe \u2014 record only, never modify requests</option>' +
+                '<option value="warn">warn \u2014 allow, but record as a violation</option>' +
+                '<option value="enforce">enforce \u2014 strip denied tools</option>' +
+              '</select>' +
+            '</div>' +
+            '<div class="form-group">' +
+              '<label class="form-label">Default for unknown tools</label>' +
+              '<select class="form-input" id="mcpgov-p-default">' +
+                '<option value="allow">allow \u2014 permissive (good for rollout)</option>' +
+                '<option value="deny">deny \u2014 allowlist posture</option>' +
+              '</select>' +
+            '</div>' +
+          '</div>' +
+
+          '<div class="form-group">' +
+            '<label class="form-label">Applies to</label>' +
+            '<select class="form-input" id="mcpgov-p-applies">' +
+              '<option value="mcp_only">MCP tools only \u2014 never touches Read/Write/Bash</option>' +
+              '<option value="all_tools">All tools \u2014 includes built-ins</option>' +
+            '</select>' +
+            '<div class="form-hint">Leave on <code>mcp_only</code> unless you specifically need to govern built-in tools. Governing all tools can break basic Claude Code use if misconfigured.</div>' +
+          '</div>' +
+
+          '<div class="form-group">' +
+            '<label class="form-label">Deny patterns</label>' +
+            '<textarea class="form-input" id="mcpgov-p-deny" rows="4" placeholder="mcp__github__delete_*&#10;mcp__risky__*"></textarea>' +
+            '<div class="form-hint">One glob per line. Deny always wins \u2014 nothing overrides a match. Denies from broader scopes are <strong>unioned</strong> in, so a global deny cannot be dropped by a narrower policy.</div>' +
+          '</div>' +
+
+          '<div class="form-group">' +
+            '<label class="form-label">Allow patterns</label>' +
+            '<textarea class="form-input" id="mcpgov-p-allow" rows="4" placeholder="mcp__github__*&#10;mcp__jira__*"></textarea>' +
+            '<div class="form-hint">One glob per line. If non-empty this becomes an <strong>exclusive allowlist</strong>: anything not matching is denied. A narrower scope\u2019s allowlist <strong>replaces</strong> a broader one. Leave empty to fall back to the catalog.</div>' +
+          '</div>' +
+
+          '<div class="form-group">' +
+            '<label class="form-label"><input type="checkbox" id="mcpgov-p-enabled" checked> Enabled</label>' +
+          '</div>' +
+        '</div>' +
+        '<div class="modal-footer">' +
+          '<button class="btn btn-secondary" onclick="closeModal()">Cancel</button>' +
+          '<button class="btn btn-primary" onclick="mcpgovSavePolicy()">Save</button>' +
+        '</div>' +
+      '</div>' +
+    '</div>';
+
+  /**
+   * Delegated click routing for rows rendered from untrusted data.
+   *
+   * Row actions carry `data-act` plus their arguments as data attributes instead of
+   * inline `onclick="fn('value')"`. Interpolating a name into an inline handler means
+   * escaping it for two nested contexts (HTML attribute, then JavaScript string), which
+   * is easy to get wrong and was in fact wrong here: quotes in a name broke the
+   * attribute. Data attributes need only attribute escaping, and the value reaches the
+   * handler as a plain string that is never parsed as code.
+   */
+  function onDelegatedClick(ev) {
+    var target = ev.target;
+    if (!target || typeof target.closest !== 'function') return;
+    var el = target.closest('[data-act]');
+    if (!el) return;
+
+    var act = el.getAttribute('data-act');
+    var name = el.getAttribute('data-name');
+    var status = el.getAttribute('data-status');
+    var id = el.getAttribute('data-id');
+
+    if (act === 'toggle') window.mcpgovToggle(name);
+    else if (act === 'server-status') window.mcpgovSetServer(name, status);
+    else if (act === 'tool-status') window.mcpgovSetTool(name, status);
+    else if (act === 'bulk') window.mcpgovBulk(name, status);
+    else if (act === 'enable-enforce') window.mcpgovEnableEnforce();
+    else if (act === 'policy-edit') window.mcpgovEditPolicy(id);
+    else if (act === 'policy-delete') {
+      window.mcpgovDeletePolicy(id, el.getAttribute('data-label') || id);
+    }
+  }
+
+  function inject() {
+    if (document.getElementById('page-' + PAGE)) return true;
+
+    var navSection = document.getElementById('nav-admin-section');
+    var main = document.querySelector('.main');
+    if (!navSection || !main) return false;
+
+    navSection.insertAdjacentHTML('beforeend', NAV_HTML);
+    main.insertAdjacentHTML('beforeend', PAGE_HTML);
+    document.body.insertAdjacentHTML('beforeend', MODAL_HTML);
+
+    var pageEl = document.getElementById('page-' + PAGE);
+    if (pageEl && pageEl.addEventListener) {
+      pageEl.addEventListener('click', onDelegatedClick);
+    }
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rendering
+  // ---------------------------------------------------------------------------
+
+  function setTabActive() {
+    var btns = document.querySelectorAll('#mcpgov-tabs .oa-tab-btn');
+    for (var i = 0; i < btns.length; i++) {
+      var active = btns[i].getAttribute('data-tab') === state.tab;
+      btns[i].classList.toggle('active', active);
+    }
+  }
+
+  function render() {
+    var el = document.getElementById('mcpgov-body');
+    if (!el) return;
+    setTabActive();
+
+    if (state.tab === 'summary') el.innerHTML = renderSummary();
+    else if (state.tab === 'catalog') el.innerHTML = renderCatalog();
+    else if (state.tab === 'policies') el.innerHTML = renderPolicies();
+    else if (state.tab === 'simulate') el.innerHTML = renderSimulator();
+    else if (state.tab === 'audit') el.innerHTML = renderAudit();
+  }
+
+  /**
+   * Warns when the catalog says "denied" but the mode says "do nothing".
+   *
+   * Denying a server or tool writes a catalog row; it does not by itself change the
+   * enforcement mode. In any mode other than `enforce` those rows are inert, so the
+   * portal reports blocks that never happen and the client keeps calling the tool.
+   * That mismatch is silent and looks exactly like a broken filter, so it gets a loud
+   * banner and a one-click fix rather than a footnote.
+   *
+   * Returns '' when there is nothing to warn about.
+   */
+  function enforcementGapBanner() {
+    var s = state.summary;
+    if (!s) return '';
+    var sum = s.summary || {};
+    var gp = s.global_policy || {};
+    var mode = gp.mode || 'observe';
+    if (mode === 'enforce') return '';
+
+    var denials = (sum.tools_denied || 0) + (sum.servers_denied || 0) +
+      ((gp.deny_patterns || []).length);
+    if (denials === 0) return '';
+
+    var what = mode === 'observe'
+      ? 'recorded as "would block" and then sent through untouched'
+      : 'flagged in the audit trail and then sent through untouched';
+
+    return '<div style="display:flex;margin-bottom:16px;padding:10px 14px;' +
+      'background:var(--yellow-subtle);border:1px solid var(--yellow);' +
+      'border-radius:var(--radius);align-items:center;gap:10px;font-size:13px">' +
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--yellow)" ' +
+        'stroke-width="2" style="flex-shrink:0"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 ' +
+        '1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>' +
+        '<line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>' +
+      '<span style="flex:1;color:var(--yellow)">' +
+        '<strong>Nothing is being blocked.</strong> You have ' + fmtNum(denials) +
+        ' denial' + (denials === 1 ? '' : 's') + ' configured, but the mode is <strong>' +
+        esc(mode) + '</strong> \u2014 denied tools are ' + what + '.' +
+      '</span>' +
+      '<button class="btn btn-sm" data-act="enable-enforce" ' +
+        'style="background:var(--yellow-subtle);color:var(--yellow);' +
+        'border:1px solid var(--yellow);font-weight:600;white-space:nowrap">' +
+        'Switch to enforce' +
+      '</button>' +
+    '</div>';
+  }
+
+  function renderSummary() {
+    var s = state.summary;
+    if (!s) return '<div class="oa-loading">Loading\u2026</div>';
+    var sum = s.summary || {};
+    var gp = s.global_policy || {};
+    var drops = s.buffer_drops || {};
+
+    var h = enforcementGapBanner();
+
+    h += '<div class="card" style="margin-bottom:16px">' +
+      '<div class="card-header"><strong>Current posture</strong></div>' +
+      '<div style="padding:12px 16px;display:flex;gap:24px;flex-wrap:wrap;align-items:center">' +
+        '<div>Mode: ' + modeBadge(gp.mode || 'observe') + '</div>' +
+        '<div>Unknown tools: <span class="badge badge-outline">' + esc(gp.default_action || 'allow') + '</span></div>' +
+        '<div>Scope: <span class="badge badge-outline">' + esc(gp.applies_to || 'mcp_only') + '</span></div>' +
+        '<div>Deny patterns: <strong>' + fmtNum((gp.deny_patterns || []).length) + '</strong></div>' +
+        '<div>Allow patterns: <strong>' + fmtNum((gp.allow_patterns || []).length) + '</strong></div>' +
+      '</div>' +
+      (gp.mode === 'observe'
+        ? '<div style="padding:0 16px 12px;color:var(--text-muted,#888);font-size:13px">' +
+          'Observe mode: nothing is being stripped. The numbers below are what <em>would</em> be blocked.' +
+          '</div>'
+        : '') +
+    '</div>';
+
+    h += '<div class="stats-grid" style="grid-template-columns:repeat(4,1fr);margin-bottom:16px">' +
+      statCard('MCP servers', sum.servers_total, sum.servers_pending + ' pending') +
+      statCard('Tools discovered', sum.tools_total, sum.tools_pending + ' undecided') +
+      statCard('Approved tools', sum.tools_approved, sum.servers_approved + ' approved servers') +
+      statCard('Denied tools', sum.tools_denied, sum.servers_denied + ' denied servers') +
+    '</div>';
+
+    h += '<div class="stats-grid" style="grid-template-columns:repeat(3,1fr);margin-bottom:16px">' +
+      statCard('Blocked (24h)', sum.events_24h_blocked, 'actually stripped') +
+      statCard('Would block (24h)', sum.events_24h_would_block, 'observe mode dry run') +
+      statCard('Warned (24h)', sum.events_24h_warned, 'allowed but flagged') +
+    '</div>';
+
+    if ((drops.discovery || 0) > 0 || (drops.events || 0) > 0) {
+      h += '<div class="info-callout"><div class="info-callout-body">' +
+        '<strong>Buffer overflow.</strong> ' + fmtNum(drops.discovery) + ' discovery and ' +
+        fmtNum(drops.events) + ' audit items were dropped because the write buffers filled. ' +
+        'Enforcement is unaffected \u2014 only recording is lossy under extreme load.' +
+        '</div></div>';
+    }
+
+    if (sum.tools_pending > 0) {
+      h += '<div class="card"><div style="padding:16px">' +
+        '<strong>' + fmtNum(sum.tools_pending) + ' tools are awaiting a decision.</strong> ' +
+        '<button class="btn btn-primary btn-sm" style="margin-left:8px" onclick="mcpgovTab(\'catalog\')">Review catalog</button>' +
+        '</div></div>';
+    }
+
+    return h;
+  }
+
+  function statCard(label, value, sub) {
+    return '<div class="stat-card">' +
+      '<div class="stat-label">' + esc(label) + '</div>' +
+      '<div class="stat-value">' + fmtNum(value) + '</div>' +
+      '<div class="stat-sub">' + esc(sub == null ? '' : sub) + '</div>' +
+    '</div>';
+  }
+
+  function renderCatalog() {
+    if (!state.servers.length && !state.tools.length) {
+      return '<div class="empty-state">' +
+        '<p>Nothing discovered yet.</p>' +
+        '<p style="font-size:13px;color:var(--text-muted,#888)">' +
+        'The catalog fills in automatically as developers send requests. Every request carries its ' +
+        'full tool list, so this becomes a complete inventory of the MCP servers actually in use.' +
+        '</p></div>';
+    }
+
+    // Group tools by server so the catalog reads as "server -> its tools".
+    var byServer = {};
+    var builtins = [];
+    for (var i = 0; i < state.tools.length; i++) {
+      var t = state.tools[i];
+      if (!t.server_name) { builtins.push(t); continue; }
+      if (!byServer[t.server_name]) byServer[t.server_name] = [];
+      byServer[t.server_name].push(t);
+    }
+
+    var h = enforcementGapBanner();
+    for (var j = 0; j < state.servers.length; j++) {
+      var srv = state.servers[j];
+      var name = srv.server_name;
+      var tools = byServer[name] || [];
+      var open = !!state.expanded[name];
+      var an = attr(name);
+
+      h += '<div class="card" style="margin-bottom:12px">' +
+        '<div class="card-header" style="display:flex;justify-content:space-between;align-items:center;gap:12px">' +
+          '<div style="display:flex;align-items:center;gap:10px;cursor:pointer" data-act="toggle" data-name="' + an + '">' +
+            '<span style="font-family:monospace">' + (open ? '\u25be' : '\u25b8') + '</span>' +
+            '<strong style="font-family:monospace">' + esc(name) + '</strong>' +
+            statusBadge(srv.status) +
+            '<span style="color:var(--text-muted,#888);font-size:12px">' + tools.length + ' tools</span>' +
+          '</div>' +
+          '<div style="display:flex;gap:6px">' +
+            '<button class="btn btn-sm btn-secondary" data-act="server-status" data-name="' + an + '" data-status="approved">Approve</button>' +
+            '<button class="btn btn-sm btn-danger" data-act="server-status" data-name="' + an + '" data-status="denied">Deny</button>' +
+            '<button class="btn btn-sm btn-ghost" data-act="server-status" data-name="' + an + '" data-status="pending">Reset</button>' +
+          '</div>' +
+        '</div>' +
+        '<div style="padding:8px 16px;font-size:12px;color:var(--text-muted,#888)">' +
+          'First seen ' + esc(fmtDate(srv.first_seen)) + ' \u00b7 last seen ' + esc(fmtDate(srv.last_seen)) +
+          (srv.notes ? ' \u00b7 ' + esc(srv.notes) : '') +
+        '</div>';
+
+      if (open) {
+        h += '<div style="padding:0 16px 12px">';
+        if (!tools.length) {
+          h += '<div style="font-size:13px;color:var(--text-muted,#888)">No tools recorded for this server yet.</div>';
+        } else {
+          h += '<div style="margin-bottom:8px;display:flex;gap:6px">' +
+            '<button class="btn btn-sm btn-secondary" data-act="bulk" data-name="' + an + '" data-status="approved">Approve all</button>' +
+            '<button class="btn btn-sm btn-danger" data-act="bulk" data-name="' + an + '" data-status="denied">Deny all</button>' +
+            '<button class="btn btn-sm btn-ghost" data-act="bulk" data-name="' + an + '" data-status="inherit">Reset all to inherit</button>' +
+            '</div>';
+          h += '<table class="oa-data-table"><thead><tr>' +
+            '<th>Tool</th><th>Status</th><th>Seen</th><th>Last seen</th><th></th>' +
+            '</tr></thead><tbody>';
+          for (var k = 0; k < tools.length; k++) {
+            h += toolRow(tools[k]);
+          }
+          h += '</tbody></table>';
+        }
+        h += '</div>';
+      }
+
+      h += '</div>';
+    }
+
+    if (builtins.length) {
+      h += '<div class="card" style="margin-bottom:12px">' +
+        '<div class="card-header"><strong>Built-in tools</strong> ' +
+        '<span style="color:var(--text-muted,#888);font-size:12px">' +
+        'not governed unless a policy sets <code>applies_to = all_tools</code></span></div>' +
+        '<div style="padding:0 16px 12px"><table class="oa-data-table"><thead><tr>' +
+        '<th>Tool</th><th>Status</th><th>Seen</th><th>Last seen</th><th></th>' +
+        '</tr></thead><tbody>';
+      for (var m = 0; m < builtins.length; m++) h += toolRow(builtins[m]);
+      h += '</tbody></table></div></div>';
+    }
+
+    return h;
+  }
+
+  function toolRow(t) {
+    var an = attr(t.tool_name);
+    return '<tr>' +
+      '<td style="font-family:monospace;font-size:12px">' + esc(t.tool_name) + '</td>' +
+      '<td>' + statusBadge(t.status) + '</td>' +
+      '<td>' + fmtNum(t.seen_count) + '</td>' +
+      '<td style="font-size:12px">' + esc(fmtDate(t.last_seen)) + '</td>' +
+      '<td style="text-align:right;white-space:nowrap">' +
+        '<button class="btn btn-sm btn-ghost" data-act="tool-status" data-name="' + an + '" data-status="approved">Approve</button> ' +
+        '<button class="btn btn-sm btn-ghost" data-act="tool-status" data-name="' + an + '" data-status="denied">Deny</button> ' +
+        '<button class="btn btn-sm btn-ghost" data-act="tool-status" data-name="' + an + '" data-status="inherit">Inherit</button>' +
+      '</td>' +
+    '</tr>';
+  }
+
+  function renderPolicies() {
+    if (!state.policies.length) {
+      return '<div class="empty-state"><p>No policies defined.</p></div>';
+    }
+
+    var h = '<table class="oa-data-table"><thead><tr>' +
+      '<th>Scope</th><th>Applies to</th><th>Mode</th><th>Unknown tools</th>' +
+      '<th>Allow</th><th>Deny</th><th>Enabled</th><th>Updated</th><th></th>' +
+      '</tr></thead><tbody>';
+
+    for (var i = 0; i < state.policies.length; i++) {
+      var p = state.policies[i];
+      var label = p.scope === 'global' ? 'global' : p.scope + ': ' + (p.scope_ref || '');
+      var allow = (p.allow_patterns || []);
+      var deny = (p.deny_patterns || []);
+      h += '<tr>' +
+        '<td><strong>' + esc(label) + '</strong></td>' +
+        '<td><span class="badge badge-outline">' + esc(p.applies_to) + '</span></td>' +
+        '<td>' + modeBadge(p.mode) + '</td>' +
+        '<td>' + esc(p.default_action) + '</td>' +
+        '<td title="' + esc(allow.join('\n')) + '">' + allow.length + '</td>' +
+        '<td title="' + esc(deny.join('\n')) + '">' + deny.length + '</td>' +
+        '<td>' + (p.enabled ? '<span class="badge badge-green">yes</span>' : '<span class="badge badge-muted">no</span>') + '</td>' +
+        '<td style="font-size:12px">' + esc(fmtDate(p.updated_at)) +
+          (p.updated_by ? '<br><span style="color:var(--text-muted,#888)">' + esc(p.updated_by) + '</span>' : '') +
+        '</td>' +
+        '<td style="text-align:right;white-space:nowrap">' +
+          '<button class="btn btn-sm btn-ghost" data-act="policy-edit" data-id="' + attr(p.id) + '">Edit</button>' +
+          (p.scope === 'global'
+            ? ''
+            : ' <button class="btn btn-sm btn-ghost" data-act="policy-delete" data-id="' +
+              attr(p.id) + '" data-label="' + attr(label) + '">Delete</button>') +
+        '</td>' +
+      '</tr>';
+    }
+    h += '</tbody></table>';
+
+    h += '<div class="info-callout" style="margin-top:16px"><div class="info-callout-body">' +
+      '<strong>Resolution order.</strong> Policies merge global \u2192 team \u2192 user. ' +
+      'Scalars (mode, defaults) take the most specific value. Deny lists are <em>unioned</em> across ' +
+      'scopes. Allow lists are <em>replaced</em> by the most specific non-empty one. ' +
+      'Per tool the order is: deny pattern \u2192 catalog denial \u2192 allowlist \u2192 catalog approval \u2192 default.' +
+      '</div></div>';
+
+    return h;
+  }
+
+  function renderSimulator() {
+    var h = '<div class="card" style="margin-bottom:16px"><div style="padding:16px">' +
+      '<div class="form-row">' +
+        '<div class="form-group">' +
+          '<label class="form-label">User identity (email)</label>' +
+          '<input class="form-input" id="mcpgov-sim-user" placeholder="dev@example.com">' +
+        '</div>' +
+        '<div class="form-group">' +
+          '<label class="form-label">Team UUID (optional)</label>' +
+          '<input class="form-input" id="mcpgov-sim-team" placeholder="leave blank for none">' +
+        '</div>' +
+      '</div>' +
+      '<div class="form-group">' +
+        '<label class="form-label">Tool names (optional)</label>' +
+        '<textarea class="form-input" id="mcpgov-sim-tools" rows="3" placeholder="One per line. Leave empty to test the entire discovered catalog."></textarea>' +
+      '</div>' +
+      '<button class="btn btn-primary" onclick="mcpgovRunSim()">Simulate</button>' +
+      '<div class="form-hint" style="margin-top:8px">Resolves the exact policy that identity would get and shows the verdict for each tool, with the reason.</div>' +
+    '</div></div>';
+
+    if (state.sim) {
+      var eff = state.sim.effective_policy || {};
+      var counts = state.sim.counts || {};
+      h += '<div class="card" style="margin-bottom:16px">' +
+        '<div class="card-header"><strong>Effective policy</strong></div>' +
+        '<div style="padding:12px 16px;display:flex;gap:24px;flex-wrap:wrap">' +
+          '<div>Mode: ' + modeBadge(eff.mode) + '</div>' +
+          '<div>Decided by: <span class="badge badge-outline">' + esc(eff.decided_by) + '</span></div>' +
+          '<div>Unknown tools: <span class="badge badge-outline">' + esc(eff.default_action) + '</span></div>' +
+          '<div>Allowed: <strong style="color:#22c55e">' + fmtNum(counts.allowed) + '</strong></div>' +
+          '<div>Denied: <strong style="color:#ef4444">' + fmtNum(counts.denied) + '</strong></div>' +
+        '</div>' +
+      '</div>';
+
+      var results = state.sim.results || [];
+      if (!results.length) {
+        h += '<div class="empty-state"><p>No tools to evaluate. Discover some traffic first, or enter tool names above.</p></div>';
+      } else {
+        h += '<table class="oa-data-table"><thead><tr>' +
+          '<th>Tool</th><th>Verdict</th><th>Why</th><th>Decided by</th>' +
+          '</tr></thead><tbody>';
+        for (var i = 0; i < results.length; i++) {
+          var r = results[i];
+          h += '<tr>' +
+            '<td style="font-family:monospace;font-size:12px">' + esc(r.tool_name) + '</td>' +
+            '<td>' + (r.allowed
+              ? '<span class="badge badge-green">allowed</span>'
+              : '<span class="badge badge-red">denied</span>') + '</td>' +
+            '<td style="font-size:12px">' + esc(r.reason) + '</td>' +
+            '<td><span class="badge badge-outline">' + esc(r.decided_by) + '</span></td>' +
+          '</tr>';
+        }
+        h += '</tbody></table>';
+      }
+    }
+
+    return h;
+  }
+
+  function renderAudit() {
+    var h = '<div style="margin-bottom:12px;display:flex;gap:8px;align-items:center">' +
+      '<label class="form-label" style="margin:0">Decision</label>' +
+      '<select class="form-input" style="max-width:200px" id="mcpgov-audit-filter" onchange="mcpgovLoadEvents()">' +
+        '<option value="">all</option>' +
+        '<option value="blocked">blocked</option>' +
+        '<option value="would_block">would_block</option>' +
+        '<option value="warned">warned</option>' +
+      '</select>' +
+      '</div>';
+
+    if (!state.events.length) {
+      return h + '<div class="empty-state"><p>No policy decisions recorded yet.</p></div>';
+    }
+
+    h += '<table class="oa-data-table"><thead><tr>' +
+      '<th>When</th><th>Decision</th><th>Tool</th><th>User</th><th>Mode</th><th>Reason</th>' +
+      '</tr></thead><tbody>';
+    for (var i = 0; i < state.events.length; i++) {
+      var e = state.events[i];
+      var badge = e.decision === 'blocked' ? 'badge-red'
+        : (e.decision === 'warned' ? 'badge-yellow' : 'badge-blue');
+      h += '<tr>' +
+        '<td style="font-size:12px;white-space:nowrap">' + esc(fmtDate(e.created_at)) + '</td>' +
+        '<td><span class="badge ' + badge + '">' + esc(e.decision) + '</span></td>' +
+        '<td style="font-family:monospace;font-size:12px">' + esc(e.tool_name) + '</td>' +
+        '<td style="font-size:12px">' + esc(e.user_identity || '-') + '</td>' +
+        '<td style="font-size:12px">' + esc(e.mode) + '</td>' +
+        '<td style="font-size:12px">' + esc(e.reason) + '</td>' +
+      '</tr>';
+    }
+    h += '</tbody></table>';
+    return h;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Data loading
+  // ---------------------------------------------------------------------------
+
+  async function loadAll() {
+    var res = await Promise.all([
+      api('GET', '/admin/mcpgov/summary'),
+      api('GET', '/admin/mcpgov/servers'),
+      api('GET', '/admin/mcpgov/tools?limit=2000'),
+      api('GET', '/admin/mcpgov/policies')
+    ]);
+
+    if (res[0] && res[0].error) {
+      var el = document.getElementById('mcpgov-body');
+      if (el) {
+        el.innerHTML = '<div class="empty-state"><p>Could not load governance data.</p>' +
+          '<p style="font-size:13px;color:var(--text-muted,#888)">' +
+          esc((res[0].error && res[0].error.message) || res[0].error) + '</p></div>';
+      }
+      return;
+    }
+
+    state.summary = res[0] || null;
+    state.servers = (res[1] && res[1].servers) || [];
+    state.tools = (res[2] && res[2].tools) || [];
+    state.policies = (res[3] && res[3].policies) || [];
+    state.loaded = true;
+    render();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Global handlers (referenced from injected onclick attributes)
+  // ---------------------------------------------------------------------------
+
+  window.mcpgovTab = function (tab) {
+    state.tab = tab;
+    render();
+    if (tab === 'audit') window.mcpgovLoadEvents();
+  };
+
+  window.mcpgovRefresh = function () {
+    loadAll();
+    toast('Refreshed', 'success');
+  };
+
+  window.mcpgovToggle = function (name) {
+    state.expanded[name] = !state.expanded[name];
+    render();
+  };
+
+  window.mcpgovSetServer = async function (name, status) {
+    var res = await api('PUT', '/admin/mcpgov/servers/status', {
+      server_name: name, status: status
+    });
+    if (res.updated) { toast('Server ' + status, 'success'); loadAll(); }
+    else toast((res.error && res.error.message) || 'Failed to update server', 'error');
+  };
+
+  window.mcpgovSetTool = async function (name, status) {
+    var res = await api('PUT', '/admin/mcpgov/tools/status', {
+      tool_name: name, status: status
+    });
+    if (res.updated) { toast('Tool ' + status, 'success'); loadAll(); }
+    else toast((res.error && res.error.message) || 'Failed to update tool', 'error');
+  };
+
+  window.mcpgovBulk = async function (server, status) {
+    if (!confirm('Set every tool of "' + server + '" to ' + status + '?')) return;
+    var res = await api('PUT', '/admin/mcpgov/servers/bulk-status', {
+      server_name: server, status: status
+    });
+    if (res.updated != null) { toast(res.updated + ' tools set to ' + status, 'success'); loadAll(); }
+    else toast((res.error && res.error.message) || 'Bulk update failed', 'error');
+  };
+
+  window.mcpgovScopeChanged = function () {
+    var scope = document.getElementById('mcpgov-p-scope').value;
+    var group = document.getElementById('mcpgov-p-ref-group');
+    var label = document.getElementById('mcpgov-p-ref-label');
+    var hint = document.getElementById('mcpgov-p-ref-hint');
+    if (scope === 'global') {
+      group.style.display = 'none';
+      return;
+    }
+    group.style.display = '';
+    if (scope === 'team') {
+      label.textContent = 'Team UUID';
+      hint.textContent = 'Must be an existing team UUID (see the Teams page).';
+    } else {
+      label.textContent = 'User email';
+      hint.textContent = 'Matched case-insensitively against the request identity.';
+    }
+  };
+
+  window.mcpgovNewPolicy = function () {
+    state.editing = null;
+    document.getElementById('mcpgov-modal-title').textContent = 'New Policy';
+    document.getElementById('mcpgov-p-scope').value = 'global';
+    document.getElementById('mcpgov-p-scope').disabled = false;
+    document.getElementById('mcpgov-p-ref').value = '';
+    document.getElementById('mcpgov-p-mode').value = 'observe';
+    document.getElementById('mcpgov-p-default').value = 'allow';
+    document.getElementById('mcpgov-p-applies').value = 'mcp_only';
+    document.getElementById('mcpgov-p-allow').value = '';
+    document.getElementById('mcpgov-p-deny').value = '';
+    document.getElementById('mcpgov-p-enabled').checked = true;
+    window.mcpgovScopeChanged();
+    if (window.showModal) window.showModal('mcpgov-policy');
+    else document.getElementById('modal-mcpgov-policy').style.display = 'flex';
+  };
+
+  window.mcpgovEditPolicy = function (id) {
+    var p = null;
+    for (var i = 0; i < state.policies.length; i++) {
+      if (state.policies[i].id === id) { p = state.policies[i]; break; }
+    }
+    if (!p) return;
+
+    state.editing = p;
+    document.getElementById('mcpgov-modal-title').textContent = 'Edit Policy';
+    document.getElementById('mcpgov-p-scope').value = p.scope;
+    // Scope identity is the primary key; changing it would create a new policy
+    // rather than edit this one, so it is locked during an edit.
+    document.getElementById('mcpgov-p-scope').disabled = true;
+    document.getElementById('mcpgov-p-ref').value = p.scope_ref || '';
+    document.getElementById('mcpgov-p-mode').value = p.mode;
+    document.getElementById('mcpgov-p-default').value = p.default_action;
+    document.getElementById('mcpgov-p-applies').value = p.applies_to;
+    document.getElementById('mcpgov-p-allow').value = (p.allow_patterns || []).join('\n');
+    document.getElementById('mcpgov-p-deny').value = (p.deny_patterns || []).join('\n');
+    document.getElementById('mcpgov-p-enabled').checked = !!p.enabled;
+    window.mcpgovScopeChanged();
+    if (window.showModal) window.showModal('mcpgov-policy');
+    else document.getElementById('modal-mcpgov-policy').style.display = 'flex';
+  };
+
+  function lines(id) {
+    var raw = document.getElementById(id).value || '';
+    return raw.split('\n').map(function (s) { return s.trim(); })
+      .filter(function (s) { return s.length > 0; });
+  }
+
+  window.mcpgovSavePolicy = async function () {
+    var scope = document.getElementById('mcpgov-p-scope').value;
+    var ref = (document.getElementById('mcpgov-p-ref').value || '').trim();
+    if (scope !== 'global' && !ref) {
+      toast('A team UUID or user email is required for this scope', 'error');
+      return;
+    }
+
+    var mode = document.getElementById('mcpgov-p-mode').value;
+    var allow = lines('mcpgov-p-allow');
+    var deny = lines('mcpgov-p-deny');
+    var applies = document.getElementById('mcpgov-p-applies').value;
+
+    // Enforcing on all tools with a deny-by-default posture and no allowlist would
+    // strip every built-in tool. Confirm rather than silently breaking Claude Code.
+    if (mode === 'enforce' && applies === 'all_tools' &&
+        document.getElementById('mcpgov-p-default').value === 'deny' && !allow.length) {
+      if (!confirm('This will deny every built-in tool (Read, Write, Bash, ...) for the ' +
+                   'matching identities, because you are enforcing all_tools with ' +
+                   'deny-by-default and no allowlist.\n\nContinue?')) {
+        return;
+      }
+    }
+
+    var payload = {
+      scope: scope,
+      scope_ref: scope === 'global' ? null : ref,
+      mode: mode,
+      default_action: document.getElementById('mcpgov-p-default').value,
+      applies_to: applies,
+      allow_patterns: allow,
+      deny_patterns: deny,
+      enabled: document.getElementById('mcpgov-p-enabled').checked
+    };
+
+    var res = await api('PUT', '/admin/mcpgov/policies', payload);
+    if (res.policy) {
+      toast('Policy saved', 'success');
+      if (window.closeModal) window.closeModal();
+      loadAll();
+    } else {
+      toast((res.error && res.error.message) || 'Failed to save policy', 'error');
+    }
+  };
+
+  /**
+   * Flips the global policy to `enforce`, preserving every other field.
+   *
+   * The policies endpoint is a full upsert, so the current global policy is replayed
+   * with only the mode changed. Anything the summary does not carry keeps the server's
+   * default, which matches what the policy editor would send for a fresh global row.
+   */
+  window.mcpgovEnableEnforce = async function () {
+    var gp = (state.summary && state.summary.global_policy) || {};
+    if (!confirm('Switch the global policy to enforce?\n\n' +
+                 'Denied tools will be removed from requests instead of only being ' +
+                 'recorded. Clients lose access to them immediately.')) {
+      return;
+    }
+
+    var res = await api('PUT', '/admin/mcpgov/policies', {
+      scope: 'global',
+      scope_ref: null,
+      mode: 'enforce',
+      default_action: gp.default_action || 'allow',
+      applies_to: gp.applies_to || 'mcp_only',
+      allow_patterns: gp.allow_patterns || [],
+      deny_patterns: gp.deny_patterns || [],
+      enabled: true
+    });
+
+    if (res.policy) { toast('Enforcement enabled', 'success'); loadAll(); }
+    else toast((res.error && res.error.message) || 'Failed to enable enforcement', 'error');
+  };
+
+  window.mcpgovDeletePolicy = async function (id, label) {
+    if (!confirm('Delete the policy for ' + label + '?')) return;
+    var res = await api('DELETE', '/admin/mcpgov/policies/' + encodeURIComponent(id));
+    if (res.deleted) { toast('Policy deleted', 'success'); loadAll(); }
+    else toast((res.error && res.error.message) || 'Failed to delete policy', 'error');
+  };
+
+  window.mcpgovRunSim = async function () {
+    var user = (document.getElementById('mcpgov-sim-user').value || '').trim();
+    var team = (document.getElementById('mcpgov-sim-team').value || '').trim();
+    var tools = lines('mcpgov-sim-tools');
+
+    var payload = { tool_names: tools };
+    if (user) payload.user_identity = user;
+    if (team) payload.team_id = team;
+
+    var res = await api('POST', '/admin/mcpgov/simulate', payload);
+    if (res.results) {
+      state.sim = res;
+      render();
+    } else {
+      toast((res.error && res.error.message) || 'Simulation failed', 'error');
+    }
+  };
+
+  window.mcpgovLoadEvents = async function () {
+    var sel = document.getElementById('mcpgov-audit-filter');
+    var filter = sel ? sel.value : '';
+    var path = '/admin/mcpgov/events?limit=300' +
+      (filter ? '&decision=' + encodeURIComponent(filter) : '');
+    var res = await api('GET', path);
+    state.events = (res && res.events) || [];
+    if (state.tab === 'audit') {
+      render();
+      // Re-apply the filter selection lost to the re-render.
+      var sel2 = document.getElementById('mcpgov-audit-filter');
+      if (sel2 && filter) sel2.value = filter;
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Boot: inject markup, then hook navigate() for lazy loading.
+  // ---------------------------------------------------------------------------
+
+  function hookNavigate() {
+    if (typeof window.navigate !== 'function' || window.navigate.__mcpgov) return false;
+    var original = window.navigate;
+    var wrapped = function (page) {
+      original(page);
+      if (page === PAGE && !state.loaded) loadAll();
+      else if (page === PAGE) render();
+    };
+    wrapped.__mcpgov = true;
+    window.navigate = wrapped;
+    return true;
+  }
+
+  function boot() {
+    if (!inject()) return false;
+    hookNavigate();
+    // Deep link support: the host SPA may have already resolved the hash before this
+    // file finished loading, in which case its page lookup silently failed.
+    if (window.location.hash === '#/' + PAGE) {
+      if (typeof window.navigate === 'function') window.navigate(PAGE);
+    }
+    return true;
+  }
+
+  // The host SPA builds its shell synchronously in an inline <script>, but this file
+  // may load before DOMContentLoaded. Retry briefly rather than assuming an order.
+  if (!boot()) {
+    var attempts = 0;
+    var timer = setInterval(function () {
+      attempts++;
+      if (boot() || attempts > 100) clearInterval(timer);
+    }, 100);
+    document.addEventListener('DOMContentLoaded', function () { boot(); });
+  }
+})();

--- a/static/index.html
+++ b/static/index.html
@@ -7674,5 +7674,7 @@ async function oaExportCsv() {
   }
 }
 </script>
+<!-- mcpgov overlay: MCP/tool governance page. Self-injecting; see src/mcpgov/ and EXTENSION.md. -->
+<script src="/portal/ext/mcp-governance.js"></script>
 </body>
 </html>

--- a/tests/frontend/tests/mcpgov.spec.ts
+++ b/tests/frontend/tests/mcpgov.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test';
+import { loginViaPortal, navigateTo, getSessionToken, apiCall } from '../helpers/gateway';
+
+// MCP / tool governance. The page is injected at runtime by
+// /portal/ext/mcp-governance.js rather than living in static/index.html, so these
+// tests double as a check that the self-injection works in a real browser.
+test.describe('MCP Governance', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginViaPortal(page);
+  });
+
+  test('injects its nav item into the admin section', async ({ page }) => {
+    const navItem = page.locator('#nav-admin-section .nav-item[data-page="mcpgov"]');
+    await expect(navItem).toBeVisible();
+    await expect(navItem).toContainText('MCP & Tools');
+  });
+
+  test('opens the page with overview stats', async ({ page }) => {
+    await navigateTo(page, 'mcpgov');
+
+    await expect(page.locator('#page-mcpgov')).toContainText('MCP & Tools Governance');
+    // Overview tab renders the posture card once the summary API answers.
+    await expect(page.locator('#mcpgov-body')).toContainText('Current posture', {
+      timeout: 5_000,
+    });
+    await expect(page.locator('#mcpgov-body')).toContainText('MCP servers');
+  });
+
+  test('renders the catalog and can approve a server', async ({ page }) => {
+    // Seed the catalog through the admin API rather than by sending a /v1/messages
+    // request. Discovery-from-traffic is covered server-side; driving it here would
+    // make this test depend on reachable Bedrock models, which the frontend suite
+    // (built without the mock-bedrock feature) does not have.
+    const token = await getSessionToken();
+    const server = `fetest${Date.now()}`;
+    await apiCall(token, 'POST', '/admin/mcpgov/servers', {
+      server_name: server,
+      status: 'pending',
+    });
+
+    await navigateTo(page, 'mcpgov');
+    await page.click('#mcpgov-tabs button[data-tab="catalog"]');
+
+    const card = page.locator('#mcpgov-body .card').filter({ hasText: server });
+    await expect(card).toBeVisible({ timeout: 5_000 });
+    await expect(card).toContainText('pending');
+
+    await card.locator('button:has-text("Approve")').first().click();
+    await expect(page.locator('#toast-container')).toContainText('approved', {
+      timeout: 5_000,
+    });
+
+    // The re-rendered card reflects the new status.
+    await expect(
+      page.locator('#mcpgov-body .card').filter({ hasText: server }),
+    ).toContainText('approved', { timeout: 5_000 });
+  });
+
+  test('creates and deletes a team policy via the modal', async ({ page }) => {
+    // A team to scope the policy to (user-scope would work too, but team exercises
+    // the UUID validation path).
+    const token = await getSessionToken();
+    const team = await apiCall(token, 'POST', '/admin/teams', {
+      name: `mcpgov-fe-team-${Date.now()}`,
+    });
+
+    await navigateTo(page, 'mcpgov');
+    await page.click('button:has-text("New Policy")');
+    await expect(page.locator('#modal-mcpgov-policy')).toBeVisible();
+
+    await page.selectOption('#mcpgov-p-scope', 'team');
+    await page.fill('#mcpgov-p-ref', team.id);
+    await page.selectOption('#mcpgov-p-mode', 'warn');
+    await page.fill('#mcpgov-p-deny', 'mcp__fe_denied__*');
+    await page.click('#modal-mcpgov-policy button:has-text("Save")');
+
+    await expect(page.locator('#toast-container')).toContainText('Policy saved', {
+      timeout: 5_000,
+    });
+
+    // The policies tab lists it.
+    await page.click('#mcpgov-tabs button[data-tab="policies"]');
+    await expect(page.locator('#mcpgov-body')).toContainText(`team: ${team.id}`, {
+      timeout: 5_000,
+    });
+
+    // And it can be deleted (the global policy shows no Delete button; team rows do).
+    page.on('dialog', (d) => d.accept());
+    const row = page.locator('#mcpgov-body tr').filter({ hasText: team.id });
+    await row.locator('button:has-text("Delete")').click();
+    await expect(page.locator('#toast-container')).toContainText('Policy deleted', {
+      timeout: 5_000,
+    });
+  });
+
+  // Regression: MCP server and tool names come from client-supplied tool definitions,
+  // so they are untrusted. An earlier version interpolated them into inline
+  // onclick="fn('name')" handlers using the SPA's esc(), which does not escape quotes
+  // (textContent -> innerHTML leaves them alone). A name containing a double quote
+  // terminated the attribute early, breaking the handler and opening a markup
+  // injection path. Row actions now use data attributes plus delegated dispatch.
+  test('handles server names containing quotes and markup safely', async ({ page }) => {
+    const token = await getSessionToken();
+    const nasty = `q"ote'<img src=x onerror=window.__pwned=1>${Date.now()}`;
+    await apiCall(token, 'POST', '/admin/mcpgov/servers', {
+      server_name: nasty,
+      status: 'pending',
+    });
+
+    await navigateTo(page, 'mcpgov');
+    await page.click('#mcpgov-tabs button[data-tab="catalog"]');
+
+    const card = page.locator('#mcpgov-body .card').filter({ hasText: nasty });
+    await expect(card).toBeVisible({ timeout: 5_000 });
+
+    // The name is rendered as text, not parsed as markup.
+    expect(await page.locator('#mcpgov-body img').count()).toBe(0);
+
+    // The action still works despite the quotes, and no injected script ran.
+    await card.locator('button[data-act="server-status"][data-status="denied"]').click();
+    await expect(page.locator('#toast-container')).toContainText('denied', {
+      timeout: 5_000,
+    });
+    expect(await page.evaluate(() => (window as any).__pwned)).toBeUndefined();
+  });
+
+  test('simulator returns verdicts for an arbitrary tool', async ({ page }) => {
+    await navigateTo(page, 'mcpgov');
+    await page.click('#mcpgov-tabs button[data-tab="simulate"]');
+
+    await page.fill('#mcpgov-sim-tools', 'mcp__simtest__some_tool');
+    await page.click('button:has-text("Simulate")');
+
+    await expect(page.locator('#mcpgov-body')).toContainText('Effective policy', {
+      timeout: 5_000,
+    });
+    await expect(page.locator('#mcpgov-body')).toContainText('mcp__simtest__some_tool');
+  });
+});


### PR DESCRIPTION
Adds server-side governance over which MCP servers and tools callers can use. Claude Code's own MCP controls are client-side, and server-managed settings are skipped for any session with a custom ANTHROPIC_BASE_URL, which is how CCAG is always used, so policy is enforced on the request path instead.

Three concerns, all additive:

* Catalog (mcpgov_servers, mcpgov_tools) auto-discovered from live traffic, each entry carrying an approval status, so operators approve from a real inventory rather than guessing.
* Policy (mcpgov_policies) resolved global -> team -> user, with allow/deny globs on tool names and three modes: observe decides and logs without touching the request, warn allows and flags, enforce strips. Defaults to mcp_only so built-in tools are never affected.
* Audit (mcpgov_events) recording every non-allow decision.

Enforcement covers both directions: denied definitions are removed from the request, denied tool_use blocks are refused on the way back including under streaming, and denied calls are scrubbed from the transcript so a continuing session cannot replay them from history.

Managed from the portal (self-injecting page, one script tag in index.html) or the `ccag mcp` CLI, both over the same /admin/mcpgov/* API.

Kept deliberately self-contained: all logic under src/mcpgov/, tables prefixed mcpgov_, migration numbered 900, and minimal contact with existing files.